### PR TITLE
Fix references to outdated 'nativeExecutables' in error messages

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
@@ -72,10 +72,10 @@ private val ERR_UNKNOWN_PREFIX =
     """|$ERR_PREFIX Could not infer signing prefix. To specify:
        |  * Set bundleID to reverse DNS notation (e.g. "com.mycompany.myapp");
        |  * Use '${ComposeProperties.MAC_SIGN_PREFIX}' Gradle property;
-       |  * Use 'nativeExecutables.macOS.signing.prefix' DSL property;
+       |  * Use 'nativeDistributions.macOS.signing.prefix' DSL property;
     """.trimMargin()
 private val ERR_UNKNOWN_SIGN_ID =
     """|$ERR_PREFIX signing identity is null or empty. To specify:
        |  * Use '${ComposeProperties.MAC_SIGN_ID}' Gradle property;
-       |  * Use 'nativeExecutables.macOS.signing.identity' DSL property;
+       |  * Use 'nativeDistributions.macOS.signing.identity' DSL property;
     """.trimMargin()

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/validateBundleID.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/validateBundleID.kt
@@ -19,7 +19,7 @@ private const val BUNDLE_ID_FORMAT =
     "bundleID may only contain alphanumeric characters (A-Z, a-z, 0-9), hyphen (-) and period (.) characters"
 private val ERR_BUNDLE_ID_IS_EMPTY =
     """|$ERR_PREFIX bundleID is empty or null. To specify:
-       |  * Use 'nativeExecutables.macOS.bundleID' DSL property;
+       |  * Use 'nativeDistributions.macOS.bundleID' DSL property;
        |  * $BUNDLE_ID_FORMAT;
        |  * Use reverse DNS notation (e.g. "com.mycompany.myapp");
        |""".trimMargin()


### PR DESCRIPTION
In 991b7ff6a7d4fcaba7c59922793acf8209dfc8fa 'nativeExecutables' was renamed to 'nativeDistributions', however a later commit added error messages that still reference the old DSL names.