### PR TITLE
Components. Fix Its usage must be marked with '@kotlinx.cinterop.ExperimentalForeignApi'

### DIFF
--- a/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/Resource.ios.kt
+++ b/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/Resource.ios.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.compose.resources
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSBundle
@@ -17,6 +18,7 @@ actual fun resource(path: String): Resource = UIKitResourceImpl(path)
 
 @ExperimentalResourceApi
 private class UIKitResourceImpl(path: String) : AbstractResourceImpl(path) {
+    @OptIn(ExperimentalForeignApi::class)
     override suspend fun readBytes(): ByteArray {
         val fileManager = NSFileManager.defaultManager()
         // todo: support fallback path at bundle root?

--- a/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/Resource.macos.kt
+++ b/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/Resource.macos.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.compose.resources
 
+import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
@@ -16,6 +17,7 @@ actual fun resource(path: String): Resource = MacOSResourceImpl(path)
 
 @ExperimentalResourceApi
 private class MacOSResourceImpl(path: String) : AbstractResourceImpl(path) {
+    @OptIn(ExperimentalForeignApi::class)
     override suspend fun readBytes(): ByteArray {
         val currentDirectoryPath = NSFileManager.defaultManager().currentDirectoryPath
         val contentsAtPath: NSData? = NSFileManager.defaultManager().run {


### PR DESCRIPTION
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_AllGitHubRelease/4238435?buildTab=dependencies&mode=list&state=failed&type=snapshot&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&showLog=4238425_373_267&logFilter=debug&logView=flowAware#4238426

Kotlin 1.9 broke source compatibility for native targets, usePinned is now experimental