### PR TITLE
Fix compiling and running Gradle tests

### DIFF
--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     // Use `embedded` helper to include a dependency.
     fun embedded(dep: Any) {
         compileOnly(dep)
+        testCompileOnly(dep)
         embeddedDependencies(dep)
     }
 

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -6,7 +6,7 @@ kotlin.code.style=official
 # unless overridden by COMPOSE_GRADLE_PLUGIN_COMPOSE_VERSION env var.
 #
 # __LATEST_COMPOSE_RELEASE_VERSION__
-compose.version=1.0.0-alpha4-build328
+compose.version=1.0.0-beta1
 compose.with.web=false
 
 # A version of Gradle plugin, that will be published,


### PR DESCRIPTION
* Tests stopped compiling after preview RPC was embedded,
because compileOnly dependencies are not visible to tests;
* Local test runs were broken, because the default
compose.version (1.0.0-alpha4-build328) is not compatible
with Kotlin 1.5.31 (compose.version is always overridden on CI,
so CI runs work);