### PR TITLE
Components. Fix `KotlinSourceSet with name 'androidTest' not found.` on Kotlin 1.9.0

### DIFF
--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -3,9 +3,9 @@ android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
 # __KOTLIN_COMPOSE_VERSION__
-kotlin.version=1.8.20
+kotlin.version=1.9.0
 # __LATEST_COMPOSE_RELEASE_VERSION__
-compose.version=0.0.0-dev1101
+compose.version=1.5.0-dev1109
 agp.version=7.3.1
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true

--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
             dependsOn(jvmAndAndroidMain)
             dependsOn(commonButJSMain)
         }
-        val androidTest by getting {
+        val androidUnitTest by getting {
             dependencies {
 
             }


### PR DESCRIPTION
`androidTest` was deprecated: https://kotlinlang.org/docs/whatsnew18.html#kotlin-multiplatform-a-new-android-source-set-layout

```
FAILURE: Build failed with an exception.
* Where:
Build file '/mnt/agent/work/eef8b9c316a53dd6/components/resources/library/build.gradle.kts' line: 66

* What went wrong: KotlinSourceSet with name 'androidTest' not found.
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
* Get more help at https://help.gradle.org BUILD FAILED in 1m 24s
Process exited with code 1
```

See https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_AllGitHubRelease/4237033?buildTab=dependencies&mode=list&state=failed&type=snapshot&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true#4237024

## Testing
./gradlew resources:library:test