### PR TITLE
Disable partial-linkage in compose compiler tests 

### DIFF
--- a/compose/integrations/composable-test-cases/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 
 group "com.example"
@@ -8,6 +9,7 @@ allprojects {
         google()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/") // to test with kotlin dev builds
         // mavenLocal()
     }
 
@@ -27,6 +29,10 @@ allprojects {
             kotlinOptions.freeCompilerArgs += listOf(
                 "-Xklib-enable-signature-clash-checks=false",
             )
+        }
+
+        tasks.withType<KotlinCompile<*>>().configureEach {
+            kotlinOptions.freeCompilerArgs += "-Xpartial-linkage=disable"
         }
     }
     disableYarnLockMismatchReport()


### PR DESCRIPTION
kotlin 1.9.0 introduced partial linkage for k/js and k/native. It means that unbound symbols don't fail the compilation. Instead it would fail at runtime but only if the problematic function is invoked.

In our compose compiler tests we should disable partial linkage to catch potential unbound symbols (like https://github.com/JetBrains/compose-multiplatform/issues/3421).  