### PR TITLE
Compose Web: add the `StyleScope.width` and `StyleScope.height` functions which take plain string arguments

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/box.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/box.kt
@@ -7,12 +7,20 @@ package org.jetbrains.compose.web.css
 
 import org.jetbrains.compose.web.css.keywords.CSSAutoKeyword
 
+fun StyleScope.width(value: String) {
+    property("width", value)
+}
+
 fun StyleScope.width(value: CSSNumeric) {
     property("width", value)
 }
 
 fun StyleScope.width(value: CSSAutoKeyword) {
     property("width", value)
+}
+
+fun StyleScope.height(value: String) {
+    property("height", value)
 }
 
 fun StyleScope.height(value: CSSNumeric) {


### PR DESCRIPTION
This can make it easier to set the string values, e.g., `fit-content`, `fit-content()`, `min-content`, and `max-content`.