### PR TITLE
Replace warnings with errors

### DIFF
--- a/examples/chat/gradle.properties
+++ b/examples/chat/gradle.properties
@@ -6,11 +6,10 @@ org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
-compose.version=1.4.3
+compose.version=1.5.0-beta02

--- a/examples/chat/shared/build.gradle.kts
+++ b/examples/chat/shared/build.gradle.kts
@@ -45,7 +45,6 @@ kotlin {
             baseName = "shared"
             isStatic = true
         }
-        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
     }
 
     sourceSets {

--- a/examples/codeviewer/gradle.properties
+++ b/examples/codeviewer/gradle.properties
@@ -6,11 +6,10 @@ org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
-compose.version=1.4.3
+compose.version=1.5.0-beta02

--- a/examples/codeviewer/shared/build.gradle.kts
+++ b/examples/codeviewer/shared/build.gradle.kts
@@ -26,7 +26,6 @@ kotlin {
             baseName = "shared"
             isStatic = true
         }
-        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
     }
 
     sourceSets {

--- a/examples/falling-balls/gradle.properties
+++ b/examples/falling-balls/gradle.properties
@@ -6,11 +6,10 @@ org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
-compose.version=1.4.3
+compose.version=1.5.0-beta02

--- a/examples/falling-balls/shared/build.gradle.kts
+++ b/examples/falling-balls/shared/build.gradle.kts
@@ -45,7 +45,6 @@ kotlin {
             baseName = "shared"
             isStatic = true
         }
-        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
     }
 
     sourceSets {

--- a/examples/imageviewer/gradle.properties
+++ b/examples/imageviewer/gradle.properties
@@ -6,11 +6,10 @@ org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
-compose.version=1.5.0-dev1114
+compose.version=1.5.0-beta02

--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -26,8 +26,6 @@ kotlin {
             baseName = "shared"
             isStatic = true
         }
-        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
-
     }
 
     sourceSets {

--- a/examples/minesweeper/gradle.properties
+++ b/examples/minesweeper/gradle.properties
@@ -6,11 +6,10 @@ org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
-compose.version=1.4.3
+compose.version=1.5.0-beta02

--- a/examples/minesweeper/shared/build.gradle.kts
+++ b/examples/minesweeper/shared/build.gradle.kts
@@ -15,16 +15,7 @@ kotlin {
     jvm("desktop")
 
     ios()
-    iosSimulatorArm64() {
-        // TODO: remove after 1.5 release
-        binaries.forEach {
-            it.freeCompilerArgs += listOf(
-                "-linker-option", "-framework", "-linker-option", "Metal",
-                "-linker-option", "-framework", "-linker-option", "CoreText",
-                "-linker-option", "-framework", "-linker-option", "CoreGraphics",
-            )
-        }
-    }
+    iosSimulatorArm64()
 
     js(IR) {
         browser()
@@ -54,7 +45,6 @@ kotlin {
             baseName = "shared"
             isStatic = true
         }
-        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
     }
 
     sourceSets {

--- a/examples/todoapp-lite/gradle.properties
+++ b/examples/todoapp-lite/gradle.properties
@@ -6,11 +6,10 @@ org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
-compose.version=1.4.3
+compose.version=1.5.0-beta02

--- a/examples/todoapp-lite/shared/build.gradle.kts
+++ b/examples/todoapp-lite/shared/build.gradle.kts
@@ -26,7 +26,6 @@ kotlin {
             baseName = "shared"
             isStatic = true
         }
-        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
     }
 
     sourceSets {

--- a/examples/visual-effects/gradle.properties
+++ b/examples/visual-effects/gradle.properties
@@ -7,10 +7,9 @@ org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
-compose.version=1.4.3
+compose.version=1.5.0-beta02

--- a/examples/visual-effects/shared/build.gradle.kts
+++ b/examples/visual-effects/shared/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
             baseName = "shared"
             isStatic = true
         }
-        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
     }
 
     sourceSets {

--- a/examples/widgets-gallery/gradle.properties
+++ b/examples/widgets-gallery/gradle.properties
@@ -6,11 +6,10 @@ org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
-compose.version=1.4.3
+compose.version=1.5.0-beta02

--- a/examples/widgets-gallery/shared/build.gradle.kts
+++ b/examples/widgets-gallery/shared/build.gradle.kts
@@ -26,7 +26,6 @@ kotlin {
             baseName = "shared"
             isStatic = true
         }
-        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
     }
 
     sourceSets {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/configureNativeCompilerCaching.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/configureNativeCompilerCaching.kt
@@ -46,9 +46,7 @@ private fun KotlinNativeTarget.checkCacheKindUserValueIsNotNone() {
             val value = provider.valueOrNull(cacheKindProperty)
             if (value != null) {
                 if (value.equals(NONE_VALUE, ignoreCase = true)) {
-                    ComposeMultiplatformBuildService
-                        .getInstance(project)
-                        .warnOnceAfterBuild(cacheKindPropertyWarningMessage(cacheKindProperty, provider))
+                    error(cacheKindPropertyWarningMessage(cacheKindProperty, provider))
                 }
                 return
             }
@@ -60,13 +58,13 @@ private fun cacheKindPropertyWarningMessage(
     cacheKindProperty: String,
     provider: KGPPropertyProvider
 ) = """
-    |Warning: '$cacheKindProperty' is explicitly set to `none`.
+    |'$cacheKindProperty' is explicitly set to `none`.
     |This option significantly slows the Kotlin/Native compiler.
     |Compose Multiplatform Gradle plugin can set this property automatically,
     |when it is necessary.
     |  * Recommended action: remove explicit '$cacheKindProperty=$NONE_VALUE' from ${provider.location}. 
     |  * Alternative action: if you are sure you need '$cacheKindProperty=$NONE_VALUE', disable
-    |this warning by adding '$COMPOSE_NATIVE_MANAGE_CACHE_KIND=false' to your 'gradle.properties'.
+    |this error by adding '$COMPOSE_NATIVE_MANAGE_CACHE_KIND=false' to your 'gradle.properties'.
 """.trimMargin()
 
 private fun KotlinNativeTarget.configureTargetCompilerCache(kotlinVersion: KotlinVersion) {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/resources/configureSyncIosResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/resources/configureSyncIosResources.kt
@@ -92,7 +92,11 @@ private fun SyncIosResourcesContext.configureCocoapodsResourcesAttribute() {
             val specAttributes = cocoapodsExt.extraSpecAttributes
             val resourcesSpec = specAttributes[RESOURCES_SPEC_ATTR]
             if (!resourcesSpec.isNullOrBlank()) {
-                project.logger.warn("Warning: kotlin.cocoapods.extraSpecAttributes[\"resources\"] is ignored by Compose Multiplatform's resource synchronization for iOS")
+                error("""
+                    |Kotlin.cocoapods.extraSpecAttributes["resources"] is not compatible with Compose Multiplatform's resources management for iOS.
+                    |  * Recommended action: remove extraSpecAttributes["resources"] from '${project.buildFile}' and run '${project.path}:podInstall' once;
+                    |  * Alternative action: turn off Compose Multiplatform's resources management for iOS by adding '${IosGradleProperties.SYNC_RESOURCES_PROPERTY}=false' to your gradle.properties;
+                """.trimMargin())
             }
             cocoapodsExt.framework {
                 val syncDir = syncDirFor(this).get().asFile

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -142,23 +142,19 @@ class GradlePluginTest : GradlePluginTestBase() {
             defaultTestEnvironment.copy(kotlinVersion = kotlinVersion)
         )
 
-        val cacheKindWarning = "Warning: 'kotlin.native.cacheKind' is explicitly set to `none`"
+        val cacheKindError = "'kotlin.native.cacheKind' is explicitly set to `none`"
 
         val args = arrayOf("build", "--dry-run", "-Pkotlin.native.cacheKind=none")
         with(nativeCacheKindWarningProject(kotlinVersion = TestKotlinVersions.v1_8_20)) {
-            gradle(*args).checks {
-                check.logContainsOnce(cacheKindWarning)
-            }
-            // check that the warning is shown even when the configuration is loaded from cache
-            gradle(*args).checks {
-                check.logContainsOnce(cacheKindWarning)
+            gradleFailure(*args).checks {
+                check.logContains(cacheKindError)
             }
         }
         testWorkDir.deleteRecursively()
         testWorkDir.mkdirs()
         with(nativeCacheKindWarningProject(kotlinVersion = TestKotlinVersions.v1_9_0) ) {
-            gradle(*args).checks {
-                check.logContainsOnce(cacheKindWarning)
+            gradleFailure(*args).checks {
+                check.logContains(cacheKindError)
             }
         }
     }


### PR DESCRIPTION
Compose Multiplatform 1.5.0 prohibits some Gradle configuration flags and Gradle DSL options.

## 1. Kotlin/Native compiler cache

By default, disabling the compiler caches for Kotlin/Native is now prohibited. The caches are disabled by the following flags in `gradle.properties` or `local.properties`:
* `kotlin.native.cacheKind=none`;
* `kotlin.native.cacheKind.<IOS_TARGET_PRESET>=none`; 

#### What can you do?
* 🟢 We recommend to remove `kotlin.native.cacheKind=none` from `gradle.properties` or `local.properties`. 
* ⚠️ If you are sure the flags are necessary, the automatic flag management and the error can be turned off by adding `compose.kotlin.native.manageCacheKind=false` to `gradle.properties`.

#### Detailed description

Disabling the compiler caches is usually not necessary because it significantly slows down incremental builds.
However, prior to Kotlin/Native 1.9.0, the compiler often could not compile Compose code with the cache. 
This has led to widespread use of `cacheKind=none` throughout many Compose Multiplatform projects. 

The root issue is partially fixed in Kotlin 1.9.0, and completely fixed in the upcoming Kotlin 1.9.20. 
Compose Multiplatform Gradle plugin now can manage the necessary caching flags by itself based on a Kotlin/Native version being used. 

To address the widespread use of the flags, Compose Multiplatform Gradle plugin now throws an error when a flag is explicitly set to `none`. 

## 2. CocoaPods resource configuration

⚠️ This section is only relevant for users of the Compose Multiplatform experimental resources library.
Users of third party libraries (such as Moko Resources or libres) should not be affected by this.

Now, explicitly setting the extra spec `resources` attribute is prohibited:
```
kotlin {
    cocoapods {
        // ...
        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
    }
}
``` 

#### What can you do?

* 🟢 We recommend to remove `extraSpecAttributes["resources"]` from build scripts:

```
kotlin {
    cocoapods {
        // The following line should be removed!
        extraSpecAttributes["resources"] = "['src/commonMain/resources/**', 'src/iosMain/resources/**']"
    }
}
```
* ⚠️ Alternatively, the automatic resource management can be disabled by adding the following line to `gradle.properties`:
```
org.jetbrains.compose.ios.resources.sync=false
```

#### Detailed description

For more information about resource management improvements, see the description of the [corresponding PR](https://github.com/JetBrains/compose-multiplatform/pull/3340).