### PR TITLE
Require JDK 17 for packaging

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
-          java-version: '16'
+          java-version: '17'
       - name: Test Gradle plugin
         shell: bash
         run: |

--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -117,7 +117,7 @@ tasks.test {
  * It is not desirable to depend on little known service for provisioning JDK distributions, even for tests.
  * Thus, the only option is to download the necessary JDK distributions ourselves.
  */
-val jdkVersionsForTests = listOf(11, 15, 18, 19)
+val jdkVersionsForTests = listOf(11, 19)
 val jdkForTestsRoot = project.gradle.gradleUserHomeDir.resolve("compose-jb-jdks")
 val downloadJdksForTests = tasks.register("downloadJdksForTests") {}
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractCheckNativeDistributionRuntime.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractCheckNativeDistributionRuntime.kt
@@ -20,7 +20,7 @@ import org.jetbrains.compose.internal.utils.clearDirs
 import java.io.File
 
 // __COMPOSE_NATIVE_DISTRIBUTIONS_MIN_JAVA_VERSION__
-internal const val MIN_JAVA_RUNTIME_VERSION = 15
+internal const val MIN_JAVA_RUNTIME_VERSION = 17
 
 @CacheableTask
 abstract class AbstractCheckNativeDistributionRuntime : AbstractComposeDesktopTask() {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -246,15 +246,6 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     }
 
     @Test
-    fun testJdk15() = with(customJdkProject(15)) {
-        testPackageJvmDistributions()
-    }
-    @Test
-    fun testJdk18() = with(customJdkProject(18)) {
-        testPackageJvmDistributions()
-    }
-
-    @Test
     fun testJdk19() = with(customJdkProject(19)) {
         testPackageJvmDistributions()
     }

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.parallel=true
 kotlin.code.style=official
 
 # Default version of Compose Libraries used by Gradle plugin
-compose.version=1.3.1
+compose.version=1.4.0-rc03
 # The latest version of Compose Compiler used by Gradle plugin. Used only in tests/CI.
 compose.tests.compiler.version=1.4.5-rc03
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
@@ -10,7 +10,7 @@ compose.tests.compiler.compatible.kotlin.version=1.8.20
 # The latest version of Kotlin compatible with compose.tests.compiler.version for JS target. Used only on CI.
 compose.tests.js.compiler.compatible.kotlin.version=1.8.20
 # __SUPPORTED_GRADLE_VERSIONS__
-compose.tests.gradle.versions=7.0.2, 8.0-rc-1
+compose.tests.gradle.versions=7.3.3, 8.0.2
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -214,14 +214,14 @@ Versions must follow the rules:
 
 ## Customizing JDK version
 
-The plugin uses `jpackage`, for which you should be using at least [JDK 15](https://openjdk.java.net/projects/jdk/15/).
+The plugin uses `jpackage`, for which you should be using at least [JDK 17](https://openjdk.java.net/projects/jdk/17/).
 Make sure you meet at least one of the following requirements:
 * `JAVA_HOME` environment variable points to the compatible JDK version.
 * `javaHome` is set via DSL:
 ``` kotlin
 compose.desktop {
     application {
-        javaHome = System.getenv("JDK_15")
+        javaHome = System.getenv("JDK_17")
     }
 }
 ``` 


### PR DESCRIPTION
Previously Compose Multiplatform Gradle plugin required JDK 15+ for distribution packaging. However, fixing #2867 required always passing --mac-entitlements to jpackage, which is only available with JDK 17+.