### PR TITLE
Allow the default window to go fullscreen

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/configureTaskToGenerateXcodeProject.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/configureTaskToGenerateXcodeProject.kt
@@ -39,6 +39,8 @@ internal fun Project.configureTaskToGenerateXcodeProject(
                 deploymentTarget: "12.0"
                 info:
                   path: plists/Ios/Info.plist
+                  properties:
+                    UILaunchStoryboardName: $projectName
                 settings:
                   LIBRARY_SEARCH_PATHS: "$(inherited)"
                   ENABLE_BITCODE: "YES"


### PR DESCRIPTION
This is an odd behaviour, but I couldn't find any other solution. If `UILaunchStoryboardName` key is  present, `UIScreen.mainScreen.bounds` will have proper size instead of a smaller window. 
[Reference](https://stackoverflow.com/a/56950026)