### PR TITLE
Fix signing bundle with Gradle 8.1 with configuration cache

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -334,6 +334,15 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     }
 
     @Test
+    fun testMacSignConfiguration() {
+        Assumptions.assumeTrue(currentOS == OS.MacOS)
+
+        with(testProject(TestProjects.macSign)) {
+            gradle("--dry-run", ":createDistributable")
+        }
+    }
+
+    @Test
     @Disabled
     // the test does not work on CI and locally unless test keychain is opened manually
     fun testMacSign() {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -20,7 +20,14 @@ import org.junit.jupiter.api.Test
 
 class GradlePluginTest : GradlePluginTestBase() {
     @Test
-    fun skikoWasm() = with(testProject(TestProjects.skikoWasm)) {
+    fun skikoWasm() = with(
+        testProject(
+            TestProjects.skikoWasm,
+            // configuration cache is disabled as a temporary workaround for KT-58057
+            // todo: enable once KT-58057 is fixed
+            testEnvironment = defaultTestEnvironment.copy(useGradleConfigurationCache = false)
+        )
+    ) {
         gradle(":build").checks {
             check.taskSuccessful(":unpackSkikoWasmRuntimeJs")
             check.taskSuccessful(":compileKotlinJs")

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
@@ -19,6 +19,7 @@ data class TestEnvironment(
     val composeCompilerPlugin: String? = null,
     val composeCompilerArgs: String? = null,
     val composeVerbose: Boolean = true,
+    val useGradleConfigurationCache: Boolean = TestProperties.gradleConfigurationCache,
 ) {
     private val placeholders = linkedMapOf(
         "COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER" to composeGradlePluginVersion,
@@ -76,7 +77,7 @@ class TestProject(
     }
 
     internal fun gradle(vararg args: String): BuildResult {
-        if (TestProperties.gradleConfigurationCache) {
+        if (testEnvironment.useGradleConfigurationCache) {
             if (GradleVersion.version(TestProperties.gradleVersionForTests).baseVersion < GradleVersion.version("8.0")) {
                 // Gradle 7.* does not use the configuration cache in the same build.
                 // In other words, if cache misses, Gradle performs configuration,
@@ -106,7 +107,7 @@ class TestProject(
     private fun gradleRunner(args: Array<out String>): GradleRunner {
         val allArgs = args.toMutableList()
         allArgs.addAll(additionalArgs)
-        if (TestProperties.gradleConfigurationCache) {
+        if (testEnvironment.useGradleConfigurationCache) {
             allArgs.add("--configuration-cache")
         }
 

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -10,7 +10,7 @@ compose.tests.compiler.compatible.kotlin.version=1.8.20
 # The latest version of Kotlin compatible with compose.tests.compiler.version for JS target. Used only on CI.
 compose.tests.js.compiler.compatible.kotlin.version=1.8.20
 # __SUPPORTED_GRADLE_VERSIONS__
-compose.tests.gradle.versions=7.3.3, 8.0.2
+compose.tests.gradle.versions=7.3.3, 8.1
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.


### PR DESCRIPTION
Compose Gradle plugin was launching
`/usr/bin/security --find-identity` in a lazy property of AbstractJPackageTask. Without the configuration cache the computation was delayed to the execution phase. However, configuration cache serializes all properties of all configured tasks, so launching of `/usr/bin/security` shifted to the configuration phase.
Gradle 8.1 started to throw an exception if an external process is launched during configuration time.
This change explicitly moves the call to
`/usr/bin/security` to the execution phase.

Resolves #3060