### PR TITLE
Add a warning for a user who sets `compose.kotlinCompilerPlugin` to `androidx.compose.compiler.compiler`

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -108,7 +108,7 @@ private const val COMPOSE_COMPILER_COMPATIBILITY_LINK =
 internal fun createWarningAboutNonCompatibleCompiler(currentCompilerPluginGroupId: String): String {
     return """
 WARNING: Usage of the Custom Compose Compiler plugin ('$currentCompilerPluginGroupId') 
-with non-JVM targets targets (Kotlin/Native, Kotlin/JS, Kotlin/WASM) is not supported.
+with non-JVM targets (Kotlin/Native, Kotlin/JS, Kotlin/WASM) is not supported.
 For more information, please visit: $COMPOSE_COMPILER_COMPATIBILITY_LINK
 """.trimMargin()
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -8,6 +8,7 @@ package org.jetbrains.compose
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.compose.internal.ComposeCompilerArtifactProvider
+import org.jetbrains.compose.internal.mppExt
 import org.jetbrains.compose.internal.webExt
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
@@ -23,6 +24,23 @@ class ComposeCompilerKotlinSupportPlugin : KotlinCompilerPluginSupportPlugin {
             composeCompilerArtifactProvider = ComposeCompilerArtifactProvider {
                 composeExt.kotlinCompilerPlugin.orNull ?:
                     ComposeCompilerCompatibility.compilerVersionFor(target.getKotlinPluginVersion())
+            }
+        }
+        warnAboutJetpackComposeCompilerUsageForNonJvm(target)
+    }
+
+    @Suppress("NON_EXHAUSTIVE_WHEN")
+    private fun warnAboutJetpackComposeCompilerUsageForNonJvm(target: Project) {
+        val isUsingJetpackComposeCompilerPlugin =
+            composeCompilerArtifactProvider.compilerArtifact.groupId.startsWith("androidx.compose.compiler")
+
+        if (isUsingJetpackComposeCompilerPlugin) {
+            target.mppExt.targets.forEach {
+                when (it.platformType) {
+                    KotlinPlatformType.native,
+                    KotlinPlatformType.js,
+                    KotlinPlatformType.wasm -> target.logger.warn(WARN_ABOUT_JC_COMPILER)
+                }
             }
         }
     }
@@ -69,3 +87,14 @@ class ComposeCompilerKotlinSupportPlugin : KotlinCompilerPluginSupportPlugin {
     private fun options(vararg options: Pair<String, String>): List<SubpluginOption> =
         options.map { SubpluginOption(it.first, it.second) }
 }
+
+private const val COMPOSE_COMPILER_COMPATIBILITY_LINK =
+    "https://github.com/JetBrains/compose-jb/blob/master/VERSIONING.md"
+
+private val WARN_ABOUT_JC_COMPILER = """
+    | WARNING: You are using the 'androidx.compose.compiler' plugin in your Kotlin multiplatform project.
+    | This plugin is only guaranteed to work with JVM targets (desktop or Android).
+    | The usage with Kotlin/JS or Kotlin/Native targets is not supported and might cause issues.
+    | Make sure you are using compatible versions of the Jetpack Compose Compiler and Kotlin.
+    | You can find the compatibility table here: $COMPOSE_COMPILER_COMPATIBILITY_LINK
+""".trimMargin()

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -8,7 +8,7 @@ package org.jetbrains.compose
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.compose.internal.ComposeCompilerArtifactProvider
-import org.jetbrains.compose.internal.mppExt
+import org.jetbrains.compose.internal.mppExtOrNull
 import org.jetbrains.compose.internal.webExt
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
@@ -26,20 +26,22 @@ class ComposeCompilerKotlinSupportPlugin : KotlinCompilerPluginSupportPlugin {
                     ComposeCompilerCompatibility.compilerVersionFor(target.getKotlinPluginVersion())
             }
         }
-        warnAboutJetpackComposeCompilerUsageForNonJvm(target)
+        target.afterEvaluate {
+            warnAboutJetpackComposeCompilerUsageForNonJvm(it)
+        }
     }
 
     @Suppress("NON_EXHAUSTIVE_WHEN")
     private fun warnAboutJetpackComposeCompilerUsageForNonJvm(target: Project) {
-        val isUsingJetpackComposeCompilerPlugin =
-            composeCompilerArtifactProvider.compilerArtifact.groupId.startsWith("androidx.compose.compiler")
+        val groupId = composeCompilerArtifactProvider.compilerArtifact.groupId
+        val isUsingNonJBComposeCompiler = !groupId.startsWith("org.jetbrains.compose.compiler")
 
-        if (isUsingJetpackComposeCompilerPlugin) {
-            target.mppExt.targets.forEach {
+        if (isUsingNonJBComposeCompiler) {
+            target.mppExtOrNull?.targets?.forEach {
                 when (it.platformType) {
                     KotlinPlatformType.native,
                     KotlinPlatformType.js,
-                    KotlinPlatformType.wasm -> target.logger.warn(WARN_ABOUT_JC_COMPILER)
+                    KotlinPlatformType.wasm -> target.logger.warn(createWarningAboutNonCompatibleCompiler(groupId))
                 }
             }
         }
@@ -89,12 +91,14 @@ class ComposeCompilerKotlinSupportPlugin : KotlinCompilerPluginSupportPlugin {
 }
 
 private const val COMPOSE_COMPILER_COMPATIBILITY_LINK =
-    "https://github.com/JetBrains/compose-jb/blob/master/VERSIONING.md"
+    "https://github.com/JetBrains/compose-jb/blob/master/VERSIONING.md#using-compose-multiplatform-compiler"
 
-private val WARN_ABOUT_JC_COMPILER = """
-    | WARNING: You are using the 'androidx.compose.compiler' plugin in your Kotlin multiplatform project.
-    | This plugin is only guaranteed to work with JVM targets (desktop or Android).
+private fun createWarningAboutNonCompatibleCompiler(currentCompilerPluginGroupId: String): String {
+    return """
+    | WARNING: You are using the '$currentCompilerPluginGroupId' compiler plugin in your Kotlin multiplatform project.
+    | This plugin is not guaranteed to work with non-JVM targets (jvm targets are: desktop or Android).
     | The usage with Kotlin/JS or Kotlin/Native targets is not supported and might cause issues.
-    | Make sure you are using compatible versions of the Compose Multiplatform Compiler and Kotlin.
+    | Make sure you are using compatible versions of the Compose Multiplatform Compiler plugin and Kotlin.
     | You can find the compatibility table here: $COMPOSE_COMPILER_COMPATIBILITY_LINK
 """.trimMargin()
+}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -95,6 +95,6 @@ private val WARN_ABOUT_JC_COMPILER = """
     | WARNING: You are using the 'androidx.compose.compiler' plugin in your Kotlin multiplatform project.
     | This plugin is only guaranteed to work with JVM targets (desktop or Android).
     | The usage with Kotlin/JS or Kotlin/Native targets is not supported and might cause issues.
-    | Make sure you are using compatible versions of the Jetpack Compose Compiler and Kotlin.
+    | Make sure you are using compatible versions of the Compose Multiplatform Compiler and Kotlin.
     | You can find the compatibility table here: $COMPOSE_COMPILER_COMPATIBILITY_LINK
 """.trimMargin()

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeMultiplatformBuildService.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeMultiplatformBuildService.kt
@@ -1,0 +1,62 @@
+package org.jetbrains.compose
+
+import org.gradle.api.Project
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.api.services.BuildServiceRegistry
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationCompletionListener
+import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
+
+// The service implements OperationCompletionListener just so Gradle would use the service
+// even if the service is not used by any task or transformation
+abstract class ComposeMultiplatformBuildService : BuildService<ComposeMultiplatformBuildService.Parameters>,
+    OperationCompletionListener, AutoCloseable {
+    interface Parameters : BuildServiceParameters {
+        val unsupportedCompilerPlugins: SetProperty<Provider<SubpluginArtifact?>>
+    }
+
+    private val log = Logging.getLogger(this.javaClass)
+
+    override fun close() {
+        notifyAboutUnsupportedCompilerPlugin()
+    }
+
+    private fun notifyAboutUnsupportedCompilerPlugin() {
+        val unsupportedCompilerPlugin = parameters.unsupportedCompilerPlugins.orNull
+            ?.firstOrNull()
+            ?.orNull
+
+        if (unsupportedCompilerPlugin != null) {
+            log.error(createWarningAboutNonCompatibleCompiler(unsupportedCompilerPlugin.groupId))
+        }
+    }
+
+    override fun onFinish(event: FinishEvent) {}
+
+    companion object {
+        fun configure(project: Project, fn: Parameters.() -> Unit): Provider<ComposeMultiplatformBuildService> =
+            project.gradle.sharedServices.registerOrConfigure<Parameters, ComposeMultiplatformBuildService> {
+                fn()
+            }
+
+        fun provider(project: Project): Provider<ComposeMultiplatformBuildService> = configure(project) {}
+    }
+}
+
+inline fun <reified P : BuildServiceParameters, reified S : BuildService<P>> BuildServiceRegistry.registerOrConfigure(
+    crossinline fn: P.() -> Unit
+): Provider<S> {
+    val serviceClass = S::class.java
+    val serviceFqName = serviceClass.canonicalName
+    val existingService = registrations.findByName(serviceFqName)
+        ?.apply { (parameters as? P)?.fn() }
+        ?.service
+    return (existingService as? Provider<S>)
+        ?: registerIfAbsent(serviceFqName, serviceClass) {
+            it.parameters.fn()
+        }
+}

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/KotlinCompatibilityTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/KotlinCompatibilityTest.kt
@@ -23,6 +23,22 @@ class KotlinCompatibilityTest : GradlePluginTestBase() {
     @Test
     fun testKotlinJsMpp_1_7_20() = testJsMpp("1.7.20")
 
+    @Suppress("RedundantUnitExpression")
+    @Test
+    fun testKotlinJs_shows_warning_for_androidx_compose_compiler() = testProject(
+        TestProjects.customCompilerArgs, defaultTestEnvironment.copy(
+            kotlinVersion = "1.8.22",
+            composeCompilerPlugin = "\"androidx.compose.compiler:compiler:1.4.8\"",
+            composeCompilerArgs = "\"suppressKotlinVersionCompatibilityCheck=1.8.22\""
+        )
+    ).let {
+        it.gradle(":compileKotlinJs").checks {
+            check.taskSuccessful(":compileKotlinJs")
+            check.logContains("WARNING: You are using the 'androidx.compose.compiler' compiler plugin in your Kotlin multiplatform project.")
+        }
+        Unit
+    }
+
     private fun testMpp(kotlinVersion: String) = with(
         testProject(
             TestProjects.mpp,

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/KotlinCompatibilityTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/KotlinCompatibilityTest.kt
@@ -23,22 +23,6 @@ class KotlinCompatibilityTest : GradlePluginTestBase() {
     @Test
     fun testKotlinJsMpp_1_7_20() = testJsMpp("1.7.20")
 
-    @Suppress("RedundantUnitExpression")
-    @Test
-    fun testKotlinJs_shows_warning_for_androidx_compose_compiler() = testProject(
-        TestProjects.customCompilerArgs, defaultTestEnvironment.copy(
-            kotlinVersion = "1.8.22",
-            composeCompilerPlugin = "\"androidx.compose.compiler:compiler:1.4.8\"",
-            composeCompilerArgs = "\"suppressKotlinVersionCompatibilityCheck=1.8.22\""
-        )
-    ).let {
-        it.gradle(":compileKotlinJs").checks {
-            check.taskSuccessful(":compileKotlinJs")
-            check.logContains("WARNING: You are using the 'androidx.compose.compiler' compiler plugin in your Kotlin multiplatform project.")
-        }
-        Unit
-    }
-
     private fun testMpp(kotlinVersion: String) = with(
         testProject(
             TestProjects.mpp,

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/UnsupportedCompilerPluginWarningTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/UnsupportedCompilerPluginWarningTest.kt
@@ -1,0 +1,44 @@
+package org.jetbrains.compose.test.tests.integration
+
+import org.jetbrains.compose.createWarningAboutNonCompatibleCompiler
+import org.jetbrains.compose.test.utils.GradlePluginTestBase
+import org.jetbrains.compose.test.utils.TestProjects
+import org.jetbrains.compose.test.utils.checks
+import org.junit.jupiter.api.Test
+
+class UnsupportedCompilerPluginWarningTest : GradlePluginTestBase() {
+
+    private val androidxComposeCompilerGroupId = "androidx.compose.compiler"
+    private val androidxComposeCompilerPlugin = "$androidxComposeCompilerGroupId:compiler:1.4.8"
+
+    @Suppress("RedundantUnitExpression")
+    @Test
+    fun testKotlinJs_shows_warning_for_androidx_compose_compiler() = testProject(
+        TestProjects.customCompilerArgs, defaultTestEnvironment.copy(
+            kotlinVersion = "1.8.22",
+            composeCompilerPlugin = "\"$androidxComposeCompilerPlugin\"",
+            composeCompilerArgs = "\"suppressKotlinVersionCompatibilityCheck=1.8.22\""
+        )
+    ).let {
+        it.gradle(":compileKotlinJs").checks {
+            check.taskSuccessful(":compileKotlinJs")
+            check.logContains(createWarningAboutNonCompatibleCompiler(androidxComposeCompilerGroupId))
+        }
+        Unit
+    }
+
+    @Suppress("RedundantUnitExpression")
+    @Test
+    fun testKotlinJvm_doesnt_show_warning_for_androidx_compose_compiler() = testProject(
+        TestProjects.customCompiler, defaultTestEnvironment.copy(
+            kotlinVersion = "1.8.22",
+            composeCompilerPlugin = "\"$androidxComposeCompilerPlugin\"",
+        )
+    ).let {
+        it.gradle(":run").checks {
+            check.taskSuccessful(":run")
+            check.logDoesntContain(createWarningAboutNonCompatibleCompiler(androidxComposeCompilerGroupId))
+        }
+        Unit
+    }
+}

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/assertUtils.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/assertUtils.kt
@@ -35,6 +35,12 @@ internal class BuildResultChecks(private val result: BuildResult) {
         }
     }
 
+    fun logDoesntContain(substring: String) {
+        if (result.output.contains(substring)) {
+            throw AssertionError("Test output contains the unexpected string: '$substring'")
+        }
+    }
+
     fun taskSuccessful(task: String) {
         taskOutcome(task, TaskOutcome.SUCCESS)
     }


### PR DESCRIPTION
To help users figure out the reason why their compose app doesn't compile for ios or web, let's show a warning when they use `androidx.compose.compiler:compiler`

The warning will show up only when a multiplatform project contains at least one of the non-jvm targets: k/js, k/native or k/wasm
