### PR TITLE
Components. Fix Mismatched @Composable annotation between expect and actual declaration

### DIFF
--- a/components/AnimatedImage/library/src/commonMain/kotlin/org/jetbrains/compose/animatedimage/AnimatedImage.kt
+++ b/components/AnimatedImage/library/src/commonMain/kotlin/org/jetbrains/compose/animatedimage/AnimatedImage.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.compose.animatedimage
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.ImageBitmap
 
 /**
@@ -23,6 +24,7 @@ expect suspend fun loadResourceAnimatedImage(path: String): AnimatedImage
  * Animates an [AnimatedImage] by returning an [ImageBitmap] for each frame of the image.
  * The caller will be recomposed with each new frame that has been rendered.
  */
+@Composable
 expect fun AnimatedImage.animate(): ImageBitmap
 
 private val BlankBitmap = ImageBitmap(1, 1)

--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -5,7 +5,7 @@ kotlin.code.style=official
 # __KOTLIN_COMPOSE_VERSION__
 kotlin.version=1.9.0
 # __LATEST_COMPOSE_RELEASE_VERSION__
-compose.version=1.5.0-dev1109
+compose.version=1.5.0-dev1112
 agp.version=7.3.1
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true


### PR DESCRIPTION
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_AllGitHubRelease/4237900?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=false&expandBuildProblemsSection=true&showLog=4237891_234_144&logFilter=debug&logView=flowAware

There was a mistake in commonMain/AnimatedImage.kt that can be caught in compile-time with Kotlin 1.9