### PR TITLE
Add a unit test to the imageviewer example.

### DIFF
--- a/examples/imageviewer/androidApp/build.gradle.kts
+++ b/examples/imageviewer/androidApp/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {

--- a/examples/imageviewer/androidApp/build.gradle.kts
+++ b/examples/imageviewer/androidApp/build.gradle.kts
@@ -17,11 +17,11 @@ kotlin {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
     defaultConfig {
         applicationId = "org.jetbrains.Imageviewer"
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
     }

--- a/examples/imageviewer/gradle.properties
+++ b/examples/imageviewer/gradle.properties
@@ -12,4 +12,4 @@ kotlin.native.useEmbeddableCompilerJar=true
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
-compose.version=1.5.0-beta02
+compose.version=1.5.0-rc01

--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 version = "1.0-SNAPSHOT"
 
 kotlin {
-    android()
+    androidTarget()
     jvm("desktop")
     ios()
     iosSimulatorArm64()
@@ -69,6 +69,13 @@ kotlin {
             dependencies {
                 implementation(compose.desktop.common)
                 implementation(project(":mapview-desktop"))
+            }
+        }
+
+        val desktopTest by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+                implementation(compose.desktop.uiTestJUnit4)
             }
         }
     }

--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -82,14 +82,14 @@ kotlin {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/examples/imageviewer/shared/src/androidMain/kotlin/example/imageviewer/view/ScrollableColumn.android.kt
+++ b/examples/imageviewer/shared/src/androidMain/kotlin/example/imageviewer/view/ScrollableColumn.android.kt
@@ -1,8 +1,9 @@
 package example.imageviewer.view
 
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-actual fun ScrollableColumn(modifier: Modifier, content: @Composable () -> Unit) =
+actual fun ScrollableColumn(modifier: Modifier, content: @Composable ColumnScope.() -> Unit) =
     TouchScrollableColumn(modifier, content)

--- a/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/GalleryScreen.kt
+++ b/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/GalleryScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import example.imageviewer.*
 import example.imageviewer.icon.IconMenu
@@ -143,7 +144,10 @@ fun GalleryScreen(
             TopLayout(
                 alignLeftContent = {},
                 alignRightContent = {
-                    CircularButton(imageVector = IconMenu) {
+                    CircularButton(
+                        imageVector = IconMenu,
+                        modifier = Modifier.testTag("toggleGalleryStyleButton")
+                    ) {
                         galleryStyle = when (galleryStyle) {
                             GalleryStyle.SQUARES -> GalleryStyle.LIST
                             GalleryStyle.LIST -> GalleryStyle.SQUARES
@@ -159,7 +163,6 @@ fun GalleryScreen(
                     pagerState = pagerState,
                     onSelect = { selectPicture(it) },
                 )
-
                 GalleryStyle.LIST -> ListGalleryView(
                     pictures = pictures,
                     onSelect = { selectPicture(it) },
@@ -183,7 +186,7 @@ private fun SquaresGalleryView(
     onSelect: (index: Int) -> Unit,
 ) {
     LazyVerticalGrid(
-        modifier = Modifier.padding(top = 4.dp),
+        modifier = Modifier.padding(top = 4.dp).testTag("squaresGalleryView"),
         columns = GridCells.Adaptive(minSize = 130.dp),
         verticalArrangement = Arrangement.spacedBy(1.dp),
         horizontalArrangement = Arrangement.spacedBy(1.dp)
@@ -253,7 +256,7 @@ private fun ListGalleryView(
 ) {
     val notification = LocalNotification.current
     ScrollableColumn(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize().testTag("listGalleryView")
     ) {
         Spacer(modifier = Modifier.height(10.dp))
         for (p in pictures.withIndex()) {

--- a/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/ScrollableColumn.common.kt
+++ b/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/view/ScrollableColumn.common.kt
@@ -1,16 +1,17 @@
 package example.imageviewer.view
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-expect fun ScrollableColumn(modifier: Modifier, content: @Composable () -> Unit)
+expect fun ScrollableColumn(modifier: Modifier, content: @Composable ColumnScope.() -> Unit)
 
 @Composable
-fun TouchScrollableColumn(modifier: Modifier, content: @Composable () -> Unit) {
+fun TouchScrollableColumn(modifier: Modifier, content: @Composable ColumnScope.() -> Unit) {
     val scrollState = rememberScrollState()
     Column(modifier.verticalScroll(scrollState)) {
         content()

--- a/examples/imageviewer/shared/src/desktopMain/kotlin/example/imageviewer/view/ScrollableColumn.desktop.kt
+++ b/examples/imageviewer/shared/src/desktopMain/kotlin/example/imageviewer/view/ScrollableColumn.desktop.kt
@@ -1,10 +1,7 @@
 package example.imageviewer.view
 
 import androidx.compose.foundation.VerticalScrollbar
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.verticalScroll
@@ -14,12 +11,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-actual fun ScrollableColumn(modifier: Modifier, content: @Composable () -> Unit) {
+actual fun ScrollableColumn(modifier: Modifier, content: @Composable ColumnScope.() -> Unit) {
     val scrollState = rememberScrollState()
-    Modifier.verticalScroll(scrollState)
-
     Box(modifier) {
-        Column(modifier.verticalScroll(scrollState)) {
+        Column(Modifier.verticalScroll(scrollState)) {
             content()
         }
         VerticalScrollbar(

--- a/examples/imageviewer/shared/src/desktopTest/kotlin/ImageViewerTest.kt
+++ b/examples/imageviewer/shared/src/desktopTest/kotlin/ImageViewerTest.kt
@@ -1,0 +1,39 @@
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import example.imageviewer.*
+import example.imageviewer.filter.PlatformContext
+import example.imageviewer.model.PictureData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.Rule
+import org.junit.Test
+
+class ImageViewerTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val dependencies = object : Dependencies() {
+        override val notification: Notification = object : PopupNotification(localization) {
+            override fun showPopUpMessage(text: String) {
+            }
+        }
+        override val imageStorage: DesktopImageStorage = DesktopImageStorage(pictures, CoroutineScope(Dispatchers.Main))
+        override val sharePicture: SharePicture = object : SharePicture {
+            override fun share(context: PlatformContext, picture: PictureData) { }
+        }
+    }
+
+    @Test
+    fun testToggleGalleryStyleButton() {
+        rule.setContent {
+            ImageViewerCommon(dependencies)
+        }
+
+        rule.onNodeWithTag("squaresGalleryView").assertExists()
+        rule.onNodeWithTag("listGalleryView").assertDoesNotExist()
+        rule.onNodeWithTag("toggleGalleryStyleButton").performClick()
+        rule.onNodeWithTag("squaresGalleryView").assertDoesNotExist()
+        rule.onNodeWithTag("listGalleryView").assertExists()
+    }
+}

--- a/examples/imageviewer/shared/src/iosMain/kotlin/example/imageviewer/view/ScrollableColumn.ios.kt
+++ b/examples/imageviewer/shared/src/iosMain/kotlin/example/imageviewer/view/ScrollableColumn.ios.kt
@@ -1,8 +1,9 @@
 package example.imageviewer.view
 
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 @Composable
-actual fun ScrollableColumn(modifier: Modifier, content: @Composable () -> Unit) =
+actual fun ScrollableColumn(modifier: Modifier, content: @Composable ColumnScope.() -> Unit) =
     TouchScrollableColumn(modifier, content)


### PR DESCRIPTION
Added the unit testing API, and a single unit test to the `imageviewer` example.

Also a minor fix: `ScrollableColumn` was using the modifier it was given twice (which broke the test).