### PR TITLE
Fix regex for number values

### DIFF
--- a/examples/codeviewer/common/src/commonMain/kotlin/org/jetbrains/codeviewer/ui/editor/EditorView.kt
+++ b/examples/codeviewer/common/src/commonMain/kotlin/org/jetbrains/codeviewer/ui/editor/EditorView.kt
@@ -169,7 +169,7 @@ private fun codeString(str: String) = buildAnnotatedString {
         addStyle(AppTheme.code.keyword, strFormatted, "package ")
         addStyle(AppTheme.code.value, strFormatted, "true")
         addStyle(AppTheme.code.value, strFormatted, "false")
-        addStyle(AppTheme.code.value, strFormatted, Regex("[0-9]*"))
+        addStyle(AppTheme.code.value, strFormatted, Regex("[0-9]+"))
         addStyle(AppTheme.code.annotation, strFormatted, Regex("^@[a-zA-Z_]*"))
         addStyle(AppTheme.code.comment, strFormatted, Regex("^\\s*//.*"))
     }


### PR DESCRIPTION
Fix regex for number values to avoid spawning style with empty range after each char