### PR TITLE
Allow injecting additional jpackage resources into build

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/AbstractDistributions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/AbstractDistributions.kt
@@ -30,6 +30,7 @@ abstract class AbstractDistributions {
     var description: String? = null
     var vendor: String? = null
     val appResourcesRootDir: DirectoryProperty = objects.directoryProperty()
+    val jpackageResourceDir: DirectoryProperty = objects.directoryProperty()
     val licenseFile: RegularFileProperty = objects.fileProperty()
 
     var targetFormats: Set<TargetFormat> = EnumSet.noneOf(TargetFormat::class.java)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -224,7 +224,9 @@ abstract class AbstractJPackageTask @Inject constructor(
     protected val signDir: Provider<Directory> = project.layout.buildDirectory.dir("compose/tmp/sign")
 
     @get:LocalState
-    protected val jpackageResources: Provider<Directory> = project.layout.buildDirectory.dir("compose/tmp/resources")
+    val jpackageResources: DirectoryProperty = objects.directoryProperty().apply {
+        set(project.layout.buildDirectory.dir("compose/tmp/resources"))
+    }
 
     @get:LocalState
     protected val skikoDir: Provider<Directory> = project.layout.buildDirectory.dir("compose/tmp/skiko")
@@ -466,7 +468,6 @@ abstract class AbstractJPackageTask @Inject constructor(
             }
         }
 
-        cleanDirs(jpackageResources)
         if (currentOS == OS.MacOS) {
             InfoPlistBuilder(macExtraPlistKeysRawXml.orNull)
                 .also { setInfoPlistValues(it) }


### PR DESCRIPTION
This PR adds a `jpackageResourceDir` property to the plugin's public DSL, which can be used to specify an extra source directory for providing jpackage resources. This should allow overriding packaging properties, such as the original WiX configuration files generating Windows installers (as documented here: https://docs.oracle.com/en/java/javase/18/jpackage/override-jpackage-resources.html).