### PR TITLE
Provide relative path to jpackage --main-jar. Fixes #1578

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -287,7 +287,8 @@ abstract class AbstractJPackageTask @Inject constructor(
 
             val mappedJar = libsMapping[launcherMainJar.ioFile]?.singleOrNull()
                 ?: error("Main jar was not processed correctly: ${launcherMainJar.ioFile}")
-            cliArg("--main-jar", mappedJar)
+            val mainJarRelative = (if (currentTarget.os == OS.Windows) "\\" else "/") + mappedJar.relativeTo(libsDir.ioFile).toString()
+            cliArg("--main-jar", mainJarRelative)
             cliArg("--main-class", launcherMainClass)
 
             when (currentOS) {


### PR DESCRIPTION
Per jpackage doc:

> --main-jar main jar file
> The main JAR of the application; containing the main class ___(specified as a path relative to the input path)___.
> 
> Either --module or --main-jar option can be specified but not both.

Tested only on Windows.

Fixes #1578