### PR TITLE
Simplify and adapt iOS examples to Compose 1.5.0

### DIFF
--- a/examples/chat/iosApp/iosApp/ComposeInsideSwiftUIScreen.swift
+++ b/examples/chat/iosApp/iosApp/ComposeInsideSwiftUIScreen.swift
@@ -38,9 +38,8 @@ struct TextInputLayer: View {
                         textFieldFocused = false
                         textState = ""
                     }) {
-                        HStack {
-                            Image(systemName: "arrow.up.circle.fill")
-                        }.tint(Color(red: 0.671, green: 0.365, blue: 0.792))
+                        Image(systemName: "arrow.up.circle.fill")
+                            .tint(Color(red: 0.671, green: 0.365, blue: 0.792))
                     }
                 }
             }.padding(15).background(RoundedRectangle(cornerRadius: 200).fill(.white).opacity(0.95)).padding(15)

--- a/examples/chat/shared/src/commonMain/kotlin/Data.kt
+++ b/examples/chat/shared/src/commonMain/kotlin/Data.kt
@@ -37,7 +37,6 @@ object ColorProvider {
         if(colors.size == 0) {
             colors.addAll(allColors)
         }
-        println(colors.lastIndex)
         val idx = Random.nextInt(colors.indices)
         val color = colors[idx]
         colors.removeAt(idx)

--- a/examples/widgets-gallery/shared/src/commonMain/kotlin/org/jetbrains/compose/demo/widgets/ui/WidgetView.kt
+++ b/examples/widgets-gallery/shared/src/commonMain/kotlin/org/jetbrains/compose/demo/widgets/ui/WidgetView.kt
@@ -1,11 +1,16 @@
 package org.jetbrains.compose.demo.widgets.ui
 
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import org.jetbrains.compose.demo.widgets.ui.screens.*
 
 @Composable
@@ -13,18 +18,38 @@ fun WidgetsView(
     widgetsTypeState: MutableState<WidgetsType>,
     modifier: Modifier
 ) {
-    Column(modifier = modifier.verticalScroll(state = rememberScrollState())) {
-        @Suppress("UNUSED_VARIABLE")
-        val exhaustive = when (widgetsTypeState.value) {
-            WidgetsType.APP_BARS -> AppBars()
-            WidgetsType.BUTTONS -> Buttons()
-            WidgetsType.CHIPS -> Chips()
-            WidgetsType.LOADERS -> Loaders()
-            WidgetsType.SNACK_BARS -> SnackBars()
-            WidgetsType.TEXT_VIEWS -> TextViews()
-            WidgetsType.TEXT_INPUTS -> TextInputs()
-            WidgetsType.TOGGLES -> Toggles()
-            WidgetsType.UI_CARDS -> UICards()
+    ClearFocusBox {
+        Column(modifier = modifier.verticalScroll(state = rememberScrollState())) {
+            @Suppress("UNUSED_VARIABLE")
+            val exhaustive = when (widgetsTypeState.value) {
+                WidgetsType.APP_BARS -> AppBars()
+                WidgetsType.BUTTONS -> Buttons()
+                WidgetsType.CHIPS -> Chips()
+                WidgetsType.LOADERS -> Loaders()
+                WidgetsType.SNACK_BARS -> SnackBars()
+                WidgetsType.TEXT_VIEWS -> TextViews()
+                WidgetsType.TEXT_INPUTS -> TextInputs()
+                WidgetsType.TOGGLES -> Toggles()
+                WidgetsType.UI_CARDS -> UICards()
+            }
         }
+    }
+}
+
+/**
+ * This wrapper need to control focus behavior on iOS to hide the keyboard.
+ */
+@Composable
+private fun ClearFocusBox(content: @Composable () -> Unit) {
+    val focusManager = LocalFocusManager.current
+    Box(
+        Modifier.fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures {
+                    focusManager.clearFocus(force = true)
+                }
+            },
+    ) {
+        content()
     }
 }


### PR DESCRIPTION
Simplify ChatApp, remove redundant code.
Adapt Widgets Gallery sample to newer focus logic on iOS. It needs to hide keyboard (added `ClearFocusBox` wrapper)