### PR TITLE
Revert enabling caching for Kotlin 1.9.0

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -128,8 +128,7 @@ class GradlePluginTest : GradlePluginTestBase() {
         with(nativeCacheKindProject(kotlinVersion = TestKotlinVersions.v1_9_0) ) {
             gradle(task, "--info").checks {
                 check.taskSuccessful(task)
-                check.logContains("-Xauto-cache-from=")
-                check.logContains("-Xlazy-ir-for-caches=disable")
+                check.logDoesntContain("-Xauto-cache-from=")
             }
         }
     }
@@ -142,19 +141,19 @@ class GradlePluginTest : GradlePluginTestBase() {
             defaultTestEnvironment.copy(kotlinVersion = kotlinVersion)
         )
 
-        val cacheKindError = "'kotlin.native.cacheKind' is explicitly set to `none`"
+        val cacheKindWarning = "'kotlin.native.cacheKind' is explicitly set to `none`"
 
         val args = arrayOf("build", "--dry-run", "-Pkotlin.native.cacheKind=none")
         with(nativeCacheKindWarningProject(kotlinVersion = TestKotlinVersions.v1_8_20)) {
-            gradleFailure(*args).checks {
-                check.logContains(cacheKindError)
+            gradle(*args).checks {
+                check.logContains(cacheKindWarning)
             }
         }
         testWorkDir.deleteRecursively()
         testWorkDir.mkdirs()
         with(nativeCacheKindWarningProject(kotlinVersion = TestKotlinVersions.v1_9_0) ) {
-            gradleFailure(*args).checks {
-                check.logContains(cacheKindError)
+            gradle(*args).checks {
+                check.logContains(cacheKindWarning)
             }
         }
     }


### PR DESCRIPTION
We tried to enable the compiler cache, when
Kotlin/Native 1.9.0 is used.
Prior to Kotlin 1.9.0, the caching could not
be used with Compose, because code generation would fail. With Kotlin 1.9.0, code generation succeeds, but  generated debug symbols cause issues with dsymutil during xcode build. For more details, see https://youtrack.jetbrains.com/issue/KT-61270

This change partially reverts https://github.com/JetBrains/compose-multiplatform/pull/3477 and https://github.com/JetBrains/compose-multiplatform/pull/3496

Now, we always set `kotlin.native.cacheKind=none` in Compose Multiplatform Gradle plugin for all
versions of Kotlin until KT-61270 is fixed.
Also, explicit cache kind error becomes a warning again.