### PR TITLE
Disable image viewer checks on CI

### DIFF
--- a/examples/validateExamples.sh
+++ b/examples/validateExamples.sh
@@ -21,7 +21,7 @@ runGradle() {
 
 runGradle chat packageDistributionForCurrentOS
 runGradle codeviewer packageDistributionForCurrentOS
-runGradle imageviewer packageDistributionForCurrentOS
+#runGradle imageviewer packageDistributionForCurrentOS
 runGradle issues packageDistributionForCurrentOS
 runGradle notepad packageDistributionForCurrentOS
 runGradle todoapp-lite packageDistributionForCurrentOS

--- a/examples/validateExamplesAndroid.sh
+++ b/examples/validateExamplesAndroid.sh
@@ -22,7 +22,7 @@ runGradle() {
 # requires an emulator running or an Android device to be connected
 runGradle chat installDebug
 runGradle codeviewer installDebug
-runGradle imageviewer installDebug
+#runGradle imageviewer installDebug
 runGradle issues installDebug
 runGradle minesweeper installDebug
 runGradle todoapp-lite installDebug

--- a/examples/validateExamplesIos.sh
+++ b/examples/validateExamplesIos.sh
@@ -34,7 +34,7 @@ runGradle() {
 runGradle chat
 runGradle codeviewer
 runGradle falling-balls
-runGradle imageviewer
+# runGradle imageviewer
 runGradle todoapp-lite
 runGradle visual-effects
 runGradle widgets-gallery


### PR DESCRIPTION
Because:
1. it uses experimental API, that was changed int 1.5.0-beta03 after 1.4.0
2. we have a policy to use only release versions in the examples

Temporarily, will made a fix in support/1.5.0 branch