### PR TITLE
Improve error messages when checking tasks

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -128,7 +128,10 @@ fun Project.configureGradlePlugin(
 }
 
 tasks.register("publishToMavenLocal") {
+    val publishToMavenLocal = this
     for (subproject in subprojects) {
-        dependsOn(subproject.tasks.named("publishToMavenLocal"))
+        subproject.plugins.withId("maven-publish") {
+            publishToMavenLocal.dependsOn("${subproject.path}:publishToMavenLocal")
+        }
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -17,6 +17,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.compose.desktop.application.internal.validation.validatePackageVersions
 import org.jetbrains.compose.desktop.application.tasks.*
 import org.jetbrains.compose.desktop.tasks.AbstractUnpackDefaultComposeApplicationResourcesTask
+import org.jetbrains.compose.internal.utils.*
 import org.jetbrains.compose.internal.utils.OS
 import org.jetbrains.compose.internal.utils.currentOS
 import org.jetbrains.compose.internal.utils.currentTarget
@@ -66,6 +67,11 @@ private fun JvmApplicationContext.configureCommonJvmDesktopTasks(): CommonJvmDes
         taskNameObject = "runtime"
     ) {
         jdkHome.set(app.javaHomeProvider)
+        jdkVersionProbeJar.from(
+            project.detachedComposeGradleDependency(
+                artifactId = "gradle-plugin-internal-jdk-version-probe"
+            ).excludeTransitiveDependencies()
+        )
     }
 
     val suggestRuntimeModules = tasks.register<AbstractSuggestModulesTask>(
@@ -249,9 +255,7 @@ private fun JvmApplicationContext.configureProguardTask(
     mainClass.set(app.mainClass)
     proguardVersion.set(settings.version)
     proguardFiles.from(proguardVersion.map { proguardVersion ->
-        project.configurations.detachedConfiguration(
-            project.dependencies.create("com.guardsquare:proguard-gradle:${proguardVersion}")
-        )
+        project.detachedDependency(groupId = "com.guardsquare", artifactId = "proguard-gradle", version = proguardVersion)
     })
     configurationFiles.from(settings.configurationFiles)
     // ProGuard uses -dontobfuscate option to turn off obfuscation, which is enabled by default

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -65,7 +65,7 @@ private fun JvmApplicationContext.configureCommonJvmDesktopTasks(): CommonJvmDes
         taskNameAction = "check",
         taskNameObject = "runtime"
     ) {
-        javaHome.set(app.javaHomeProvider)
+        jdkHome.set(app.javaHomeProvider)
     }
 
     val suggestRuntimeModules = tasks.register<AbstractSuggestModulesTask>(

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractCheckNativeDistributionRuntime.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractCheckNativeDistributionRuntime.kt
@@ -110,21 +110,25 @@ abstract class AbstractCheckNativeDistributionRuntime : AbstractComposeDesktopTa
                 import java.lang.reflect.Method;
 
                 public class $printJavaRuntimeClassName {
-                    public static void main(String[] args) {
-                        Class<Runtime> runtimeClass = Runtime.class;
+                    Class<Runtime> runtimeClass = Runtime.class;
+                    try {
+                        Method version = runtimeClass.getMethod("version");
+                        Object runtimeVer = version.invoke(runtimeClass);
+                        Class<? extends Object> runtimeVerClass = runtimeVer.getClass();
                         try {
-                            Method version = runtimeClass.getMethod("version");
-                            Object runtimeVer = version.invoke(runtimeClass);
-                            Class<? extends Object> runtimeVerClass = runtimeVer.getClass();
-                            try {
-                                int feature = (int) runtimeVerClass.getMethod("feature").invoke(runtimeVer);
-                                printVersionAndHalt((Integer.valueOf(feature)).toString());
-                            } catch (NoSuchMethodException e) {
-                                int major = (int) runtimeVerClass.getMethod("major").invoke(runtimeVer);
-                                printVersionAndHalt((Integer.valueOf(major)).toString());
-                            }
-                        } catch (Exception e) {
-                            printVersionAndHalt(System.getProperty("java.version"));
+                            int feature = (int) runtimeVerClass.getMethod("feature").invoke(runtimeVer);
+                            printVersionAndHalt((Integer.valueOf(feature)).toString());
+                        } catch (NoSuchMethodException e) {
+                            int major = (int) runtimeVerClass.getMethod("major").invoke(runtimeVer);
+                            printVersionAndHalt((Integer.valueOf(major)).toString());
+                        }
+                    } catch (Exception e) {
+                        String javaVersion = System.getProperty("java.version");
+                        String[] parts = javaVersion.split("\\.");
+                        if (parts.length > 2 && "1".equalsIgnoreCase(parts[0])) {
+                            printVersionAndHalt(parts[1]);
+                        } else {
+                            throw new IllegalStateException("Could not determine JDK version from string: '" + javaVersion + "'");
                         }
                     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
@@ -6,12 +6,12 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
-import org.jetbrains.compose.ComposeBuildConfig
+import org.jetbrains.compose.desktop.tasks.AbstractComposeDesktopTask
+import org.jetbrains.compose.desktop.ui.tooling.preview.rpc.*
+import org.jetbrains.compose.internal.utils.*
 import org.jetbrains.compose.internal.utils.currentTarget
 import org.jetbrains.compose.internal.utils.javaExecutable
 import org.jetbrains.compose.internal.utils.notNullProperty
-import org.jetbrains.compose.desktop.tasks.AbstractComposeDesktopTask
-import org.jetbrains.compose.desktop.ui.tooling.preview.rpc.*
 import java.io.File
 
 abstract class AbstractConfigureDesktopPreviewTask : AbstractComposeDesktopTask() {
@@ -37,14 +37,15 @@ abstract class AbstractConfigureDesktopPreviewTask : AbstractComposeDesktopTask(
         project.providers.gradleProperty("compose.desktop.preview.ide.port")
 
     @get:InputFiles
-    internal val uiTooling: FileCollection = project.configurations.detachedConfiguration(
-        project.dependencies.create("org.jetbrains.compose.ui:ui-tooling-desktop:${ComposeBuildConfig.composeVersion}")
-    ).apply { isTransitive = false }
+    internal val uiTooling: FileCollection =
+        project.detachedComposeDependency(
+            groupId = "org.jetbrains.compose.ui",
+            artifactId = "ui-tooling-desktop",
+        ).excludeTransitiveDependencies()
 
     @get:InputFiles
-    internal val hostClasspath: FileCollection = project.configurations.detachedConfiguration(
-        project.dependencies.create("org.jetbrains.compose:preview-rpc:${ComposeBuildConfig.composeVersion}")
-    )
+    internal val hostClasspath: FileCollection =
+        project.detachedComposeGradleDependency(artifactId = "preview-rpc")
 
     @TaskAction
     fun run() {
@@ -95,10 +96,12 @@ abstract class AbstractConfigureDesktopPreviewTask : AbstractComposeDesktopTask(
             }
             if (hasSkikoJvmRuntime) return emptyList()
 
-            if (hasSkikoJvm && skikoVersion != null && skikoVersion.isNotBlank()) {
-                val skikoRuntimeConfig = project.configurations.detachedConfiguration(
-                    project.dependencies.create("org.jetbrains.skiko:skiko-awt-runtime-${currentTarget.id}:$skikoVersion")
-                ).apply { isTransitive = false }
+            if (hasSkikoJvm && !skikoVersion.isNullOrBlank()) {
+                val skikoRuntimeConfig = project.detachedDependency(
+                    groupId = "org.jetbrains.skiko",
+                    artifactId = "skiko-awt-runtime-${currentTarget.id}",
+                    version = skikoVersion
+                ).excludeTransitiveDependencies()
                 return skikoRuntimeConfig.files
             }
         } catch (e: Exception) {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/internal/configureExperimentalWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/internal/configureExperimentalWebApplication.kt
@@ -12,8 +12,9 @@ import org.gradle.api.artifacts.UnresolvedDependency
 import org.gradle.api.provider.Provider
 import org.jetbrains.compose.ComposeBuildConfig
 import org.jetbrains.compose.experimental.dsl.ExperimentalWebApplication
-import org.jetbrains.compose.internal.utils.registerTask
 import org.jetbrains.compose.experimental.web.tasks.ExperimentalUnpackSkikoWasmRuntimeTask
+import org.jetbrains.compose.internal.utils.*
+import org.jetbrains.compose.internal.utils.registerTask
 import org.jetbrains.compose.internal.utils.uppercaseFirstChar
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 
@@ -43,8 +44,9 @@ private const val SKIKO_GROUP = "org.jetbrains.skiko"
 
 private fun skikoVersionProvider(project: Project): Provider<String> {
     val composeVersion = ComposeBuildConfig.composeVersion
-    val configurationWithSkiko = project.configurations.detachedConfiguration(
-        project.dependencies.create("org.jetbrains.compose.ui:ui-graphics:$composeVersion")
+    val configurationWithSkiko = project.detachedComposeDependency(
+        artifactId = "ui-graphics",
+        groupId = "org.jetbrains.compose.ui"
     )
     return project.provider {
         val skikoDependency = configurationWithSkiko.allDependenciesDescriptors.firstOrNull(::isSkikoDependency)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/gradleUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/gradleUtils.kt
@@ -6,7 +6,9 @@
 package org.jetbrains.compose.internal.utils
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.logging.Logger
+import org.jetbrains.compose.ComposeBuildConfig
 import java.util.*
 
 internal inline fun Logger.info(fn: () -> String) {
@@ -35,3 +37,27 @@ fun Project.getLocalProperty(key: String): String? {
         return null
     }
 }
+
+internal fun Project.detachedComposeGradleDependency(
+    artifactId: String,
+    groupId: String = "org.jetbrains.compose",
+): Configuration =
+    detachedDependency(groupId = groupId, artifactId = artifactId, version = ComposeBuildConfig.composeGradlePluginVersion)
+
+internal fun Project.detachedComposeDependency(
+    artifactId: String,
+    groupId: String = "org.jetbrains.compose",
+): Configuration =
+    detachedDependency(groupId = groupId, artifactId = artifactId, version = ComposeBuildConfig.composeVersion)
+
+internal fun Project.detachedDependency(
+    groupId: String,
+    artifactId: String,
+    version: String
+): Configuration =
+    project.configurations.detachedConfiguration(
+        project.dependencies.create("$groupId:$artifactId:$version")
+    )
+
+internal fun Configuration.excludeTransitiveDependencies(): Configuration =
+    apply { isTransitive = false }

--- a/gradle-plugins/jdk-version-probe/build.gradle.kts
+++ b/gradle-plugins/jdk-version-probe/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    java
+    id("maven-publish")
+}
+
+mavenPublicationConfig {
+    displayName = "JDK version probe"
+    description = "JDK version probe (Internal)"
+    artifactId = "gradle-plugin-internal-jdk-version-probe"
+}
+
+tasks.jar.configure {
+    manifest.attributes["Main-Class"] = "org.jetbrains.compose.desktop.application.internal.JdkVersionProbe"
+}

--- a/gradle-plugins/jdk-version-probe/src/main/java/org/jetbrains/compose/desktop/application/internal/JdkVersionProbe.java
+++ b/gradle-plugins/jdk-version-probe/src/main/java/org/jetbrains/compose/desktop/application/internal/JdkVersionProbe.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020-2023 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+package org.jetbrains.compose.desktop.application.internal;
+
+import java.lang.reflect.Method;
+
+public class JdkVersionProbe {
+    public static void main(String[] args) {
+        Class<Runtime> runtimeClass = Runtime.class;
+        try {
+            Method version = runtimeClass.getMethod("version");
+            Object runtimeVer = version.invoke(runtimeClass);
+            Class<?> runtimeVerClass = runtimeVer.getClass();
+            try {
+                int feature = (int) runtimeVerClass.getMethod("feature").invoke(runtimeVer);
+                printVersionAndHalt((Integer.valueOf(feature)).toString());
+            } catch (NoSuchMethodException e) {
+                int major = (int) runtimeVerClass.getMethod("major").invoke(runtimeVer);
+                printVersionAndHalt((Integer.valueOf(major)).toString());
+            }
+        } catch (Exception e) {
+            String javaVersion = System.getProperty("java.version");
+            String[] parts = javaVersion.split("\\.");
+            if (parts.length > 2 && "1".equalsIgnoreCase(parts[0])) {
+                printVersionAndHalt(parts[1]);
+            } else {
+                throw new IllegalStateException("Could not determine JDK version from string: '" + javaVersion + "'");
+            }
+        }
+    }
+
+    private static void printVersionAndHalt(String version) {
+        System.out.println(version);
+        Runtime.getRuntime().exit(0);
+    }
+}

--- a/gradle-plugins/settings.gradle.kts
+++ b/gradle-plugins/settings.gradle.kts
@@ -7,3 +7,4 @@ pluginManagement {
 
 include(":compose")
 include(":preview-rpc")
+include(":jdk-version-probe")


### PR DESCRIPTION
Previously some errors in checkRuntime task
were reported as a nested exception.
By default, Gradle shows only top-level
error message of an exception, which
made some errors confusing.
For example, when javac was missing from JDK,
Gradle only showed "Could not infer Java runtime version for Java home directory". The part that said javac was missing was only shown, when Gradle was run with --stacktrace argument.
This is suboptimal UX, so this commit refactors
checkRuntime to make error messages more descriptive.

#3133