### PR TITLE
Make codeviewer example more photogenic

### DIFF
--- a/examples/codeviewer/iosApp/iosApp/ContentView.swift
+++ b/examples/codeviewer/iosApp/iosApp/ContentView.swift
@@ -13,7 +13,7 @@ struct ComposeView: UIViewControllerRepresentable {
 struct ContentView: View {
     var body: some View {
         ComposeView()
-                .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+                .ignoresSafeArea(.all, edges: .bottom) // Compose has own keyboard handler
     }
 }
 

--- a/examples/codeviewer/iosApp/iosApp/iOSApp.swift
+++ b/examples/codeviewer/iosApp/iosApp/iOSApp.swift
@@ -4,7 +4,10 @@ import SwiftUI
 struct iOSApp: App {
 	var body: some Scene {
 		WindowGroup {
-			ContentView()
+		    ZStack {
+		        Color(#colorLiteral(red: 0.235, green: 0.247, blue: 0.255, alpha: 1)).ignoresSafeArea(.all)
+			    ContentView()
+			}.preferredColorScheme(.dark)
 		}
 	}
 }

--- a/examples/codeviewer/shared/src/commonMain/kotlin/org/jetbrains/codeviewer/ui/statusbar/StatusBar.kt
+++ b/examples/codeviewer/shared/src/commonMain/kotlin/org/jetbrains/codeviewer/ui/statusbar/StatusBar.kt
@@ -18,9 +18,9 @@ private val MaxFontSize = 40.sp
 @Composable
 fun StatusBar(settings: Settings) = Box(
     Modifier
+        .padding(16.dp, 4.dp, 16.dp, 16.dp)
         .height(32.dp)
         .fillMaxWidth()
-        .padding(4.dp)
 ) {
     Row(Modifier.fillMaxHeight().align(Alignment.CenterEnd)) {
         Text(


### PR DESCRIPTION
Matching color for status bar, adjusted margins for bottom bar.

<img width="437" alt="Screenshot 2023-05-16 at 16 52 58" src="https://github.com/JetBrains/compose-multiplatform/assets/2178959/47ada891-4691-4461-9101-b0a59c546f42">
