### PR TITLE
ImageViewer fix delete picture crash

### DIFF
--- a/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/MemoryScreen.kt
+++ b/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/MemoryScreen.kt
@@ -97,12 +97,15 @@ fun MemoryScreen(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         items(items = shuffledIndices) { index ->
-                            Box(Modifier.size(130.dp).clip(RoundedCornerShape(8.dp))) {
-                                SquareThumbnail(
-                                    picture = pictures[index],
-                                    isHighlighted = false,
-                                    onClick = { onSelectRelatedMemory(index) }
-                                )
+                            val relatedPicture = pictures.getOrNull(index)
+                            if (relatedPicture != null) {
+                                Box(Modifier.size(130.dp).clip(RoundedCornerShape(8.dp))) {
+                                    SquareThumbnail(
+                                        picture = relatedPicture,
+                                        isHighlighted = false,
+                                        onClick = { onSelectRelatedMemory(index) }
+                                    )
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Was `index out of bounds` crash after deleting random picture.
Fixed with safe call `pictures.getOrNull(index)`