### PR TITLE
Widgets gallery: fix for mismatched @Composable annotation (desktop)

### DIFF
--- a/examples/widgets-gallery/shared/src/desktopMain/kotlin/org/jetbrains/compose/demo/widgets/platform/System.kt
+++ b/examples/widgets-gallery/shared/src/desktopMain/kotlin/org/jetbrains/compose/demo/widgets/platform/System.kt
@@ -1,5 +1,0 @@
-package org.jetbrains.compose.demo.widgets.platform
-
-import org.jetbrains.skiko.SystemTheme
-
-actual fun isSystemInDarkTheme(): Boolean = org.jetbrains.skiko.currentSystemTheme == SystemTheme.DARK


### PR DESCRIPTION
Followup after https://github.com/JetBrains/compose-multiplatform/pull/3402