### PR TITLE
Added performance issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -10,7 +10,7 @@ assignees: ''
 **Describe the problem**
 Explain the performance issue you're experiencing, including the following details:
 
-- What specific issue did you encounter? (e.g., missing frames, high CPU usage, memory leaks)
+- What specific issue did you encounter? (e.g. missing frames, high CPU usage, memory leaks)
 - Have you noticed any patterns or specific circumstances under which the problem occurs?
 
 **Affected platforms**
@@ -42,7 +42,7 @@ Please provide a detailed step-by-step guide on how to reproduce the issue you a
 If you're reporting slow app work or missing frames, please provide a video of the problem.
 
 **Profiling data**
-Please provide any relevant profiling data that might be helpful. This could include information like memory usage, CPU time, or any other data that could provide insight into the performance issue.
+Please provide any relevant profiling data that might be helpful. This could include information like FPS, memory usage, CPU time, or any other data that could provide insight into the performance issue.
 
 **Additional information**
 Provide any other details that you think might be helpful for us to understand the problem. This could include things like the system configuration, external factors, etc.

--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -1,0 +1,48 @@
+---
+name: Performance problem
+about: Create a report to help us improve
+title: ''
+labels: ['submitted', 'performance']
+assignees: ''
+
+---
+
+**Describe the problem**
+Explain the performance issue you're experiencing, including the following details:
+
+- What specific issue did you encounter? (e.g., missing frames, high CPU usage, memory leaks)
+- Have you noticed any patterns or specific circumstances under which the problem occurs?
+
+**Affected platforms**
+Select one of the platforms below:
+- All
+- Desktop
+- Web (K/Wasm) - Canvas based API
+- Web (K/JS) - Canvas based API
+- Web (K/JS) - HTML library
+- iOS
+- Other
+
+If the problem is Android-only, report it in the [Jetpack Compose tracker](https://issuetracker.google.com/issues/new?component=612128)
+
+**Versions**
+- Kotlin version: 
+- Compose Multiplatform version: 
+- OS version(s) (required for Desktop and iOS issues): 
+- OS architecture (x86 or arm64): 
+- JDK (for desktop issues): 
+
+**Sample code**
+If possible, provide a small piece of code that reproduces the problem. If the code snippet is too large to paste here, please link to a Gist, a GitHub repo, or any other public code repository.
+
+**Reproduction steps**
+Please provide a detailed step-by-step guide on how to reproduce the issue you are experiencing.
+
+**Video**
+If you're reporting slow app work or missing frames, please provide a video of the problem.
+
+**Profiling data**
+Please provide any relevant profiling data that might be helpful. This could include information like memory usage, CPU time, or any other data that could provide insight into the performance issue.
+
+**Additional information**
+Provide any other details that you think might be helpful for us to understand the problem. This could include things like the system configuration, external factors, etc.


### PR DESCRIPTION
In order to collect more performance problems from Compose users, I'm adding a new issue template. We'll link to it from 1.5.0-Beta blogpost and other marketing materials.