### PR TITLE
Fix iOS ImageViewer example with Compose 1.4.3 and Kotlin 1.9.0

### DIFF
--- a/examples/imageviewer/shared/src/iosMain/kotlin/example/imageviewer/platform.ios.kt
+++ b/examples/imageviewer/shared/src/iosMain/kotlin/example/imageviewer/platform.ios.kt
@@ -17,6 +17,7 @@ import platform.Foundation.CFBridgingRelease
 import platform.UIKit.UIApplication
 import platform.UIKit.UIImage
 
+@OptIn(ExperimentalForeignApi::class)
 private val iosNotchInset = object : WindowInsets {
     override fun getTop(density: Density): Int {
         val safeAreaInsets = UIApplication.sharedApplication.keyWindow?.safeAreaInsets


### PR DESCRIPTION
iOS Compilation of ImageViewer in master branch is broken. It happends after updating Kotlin from 1.8.20 to 1.9.0.
In this PR we fixed it.