### PR TITLE
Components. Downgrade to Kotlin 1.8.22

### DIFF
--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -3,7 +3,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
 # __KOTLIN_COMPOSE_VERSION__
-kotlin.version=1.9.0
+kotlin.version=1.8.22
 # __LATEST_COMPOSE_RELEASE_VERSION__
 compose.version=1.5.0-dev1112
 agp.version=7.3.1

--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
             dependsOn(jvmAndAndroidMain)
             dependsOn(commonButJSMain)
         }
-        val androidUnitTest by getting {
+        val androidTest by getting {
             dependencies {
 
             }

--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -63,11 +63,6 @@ kotlin {
             dependsOn(jvmAndAndroidMain)
             dependsOn(commonButJSMain)
         }
-        val androidTest by getting {
-            dependencies {
-
-            }
-        }
         val iosMain by getting {
             dependsOn(skikoMain)
             dependsOn(commonButJSMain)

--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -63,6 +63,11 @@ kotlin {
             dependsOn(jvmAndAndroidMain)
             dependsOn(commonButJSMain)
         }
+        val androidTest by getting {
+            dependencies {
+
+            }
+        }
         val iosMain by getting {
             dependsOn(skikoMain)
             dependsOn(commonButJSMain)

--- a/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/Resource.ios.kt
+++ b/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/Resource.ios.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.compose.resources
 
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSBundle
@@ -18,7 +17,6 @@ actual fun resource(path: String): Resource = UIKitResourceImpl(path)
 
 @ExperimentalResourceApi
 private class UIKitResourceImpl(path: String) : AbstractResourceImpl(path) {
-    @OptIn(ExperimentalForeignApi::class)
     override suspend fun readBytes(): ByteArray {
         val fileManager = NSFileManager.defaultManager()
         // todo: support fallback path at bundle root?

--- a/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/Resource.macos.kt
+++ b/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/Resource.macos.kt
@@ -5,7 +5,6 @@
 
 package org.jetbrains.compose.resources
 
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
@@ -17,7 +16,6 @@ actual fun resource(path: String): Resource = MacOSResourceImpl(path)
 
 @ExperimentalResourceApi
 private class MacOSResourceImpl(path: String) : AbstractResourceImpl(path) {
-    @OptIn(ExperimentalForeignApi::class)
     override suspend fun readBytes(): ByteArray {
         val currentDirectoryPath = NSFileManager.defaultManager().currentDirectoryPath
         val contentsAtPath: NSData? = NSFileManager.defaultManager().run {


### PR DESCRIPTION
Dowgrading to Kotlin 1.8 will allow to use `components` in Kotlin 1.8 and Kotlin 1.9 projects (iOS, JS targets). Now it is supported only in Kotlin 1.9 projects.