### PR TITLE
Expose jpackage's --resource-dir in Gradle DSL 

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/NativeDistributions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/NativeDistributions.kt
@@ -27,6 +27,7 @@ open class NativeDistributions @Inject constructor(
     var vendor: String? = null
     var packageVersion: String? = null
     val appResourcesRootDir: DirectoryProperty = objects.directoryProperty()
+    val packagingResourcesRootDir: DirectoryProperty = objects.directoryProperty()
     val licenseFile: RegularFileProperty = objects.fileProperty()
 
     val outputBaseDir: DirectoryProperty = objects.directoryProperty().apply {


### PR DESCRIPTION
jpackage provides the option `--resource-dir` that allows to override
> resources used by jpackage, such as background images and template files for properties and scripts.

https://docs.oracle.com/en/java/javase/17/jpackage/override-jpackage-resources.html

This includes files like `preinst` and `postinst` that are used by .deb files to allow modifications of the installation process.

When looking at the .deb file generated by jpackage, the default `preinst` and `postinst` scripts land in the _control.tar.xz_ archive of the .deb file.

However, with the .deb files produced by the `packageDeb` task, one can see that the files from the source's `appResourcesRootDir` (specified in `build.gradle.kts`) land in _/opt/briar-desktop/lib/app/resources/_ inside the _data.tar.xz_
archive.

Looking at the jpackage parameters used during `packageDeb`, one can see that it uses _compose/tmp/resources_:
```
--resource-dir
"/home/dev/Documents/briar-desktop/build/compose/tmp/resources"
```
[project root]/build/compose/tmp/packageDeb.args.txt

Looking at that directory, it is empty. However, inside _compose/tmp/main/resources_ the files provided in source's `appResourcesRootDir` are found:
```
$ ls -l compose/tmp/main/resources/
total 8
-rwxr-xr-x 1 dev dev   9 Feb 14 13:02 postinst
-rwxr-xr-x 1 dev dev 618 Feb 14 13:02 preinst
$ ls -l compose/tmp/resources/
total 0
```

This MR therefore exposes `jpackageResources` to be specified in Gradle build files  by
Compose projects.

https://github.com/JetBrains/compose-jb/blob/v1.0.1/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt#L248

Fixes #1766.