### PR TITLE
ImageViewer - limit zoom by the window/screen size

### DIFF
--- a/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/model/ScalableState.kt
+++ b/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/model/ScalableState.kt
@@ -40,7 +40,7 @@ class ScalableState {
     }
 
     /**
-     * The calculated base scale for 100% zoom. Calculated in a way the target size fits the area size.
+     * The calculated base scale for 100% zoom. Calculated so that the target fits the area.
      */
     private val scaleFor100PercentZoom by derivedStateOf {
         if (targetSize.isSpecified && areaSize.isSpecified) {

--- a/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/ScalableImage.common.kt
+++ b/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/ScalableImage.common.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import example.imageviewer.model.ScalableState
 import example.imageviewer.utils.onPointerEvent
-import kotlin.math.min
 import kotlin.math.pow
 
 @Composable
@@ -29,24 +28,14 @@ internal fun ScalableImage(scalableState: ScalableState, image: ImageBitmap, mod
         val imageCenter = Offset(image.width / 2f, image.height / 2f)
         val areaCenter = Offset(areaSize.width / 2f, areaSize.height / 2f)
 
-        if (areaSize.width > 0 && areaSize.height > 0) {
-            DisposableEffect(Unit) {
-                scalableState.setScale(
-                    min(areaSize.width / imageSize.width, areaSize.height / imageSize.height),
-                    Offset.Zero,
-                )
-                onDispose { }
-            }
-        }
-
         Box(
             modifier
                 .drawWithContent {
                     drawIntoCanvas {
                         it.withSave {
                             it.translate(areaCenter.x, areaCenter.y)
-                            it.translate(scalableState.offset.x, scalableState.offset.y)
-                            it.scale(scalableState.scale, scalableState.scale)
+                            it.translate(scalableState.transformation.offset.x, scalableState.transformation.offset.y)
+                            it.scale(scalableState.transformation.scale, scalableState.transformation.scale)
                             it.translate(-imageCenter.x, -imageCenter.y)
                             drawImage(image)
                         }
@@ -55,22 +44,22 @@ internal fun ScalableImage(scalableState: ScalableState, image: ImageBitmap, mod
                 .pointerInput(Unit) {
                     detectTransformGestures { centroid, pan, zoom, _ ->
                         scalableState.addPan(pan)
-                        scalableState.addScale(zoom, centroid - areaCenter)
+                        scalableState.addZoom(zoom, centroid - areaCenter)
                     }
                 }
                 .onPointerEvent(PointerEventType.Scroll) {
                     val centroid = it.changes[0].position
                     val delta = it.changes[0].scrollDelta
                     val zoom = 1.2f.pow(-delta.y)
-                    scalableState.addScale(zoom, centroid - areaCenter)
+                    scalableState.addZoom(zoom, centroid - areaCenter)
                 }
                 .pointerInput(Unit) {
                     detectTapGestures(onDoubleTap = { position ->
-                        scalableState.setScale(
-                            if (scalableState.scale > 2.0) {
-                                scalableState.scaleLimits.start
+                        scalableState.setZoom(
+                            if (scalableState.zoom > 1.5f) {
+                                1.0f
                             } else {
-                                scalableState.scaleLimits.endInclusive
+                                scalableState.zoomLimits.endInclusive
                             },
                             position - areaCenter
                         )

--- a/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/ScalableImage.common.kt
+++ b/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/ScalableImage.common.kt
@@ -20,6 +20,16 @@ import example.imageviewer.model.ScalableState
 import example.imageviewer.utils.onPointerEvent
 import kotlin.math.pow
 
+/**
+ * Initial zoom of the image. 1.0f means the image fully fits the window.
+ */
+private const val INITIAL_ZOOM = 1.0f
+
+/**
+ * This zoom means that the image isn't significantly zoomed for the user yet.
+ */
+private const val SLIGHTLY_INCREASED_ZOOM = 1.5f
+
 @Composable
 internal fun ScalableImage(scalableState: ScalableState, image: ImageBitmap, modifier: Modifier = Modifier) {
     BoxWithConstraints {
@@ -55,9 +65,11 @@ internal fun ScalableImage(scalableState: ScalableState, image: ImageBitmap, mod
                 }
                 .pointerInput(Unit) {
                     detectTapGestures(onDoubleTap = { position ->
+                        // If a user zoomed significantly, the zoom should be the restored on double tap,
+                        // otherwise the zoom should be increased
                         scalableState.setZoom(
-                            if (scalableState.zoom > 1.5f) {
-                                1.0f
+                            if (scalableState.zoom > SLIGHTLY_INCREASED_ZOOM) {
+                                INITIAL_ZOOM
                             } else {
                                 scalableState.zoomLimits.endInclusive
                             },

--- a/examples/imageviewer/shared/src/desktopMain/kotlin/example/imageviewer/view/ZoomControllerView.desktop.kt
+++ b/examples/imageviewer/shared/src/desktopMain/kotlin/example/imageviewer/view/ZoomControllerView.desktop.kt
@@ -14,9 +14,9 @@ import example.imageviewer.model.ScalableState
 internal actual fun ZoomControllerView(modifier: Modifier, scalableState: ScalableState) {
     Slider(
         modifier = modifier.fillMaxWidth(0.5f).padding(12.dp),
-        value = scalableState.scale,
-        valueRange = scalableState.scaleLimits.start..scalableState.scaleLimits.endInclusive,
-        onValueChange = { scalableState.setScale(it) },
+        value = scalableState.zoom,
+        valueRange = scalableState.zoomLimits.start..scalableState.zoomLimits.endInclusive,
+        onValueChange = { scalableState.setZoom(it) },
         colors = SliderDefaults.colors(thumbColor = Color.White, activeTrackColor = Color.White)
     )
 }


### PR DESCRIPTION
- add a `zoom` field, which is the same across different screen/window sizes

- The `scale` field is not a base state now, it is derived from the current zoom and the current screen/window size.

- drag amount is still independent of scale/zoom (if we drag by 5 pixels, the image moves by 5 pixels)

- offset is still limited by the area and the current scale

https://user-images.githubusercontent.com/5963351/230199995-f7d93a80-01b3-4cab-aeaa-f84bb2dbaa4f.mp4

