### PR TITLE
Add IDE resolution warning for examples sharing JVM & Android code.

### DIFF
--- a/examples/imageviewer/common/src/commonMain/kotlin/example/imageviewer/model/ImageRepository.kt
+++ b/examples/imageviewer/common/src/commonMain/kotlin/example/imageviewer/model/ImageRepository.kt
@@ -1,3 +1,18 @@
+// READ ME FIRST!
+//
+// Code in this file is shared between the Android and Desktop JVM targets.
+// Kotlin's hierarchical multiplatform projects currently
+// don't support sharing code depending on JVM declarations.
+//
+// You can follow the progress for HMPP JVM & Android intermediate source sets here:
+// https://youtrack.jetbrains.com/issue/KT-42466
+//
+// The workaround used here to access JVM libraries causes IntelliJ IDEA to not
+// resolve symbols in this file properly.
+//
+// Resolution errors in your IDE do not indicate a problem with your setup.
+
+
 package example.imageviewer.model
 
 import example.imageviewer.core.Repository

--- a/examples/imageviewer/common/src/commonMain/kotlin/example/imageviewer/model/Miniatures.kt
+++ b/examples/imageviewer/common/src/commonMain/kotlin/example/imageviewer/model/Miniatures.kt
@@ -1,3 +1,17 @@
+// READ ME FIRST!
+//
+// Code in this file is shared between the Android and Desktop JVM targets.
+// Kotlin's hierarchical multiplatform projects currently
+// don't support sharing code depending on JVM declarations.
+//
+// You can follow the progress for HMPP JVM & Android intermediate source sets here:
+// https://youtrack.jetbrains.com/issue/KT-42466
+//
+// The workaround used here to access JVM libraries causes IntelliJ IDEA to not
+// resolve symbols in this file properly.
+//
+// Resolution errors in your IDE do not indicate a problem with your setup.
+
 package example.imageviewer.model
 
 

--- a/examples/imageviewer/common/src/commonMain/kotlin/example/imageviewer/utils/Network.kt
+++ b/examples/imageviewer/common/src/commonMain/kotlin/example/imageviewer/utils/Network.kt
@@ -1,3 +1,17 @@
+// READ ME FIRST!
+//
+// Code in this file is shared between the Android and Desktop JVM targets.
+// Kotlin's hierarchical multiplatform projects currently
+// don't support sharing code depending on JVM declarations.
+//
+// You can follow the progress for HMPP JVM & Android intermediate source sets here:
+// https://youtrack.jetbrains.com/issue/KT-42466
+//
+// The workaround used here to access JVM libraries causes IntelliJ IDEA to not
+// resolve symbols in this file properly.
+//
+// Resolution errors in your IDE do not indicate a problem with your setup.
+
 package example.imageviewer.utils
 
 import java.net.InetAddress

--- a/examples/issues/common/src/commonMain/kotlin/androidx/ui/examples/jetissues/data/IssuesRepository.kt
+++ b/examples/issues/common/src/commonMain/kotlin/androidx/ui/examples/jetissues/data/IssuesRepository.kt
@@ -1,3 +1,18 @@
+// READ ME FIRST!
+//
+// Code in this file is shared between the Android and Desktop JVM targets.
+// Kotlin's hierarchical multiplatform projects currently
+// don't support sharing code depending on JVM declarations.
+//
+// You can follow the progress for HMPP JVM & Android intermediate source sets here:
+// https://youtrack.jetbrains.com/issue/KT-42466
+//
+// The workaround used here to access JVM libraries causes IntelliJ IDEA to not
+// resolve symbols in this file properly.
+//
+// Resolution errors in your IDE do not indicate a problem with your setup.
+
+
 package androidx.ui.examples.jetissues.data
 
 import androidx.ui.examples.jetissues.query.IssueQuery

--- a/examples/issues/common/src/commonMain/kotlin/androidx/ui/examples/jetissues/view/JetIssuesView.kt
+++ b/examples/issues/common/src/commonMain/kotlin/androidx/ui/examples/jetissues/view/JetIssuesView.kt
@@ -1,3 +1,17 @@
+// READ ME FIRST!
+//
+// Code in this file is shared between the Android and Desktop JVM targets.
+// Kotlin's hierarchical multiplatform projects currently
+// don't support sharing code depending on JVM declarations.
+//
+// You can follow the progress for HMPP JVM & Android intermediate source sets here:
+// https://youtrack.jetbrains.com/issue/KT-42466
+//
+// The workaround used here to access JVM libraries causes IntelliJ IDEA to not
+// resolve symbols in this file properly.
+//
+// Resolution errors in your IDE do not indicate a problem with your setup.
+
 package androidx.ui.examples.jetissues.view
 
 import androidx.compose.foundation.Box


### PR DESCRIPTION
Add a warning message to shared files in examples that red code is expected in certain parts of the application based on the workaround for sharing code between JVM and Android targets.