### PR TITLE
Painter resource addition

### DIFF
--- a/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/UseResources.kt
+++ b/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/UseResources.kt
@@ -33,5 +33,14 @@ internal fun UseResources() {
             modifier = Modifier.size(150.dp),
             contentDescription = null
         )
+        Icon(
+            painter = resource("vector.xml").rememberImageVector(LocalDensity.current).asPainter(),
+            modifier = Modifier.size(150.dp),
+            contentDescription = null
+        )
+        Image(
+            painter = resource("img.webp").rememberImageBitmap().asPainter(),
+            contentDescription = null,
+        )
     }
 }

--- a/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/UseResources.kt
+++ b/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/UseResources.kt
@@ -34,12 +34,12 @@ internal fun UseResources() {
             contentDescription = null
         )
         Icon(
-            painter = resource("vector.xml").rememberImageVector(LocalDensity.current).asPainter(),
+            painter = resource("vector.xml").rememberImageVector(LocalDensity.current).toPainter(),
             modifier = Modifier.size(150.dp),
             contentDescription = null
         )
         Image(
-            painter = resource("img.webp").rememberImageBitmap().asPainter(),
+            painter = resource("img.webp").rememberImageBitmap().toPainter(),
             contentDescription = null,
         )
     }

--- a/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/UseResources.kt
+++ b/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/UseResources.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.*
 
 @OptIn(ExperimentalResourceApi::class)
@@ -23,6 +25,12 @@ internal fun UseResources() {
         )
         Icon(
             imageVector = resource("vector.xml").rememberImageVector(LocalDensity.current).orEmpty(),
+            modifier = Modifier.size(150.dp),
+            contentDescription = null
+        )
+        Icon(
+            painter = painterResource("dir/vector.xml"),
+            modifier = Modifier.size(150.dp),
             contentDescription = null
         )
     }

--- a/components/resources/demo/shared/src/commonMain/resources/dir/vector.xml
+++ b/components/resources/demo/shared/src/commonMain/resources/dir/vector.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M352,0H160C71.648,0 0,71.648 0,160v192c0,88.352 71.648,160 160,160h192c88.352,0 160,-71.648 160,-160V160C512,71.648 440.352,0 352,0zM464,352c0,61.76 -50.24,112 -112,112H160c-61.76,0 -112,-50.24 -112,-112V160C48,98.24 98.24,48 160,48h192c61.76,0 112,50.24 112,112V352z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M256,128c-70.688,0 -128,57.312 -128,128s57.312,128 128,128s128,-57.312 128,-128S326.688,128 256,128zM256,336c-44.096,0 -80,-35.904 -80,-80c0,-44.128 35.904,-80 80,-80s80,35.872 80,80C336,300.096 300.096,336 256,336z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M393.6,118.4m-17.056,0a17.056,17.056 0,1 1,34.112 0a17.056,17.056 0,1 1,-34.112 0" />
+</vector>

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ComposeResource.common.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ComposeResource.common.kt
@@ -72,7 +72,13 @@ fun LoadState<ImageBitmap>.orEmpty(): ImageBitmap = orEmpty(emptyImageBitmap)
 fun LoadState<ImageVector>.orEmpty(): ImageVector = orEmpty(emptyImageVector)
 
 /**
- * Return Painter depending on the extension of the resource name (vector or bitmap).
+ * Return a Painter from the given resource path.
+ * Can load either a BitmapPainter for rasterized images (.png, .jpg) or
+ * a VectorPainter for XML Vector Drawables (.xml).
+ *
+ * XML Vector Drawables have the same format as for Android
+ * (https://developer.android.com/reference/android/graphics/drawable/VectorDrawable)
+ * except that external references to Android resources are not supported.
  */
 @ExperimentalResourceApi
 @Composable

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ComposeResource.common.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ComposeResource.common.kt
@@ -7,7 +7,11 @@ package org.jetbrains.compose.resources
 
 import androidx.compose.runtime.*
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import org.jetbrains.compose.resources.vector.xmldom.Element
 import org.jetbrains.compose.resources.vector.parseVectorRoot
@@ -56,16 +60,29 @@ private fun <T> LoadState<T>.orEmpty(emptyValue: T): T = when (this) {
 }
 
 /**
- * return current ImageBitmap or return empty while loading
+ * Return current ImageBitmap or return empty while loading.
  */
 @ExperimentalResourceApi
 fun LoadState<ImageBitmap>.orEmpty(): ImageBitmap = orEmpty(emptyImageBitmap)
 
 /**
- * return current ImageVector or return empty while loading
+ * Return current ImageVector or return empty while loading.
  */
 @ExperimentalResourceApi
 fun LoadState<ImageVector>.orEmpty(): ImageVector = orEmpty(emptyImageVector)
+
+/**
+ * Return Painter depending on the extension of the resource name (vector or bitmap).
+ */
+@ExperimentalResourceApi
+@Composable
+fun painterResource(res: String): Painter {
+    if (res.endsWith(".xml")) {
+        return rememberVectorPainter(resource(res).rememberImageVector(LocalDensity.current).orEmpty())
+    }
+
+    return BitmapPainter(resource(res).rememberImageBitmap().orEmpty())
+}
 
 internal expect fun ByteArray.toImageBitmap(): ImageBitmap
 

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ComposeResource.common.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ComposeResource.common.kt
@@ -91,15 +91,21 @@ fun painterResource(res: String): Painter {
     return BitmapPainter(resource(res).rememberImageBitmap().orEmpty())
 }
 
+/**
+ * Convert LoadState<ImageVector> to Painter
+ */
 @ExperimentalResourceApi
 @Composable
-@JvmName("loadStateImageVectorAsPainter")
-fun LoadState<ImageVector>.asPainter(): Painter = rememberVectorPainter(orEmpty())
+@JvmName("loadStateImageVectorToPainter")
+fun LoadState<ImageVector>.toPainter(): Painter = rememberVectorPainter(orEmpty())
 
+/**
+ * Convert LoadState<ImageBitmap> to Painter
+ */
 @ExperimentalResourceApi
 @Composable
-@JvmName("loadStateImageBitmapAsPainter")
-fun LoadState<ImageBitmap>.asPainter(): Painter {
+@JvmName("loadStateImageBitmapToPainter")
+fun LoadState<ImageBitmap>.toPainter(): Painter {
     val imageBitmap = orEmpty()
     return remember(imageBitmap) { BitmapPainter(imageBitmap) }
 }

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ComposeResource.common.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ComposeResource.common.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.Density
 import org.jetbrains.compose.resources.vector.xmldom.Element
 import org.jetbrains.compose.resources.vector.parseVectorRoot
 import androidx.compose.ui.unit.dp
+import kotlin.jvm.JvmName
 
 private val emptyImageBitmap: ImageBitmap by lazy { ImageBitmap(1, 1) }
 
@@ -88,6 +89,19 @@ fun painterResource(res: String): Painter {
     }
 
     return BitmapPainter(resource(res).rememberImageBitmap().orEmpty())
+}
+
+@ExperimentalResourceApi
+@Composable
+@JvmName("loadStateImageVectorAsPainter")
+fun LoadState<ImageVector>.asPainter(): Painter = rememberVectorPainter(orEmpty())
+
+@ExperimentalResourceApi
+@Composable
+@JvmName("loadStateImageBitmapAsPainter")
+fun LoadState<ImageBitmap>.asPainter(): Painter {
+    val imageBitmap = orEmpty()
+    return remember(imageBitmap) { BitmapPainter(imageBitmap) }
 }
 
 internal expect fun ByteArray.toImageBitmap(): ImageBitmap


### PR DESCRIPTION
Addition to this PR: https://github.com/JetBrains/compose-jb/pull/2753

Also, we can use another approach, that described here.
```Kotlin
resource("vector.xml").rememberImageVector(LocalDensity.current).toPainter(),
```

```Kotlin
resource("img.webp").rememberImageBitmap().toPainter()
```

This approach is more verbose, but also more flexible.
In the future, we may have async loading from network that will return `LoadState<ImageBitmap>` or `LoadState<ImageVector>`. In this case, we can use these functions.