### PR TITLE
web: reuse attrsScope instance per Element instance

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
@@ -135,6 +135,15 @@ open class AttrsScopeBuilder<TElement : Element>(
     internal var refEffect: (DisposableEffectScope.(TElement) -> DisposableEffectResult)? = null
     internal val classes: MutableList<String> = mutableListOf()
 
+    internal fun clear() {
+        eventsListenerScopeBuilder.clear()
+        attributesMap.clear()
+        styleScope.clear()
+        propertyUpdates.clear()
+        refEffect = null
+        classes.clear()
+    }
+
     /**
      * [classes] adds all values passed as params to the element's classList.
      *  This method acts cumulatively, that is, each call adds values to the classList.

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/EventsListenerScope.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/EventsListenerScope.kt
@@ -280,4 +280,8 @@ open class EventsListenerScopeBuilder : EventsListenerScope {
     }
 
     internal fun collectListeners(): List<SyntheticEventListener<*>> = listeners
+
+    internal fun clear() {
+        listeners.clear()
+    }
 }

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleScope.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleScope.kt
@@ -169,6 +169,11 @@ open class StyleScopeBuilder : StyleScope, StyleHolder {
         properties.addAll(sb.properties)
         variables.addAll(sb.variables)
     }
+
+    internal fun clear() {
+        properties.clear()
+        variables.clear()
+    }
 }
 
 data class StylePropertyDeclaration(

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
@@ -108,7 +108,6 @@ fun <TElement : Element> TagElement(
     content: (@Composable ElementScope<TElement>.() -> Unit)?
 ) {
     val scope = remember {  ElementScopeImpl<TElement>() }
-    val attrsScope = remember { AttrsScopeBuilder<TElement>() }
     var refEffect: (DisposableEffectScope.(TElement) -> DisposableEffectResult)? = null
 
     ComposeDomNode<ElementScope<TElement>, DomElementWrapper>(
@@ -118,6 +117,7 @@ fun <TElement : Element> TagElement(
             DomElementWrapper(node)
         },
         attrsSkippableUpdate = {
+            val attrsScope = scope.attrsScope
             attrsScope.clear()
             applyAttrs?.invoke(attrsScope)
 

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/ElementScope.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/ElementScope.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.remember
+import org.jetbrains.compose.web.attributes.AttrsScopeBuilder
 import org.w3c.dom.Element
 
 /**
@@ -122,6 +123,8 @@ internal open class ElementScopeImpl<TElement : Element> : ElementScopeBase<TEle
 
     override val DisposableEffectScope.scopeElement: TElement
         get() = element
+
+    internal val attrsScope = AttrsScopeBuilder<TElement>()
 }
 
 interface DomEffectScope {


### PR DESCRIPTION
We can create 1 attrsScope instance per element (tag) instance and reuse it for future updates.