### PR TITLE
Handle ClassCastException for ComposeMultiplatformBuildService in Compose Gradle plugin

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -60,7 +60,7 @@ class ComposeCompilerKotlinSupportPlugin @Inject constructor(
             throw IllegalStateException(
                 "Failed to get ComposeMultiplatformBuildService instance." +
                         " Compose Gradle plugin was probably loaded more than once." +
-                        " Consider declaring it in the root build.gradle.kts. Original exception message: ${e.message}",
+                        " Consider declaring it in the root build.gradle.kts",
                 e
             )
         }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -13,6 +13,7 @@ import org.jetbrains.compose.internal.mppExtOrNull
 import org.jetbrains.compose.internal.webExt
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
+import java.lang.ClassCastException
 import javax.inject.Inject
 
 @Suppress("UnstableApiUsage")
@@ -50,7 +51,21 @@ class ComposeCompilerKotlinSupportPlugin @Inject constructor(
         val service = ComposeMultiplatformBuildService.provider(target)
         buildEventsListenerRegistry.onTaskCompletion(service)
 
-        service.get().parameters.unsupportedCompilerPlugins.add(
+        val providedService = try {
+            service.get()
+        } catch (e: ClassCastException) {
+            // Compose Gradle plugin was probably loaded more than once
+            // See https://github.com/JetBrains/compose-multiplatform/issues/3459
+
+            throw IllegalStateException(
+                "Failed to get ComposeMultiplatformBuildService instance." +
+                        " Compose Gradle plugin was probably loaded more than once." +
+                        " Consider declaring it in the root build.gradle.kts. Original exception message: ${e.message}",
+                e
+            )
+        }
+
+        providedService.parameters.unsupportedCompilerPlugins.add(
             target.provider {
                 composeCompilerArtifactProvider.compilerArtifact.takeIf {
                     target.hasNonJvmTargets() && it.isNonJBComposeCompiler()


### PR DESCRIPTION
ClassCastException might occur when our gradle plugin was loaded more than once.  See https://github.com/JetBrains/compose-multiplatform/issues/3459

We throw another exception with a bit more clear message.