### PR TITLE
Add a workaround to examples to run the js app with kotlin 1.9.0

### DIFF
--- a/examples/falling-balls/gradle.properties
+++ b/examples/falling-balls/gradle.properties
@@ -12,3 +12,8 @@ kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
 compose.version=1.5.0-rc01
+
+# TODO: remove when switching to 1.9.10. See: https://youtrack.jetbrains.com/issue/KT-60852
+# usage: ./gradlew :jsApp:jsBrowserRun -Pworkaround.kotlin.js.kt60852=true
+# setting it to `true` breaks other targets (see shared/build.gradle.kts), so it should be used to run the web app only.
+workaround.kotlin.js.kt60852=false

--- a/examples/falling-balls/jsApp/build.gradle.kts
+++ b/examples/falling-balls/jsApp/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         val jsMain by getting  {
             dependencies {
                 implementation(project(":shared"))
+                implementation(compose.ui)
             }
         }
     }

--- a/examples/falling-balls/shared/build.gradle.kts
+++ b/examples/falling-balls/shared/build.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("OPT_IN_IS_NOT_ENABLED")
 
+import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
+
+
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
@@ -43,15 +46,23 @@ kotlin {
         }
     }
 
+    val enableKjsWorkaround = project.properties["workaround.kotlin.js.kt60852"] == "true"
+
+    fun  KotlinDependencyHandler.addCommonDependencies() {
+        implementation(compose.ui)
+        implementation(compose.runtime)
+        implementation(compose.foundation)
+        implementation(compose.material)
+        @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+        implementation(compose.components.resources)
+    }
+
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.ui)
-                implementation(compose.runtime)
-                implementation(compose.foundation)
-                implementation(compose.material)
-                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
-                implementation(compose.components.resources)
+                if (!enableKjsWorkaround) {
+                    addCommonDependencies()
+                }
             }
         }
         val androidMain by getting {
@@ -83,6 +94,13 @@ kotlin {
         }
         val macosArm64Main by getting {
             dependsOn(macosMain)
+        }
+        val jsMain by getting {
+            dependencies {
+                if (enableKjsWorkaround) {
+                    addCommonDependencies()
+                }
+            }
         }
     }
 }

--- a/examples/html/compose-bird/gradle.properties
+++ b/examples/html/compose-bird/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 kotlin.version=1.9.0
-compose.version=1.4.3
+compose.version=1.5.0-rc01

--- a/examples/html/compose-in-js/gradle.properties
+++ b/examples/html/compose-in-js/gradle.properties
@@ -3,4 +3,4 @@ kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
 kotlin.js.webpack.major.version=4
 kotlin.version=1.9.0
-compose.version=1.4.3
+compose.version=1.5.0-rc01

--- a/examples/html/landing/gradle.properties
+++ b/examples/html/landing/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 kotlin.version=1.9.0
-compose.version=1.4.3
+compose.version=1.5.0-rc01

--- a/examples/html/with-react/gradle.properties
+++ b/examples/html/with-react/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 kotlin.version=1.9.0
-compose.version=1.4.3
+compose.version=1.5.0-rc01

--- a/examples/minesweeper/gradle.properties
+++ b/examples/minesweeper/gradle.properties
@@ -12,3 +12,8 @@ kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
 agp.version=7.1.3
 compose.version=1.5.0-rc01
+
+# TODO: remove when switching to 1.9.10. See: https://youtrack.jetbrains.com/issue/KT-60852
+# usage: ./gradlew :jsApp:jsBrowserRun -Pworkaround.kotlin.js.kt60852=true
+# setting it to `true` breaks other targets (see shared/build.gradle.kts), so it should be used to run the web app only.
+workaround.kotlin.js.kt60852=false

--- a/examples/minesweeper/jsApp/build.gradle.kts
+++ b/examples/minesweeper/jsApp/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         val jsMain by getting  {
             dependencies {
                 implementation(project(":shared"))
+                implementation(compose.ui)
             }
         }
     }

--- a/examples/minesweeper/shared/build.gradle.kts
+++ b/examples/minesweeper/shared/build.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("OPT_IN_IS_NOT_ENABLED")
 
+import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
+
+
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
@@ -43,15 +46,23 @@ kotlin {
         }
     }
 
+    val enableKjsWorkaround = project.properties["workaround.kotlin.js.kt60852"] == "true"
+
+    fun KotlinDependencyHandler.addCommonDependencies() {
+        implementation(compose.ui)
+        implementation(compose.runtime)
+        implementation(compose.foundation)
+        implementation(compose.material)
+        @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+        implementation(compose.components.resources)
+    }
+
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.ui)
-                implementation(compose.runtime)
-                implementation(compose.foundation)
-                implementation(compose.material)
-                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
-                implementation(compose.components.resources)
+                if (!enableKjsWorkaround) {
+                    addCommonDependencies()
+                }
             }
         }
         val commonTest by getting {
@@ -93,6 +104,13 @@ kotlin {
         }
         val macosArm64Main by getting {
             dependsOn(macosMain)
+        }
+        val jsMain by getting {
+            dependencies {
+                if (enableKjsWorkaround) {
+                    addCommonDependencies()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The workaround can be removed after we switch to kotlin 1.9.10 (see https://youtrack.jetbrains.com/issue/KT-60852)