### PR TITLE
Update ComposeCompilerCompatibility.kt

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
@@ -14,7 +14,7 @@ internal object ComposeCompilerCompatibility {
         "1.8.22" to "1.4.8",
         "1.9.0-Beta" to "1.4.7.1-beta",
         "1.9.0-RC" to "1.4.8-beta",
-        "1.9.0" to "1.5.0"
+        "1.9.0" to "1.5.1-rc01"
     )
 
     fun compilerVersionFor(kotlinVersion: String): String {


### PR DESCRIPTION
It updates the default version of compose compiler plugin for kotlin 1.9.0
For now it's 1.5.1-rc01 version. For a stable release, we'll build a stable 1.5.1 compose compiler plugin. 