### PR TITLE
Update compose gradle plugin version in integration composable-test-cases

### DIFF
--- a/compose/integrations/composable-test-cases/gradle.properties
+++ b/compose/integrations/composable-test-cases/gradle.properties
@@ -2,9 +2,9 @@ org.gradle.jvmargs=-Xmx2048M -XX:MaxMetaspaceSize=512m
 kotlin.code.style=official
 kotlin.native.enableDependencyPropagation=false
 android.useAndroidX=true
-kotlin.version=1.8.10
+kotlin.version=1.8.20
 agp.version=7.3.0
-compose.version=1.3.1
+compose.version=1.5.0-dev1063
 kotlin.native.cacheKind=none
 
 #empty by default - a default version will be used


### PR DESCRIPTION

Reason: https://github.com/JetBrains/compose-multiplatform/issues/3169 is needed to run the tests with kotlin 1.9.0-Beta