### PR TITLE
Resources library minSdk 21

### DIFF
--- a/components/resources/demo/androidApp/build.gradle.kts
+++ b/components/resources/demo/androidApp/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     compileSdk = 33
     defaultConfig {
         applicationId = "me.user.androidApp"
-        minSdk = 24
+        minSdk = 21
         targetSdk = 33
         versionCode = 1
         versionName = "1.0"

--- a/components/resources/demo/shared/build.gradle.kts
+++ b/components/resources/demo/shared/build.gradle.kts
@@ -82,7 +82,7 @@ android {
     compileSdk = 33
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
         targetSdk = 33
     }
     compileOptions {

--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -99,7 +99,7 @@ android {
     compileSdk = 33
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 24
+        minSdk = 21
         targetSdk = 33
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
@terrakok suggest using a lover version on minimal available Android minSdk.
JetPack Compose for Android is available since minSdk 21. Checked with a demo resource project.