### PR TITLE
Remove variant redirection from Gradle plugin

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/android/AndroidExtension.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/android/AndroidExtension.kt
@@ -7,10 +7,4 @@ import org.gradle.api.tasks.Input
 import javax.inject.Inject
 
 abstract class AndroidExtension @Inject constructor(private val objectFactory: ObjectFactory) : ExtensionAware {
-    @Input
-    var useAndroidX : Boolean = false
-    @Input
-    var androidxVersion: String = "1.0.1" //should be set by CI, but could be overridden in build script
-    @Input
-    var mppSolutionGroup: String = "org.jetbrains.compose" //it is added for future use by Google
 }


### PR DESCRIPTION
It was experimental and it is not needed
since our published Gradle Metadata
already has references for Android artifacts
for Android variants