### PR TITLE
CMP-5906 Add option to enable Class data sharing (CDS)

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/JvmApplicationDistributions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/JvmApplicationDistributions.kt
@@ -19,6 +19,8 @@ abstract class JvmApplicationDistributions : AbstractDistributions() {
     }
     var includeAllModules: Boolean = false
 
+    var cds: Boolean = false
+
     val linux: LinuxPlatformSettings = objects.newInstance(LinuxPlatformSettings::class.java)
     open fun linux(fn: Action<LinuxPlatformSettings>) {
         fn.execute(linux)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -110,6 +110,7 @@ private fun JvmApplicationContext.configureCommonJvmDesktopTasks(): CommonJvmDes
         modules.set(provider { app.nativeDistributions.modules })
         includeAllModules.set(provider { app.nativeDistributions.includeAllModules })
         javaRuntimePropertiesFile.set(checkRuntime.flatMap { it.javaRuntimePropertiesFile })
+        cds.set(provider { app.nativeDistributions.cds })
         destinationDir.set(appTmpDir.dir("runtime"))
     }
 

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -280,6 +280,21 @@ compose.desktop {
 }
 ```
 
+## Enabling Class data sharing (CDS)
+
+This option requires JDK 18. Class data sharing (CDS) can be enabled which helps reduce the startup
+time and memory footprint.
+
+``` kotlin
+compose.desktop {
+    application {
+        nativeDistributions {
+            cds = true
+        }
+    }
+}
+```
+
 ## Packaging resources
 
 There are multiple ways to package and load resources with Compose for Desktop.


### PR DESCRIPTION
[CMP-5906](https://youtrack.jetbrains.com/issue/CMP-5906) Add option to enable Class data sharing (CDS)

Alternatively this could be enabled by default, what do you think?

This PR adds an option for CDS, not for AppCDS.

AppCDS is probably not worth it. Generating it at first startup slows down the startup. So it should probably be generated at install time somehow (not sure if even possible, and would take too much time). Generating it at build time in this gradle plugin would be another option (which I think is best), but that would increase app size. AppCDS would require more investigation before adding it. I think what would be ideal, is that the gradle plugin would launch the app in the background when building, and maybe run some sort of compose test to warm up code. Then exit and include the generated file in the archive. Does this make sense?