### PR TITLE
Widgets gallery: Use title, not readableName

### DIFF
--- a/examples/widgets-gallery/shared/src/commonMain/kotlin/org/jetbrains/compose/demo/widgets/ui/MainView.kt
+++ b/examples/widgets-gallery/shared/src/commonMain/kotlin/org/jetbrains/compose/demo/widgets/ui/MainView.kt
@@ -145,7 +145,7 @@ private fun WidgetsListItemViewImpl(
         }
 
         Text(
-            text = widgetsType.readableName,
+            text = widgetsType.title,
             color = textColor,
             modifier = Modifier
                 .align(Alignment.CenterVertically)

--- a/examples/widgets-gallery/shared/src/commonMain/kotlin/org/jetbrains/compose/demo/widgets/ui/WidgetsType.kt
+++ b/examples/widgets-gallery/shared/src/commonMain/kotlin/org/jetbrains/compose/demo/widgets/ui/WidgetsType.kt
@@ -11,7 +11,7 @@ enum class WidgetsType(private val customTitle: String? = null) {
     TOGGLES,
     UI_CARDS("UI Cards");
 
-    val readableName: String by lazy {
+    private val readableName: String by lazy {
         name.split("_")
             .map { it.lowercase() }
             .mapIndexed { i, it ->


### PR DESCRIPTION
MainView should use title so that if a custom title is available it will be used. Hide readableName to prevent this from happening again by mistake.