### PR TITLE
Update Android projects

### DIFF
--- a/examples/chat/androidApp/build.gradle.kts
+++ b/examples/chat/androidApp/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     compileSdk = 34
     namespace = "org.jetbrains.chat"
     defaultConfig {
-        applicationId = "org.jetbrains.chat.Chat"
+        applicationId = "org.jetbrains.Chat"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/examples/chat/androidApp/build.gradle.kts
+++ b/examples/chat/androidApp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {
@@ -17,8 +17,9 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.chat"
     defaultConfig {
-        applicationId = "org.jetbrains.Chat"
+        applicationId = "org.jetbrains.chat.Chat"
         minSdk = 26
         targetSdk = 34
         versionCode = 1
@@ -27,5 +28,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/chat/androidApp/src/androidMain/AndroidManifest.xml
+++ b/examples/chat/androidApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jetbrains.chat">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/examples/chat/gradle.properties
+++ b/examples/chat/gradle.properties
@@ -10,5 +10,5 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.0-rc04

--- a/examples/chat/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/chat/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/chat/shared/build.gradle.kts
+++ b/examples/chat/shared/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 version = "1.0-SNAPSHOT"
 
 kotlin {
-    android()
+    androidTarget()
 
     jvm("desktop")
 
@@ -57,9 +57,9 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api("androidx.activity:activity-compose:1.6.1")
+                api("androidx.activity:activity-compose:1.7.2")
                 api("androidx.appcompat:appcompat:1.6.1")
-                api("androidx.core:core-ktx:1.9.0")
+                api("androidx.core:core-ktx:1.10.1")
             }
         }
         val iosMain by creating {
@@ -94,16 +94,19 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.chat.shared"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/chat/shared/build.gradle.kts
+++ b/examples/chat/shared/build.gradle.kts
@@ -94,7 +94,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.chat.shared"
+    namespace = "org.jetbrains.chat"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")

--- a/examples/chat/shared/src/androidMain/AndroidManifest.xml
+++ b/examples/chat/shared/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.jetbrains.chat"/>
+<manifest />

--- a/examples/cocoapods-ios-example/gradle.properties
+++ b/examples/cocoapods-ios-example/gradle.properties
@@ -20,5 +20,5 @@ org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Versions
 kotlin.version=1.9.0
-agp.version=7.4.2
+agp.version=8.0.2
 compose.version=1.5.0-rc04

--- a/examples/cocoapods-ios-example/shared/build.gradle.kts
+++ b/examples/cocoapods-ios-example/shared/build.gradle.kts
@@ -56,7 +56,6 @@ android {
 
     defaultConfig {
         minSdk = (findProperty("android.minSdk") as String).toInt()
-        targetSdk = (findProperty("android.targetSdk") as String).toInt()
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/examples/codeviewer/androidApp/build.gradle.kts
+++ b/examples/codeviewer/androidApp/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     compileSdk = 34
     namespace = "org.jetbrains.codeviewer"
     defaultConfig {
-        applicationId = "org.jetbrains.codeviewer.Codeviewer"
+        applicationId = "org.jetbrains.Codeviewer"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/examples/codeviewer/androidApp/build.gradle.kts
+++ b/examples/codeviewer/androidApp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {
@@ -17,8 +17,9 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.codeviewer"
     defaultConfig {
-        applicationId = "org.jetbrains.Codeviewer"
+        applicationId = "org.jetbrains.codeviewer.Codeviewer"
         minSdk = 26
         targetSdk = 34
         versionCode = 1
@@ -27,5 +28,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/codeviewer/androidApp/src/androidMain/AndroidManifest.xml
+++ b/examples/codeviewer/androidApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jetbrains.codeviewer">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/examples/codeviewer/gradle.properties
+++ b/examples/codeviewer/gradle.properties
@@ -10,5 +10,5 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.0-rc04

--- a/examples/codeviewer/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/codeviewer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/codeviewer/shared/build.gradle.kts
+++ b/examples/codeviewer/shared/build.gradle.kts
@@ -66,7 +66,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.codeviewer.shared"
+    namespace = "org.jetbrains.codeviewer.common"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res", "src/commonMain/resources")
     defaultConfig {

--- a/examples/codeviewer/shared/build.gradle.kts
+++ b/examples/codeviewer/shared/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 version = "1.0-SNAPSHOT"
 
 kotlin {
-    android()
+    androidTarget()
 
     jvm("desktop")
 
@@ -38,9 +38,9 @@ kotlin {
         val androidMain by getting {
             kotlin.srcDirs("src/jvmMain/kotlin")
             dependencies {
-                api("androidx.activity:activity-compose:1.6.1")
+                api("androidx.activity:activity-compose:1.7.2")
                 api("androidx.appcompat:appcompat:1.6.1")
-                api("androidx.core:core-ktx:1.9.0")
+                api("androidx.core:core-ktx:1.10.1")
             }
         }
         val iosMain by creating {
@@ -66,14 +66,17 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.codeviewer.shared"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res", "src/commonMain/resources")
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/codeviewer/shared/src/androidMain/AndroidManifest.xml
+++ b/examples/codeviewer/shared/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.jetbrains.codeviewer.common"/>
+<manifest />

--- a/examples/falling-balls/androidApp/build.gradle.kts
+++ b/examples/falling-balls/androidApp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {
@@ -17,8 +17,9 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.fallingballs"
     defaultConfig {
-        applicationId = "org.jetbrains.FallingBalls"
+        applicationId = "org.jetbrains.fallingballs.FallingBalls"
         minSdk = 26
         targetSdk = 34
         versionCode = 1
@@ -27,5 +28,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/falling-balls/androidApp/build.gradle.kts
+++ b/examples/falling-balls/androidApp/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     compileSdk = 34
     namespace = "org.jetbrains.fallingballs"
     defaultConfig {
-        applicationId = "org.jetbrains.fallingballs.FallingBalls"
+        applicationId = "org.jetbrains.FallingBalls"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/examples/falling-balls/androidApp/src/androidMain/AndroidManifest.xml
+++ b/examples/falling-balls/androidApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jetbrains.fallingballs">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/examples/falling-balls/gradle.properties
+++ b/examples/falling-balls/gradle.properties
@@ -10,7 +10,7 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.0-rc04
 
 # TODO: remove when switching to 1.9.10. See: https://youtrack.jetbrains.com/issue/KT-60852

--- a/examples/falling-balls/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/falling-balls/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/falling-balls/shared/build.gradle.kts
+++ b/examples/falling-balls/shared/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 version = "1.0-SNAPSHOT"
 
 kotlin {
-    android()
+    androidTarget()
 
     jvm("desktop")
     
@@ -67,9 +67,9 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api("androidx.activity:activity-compose:1.6.1")
+                api("androidx.activity:activity-compose:1.7.2")
                 api("androidx.appcompat:appcompat:1.6.1")
-                api("androidx.core:core-ktx:1.9.0")
+                api("androidx.core:core-ktx:1.10.1")
             }
         }
         val iosMain by creating {
@@ -107,16 +107,19 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.fallingballs.shared"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/falling-balls/shared/build.gradle.kts
+++ b/examples/falling-balls/shared/build.gradle.kts
@@ -107,7 +107,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.fallingballs.shared"
+    namespace = "org.jetbrains.fallingballs"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")

--- a/examples/falling-balls/shared/src/androidMain/AndroidManifest.xml
+++ b/examples/falling-balls/shared/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.jetbrains.fallingballs"/>
+<manifest />

--- a/examples/html/compose-bird/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/html/compose-bird/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/html/compose-in-js/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/html/compose-in-js/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/html/landing/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/html/landing/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/html/with-react/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/html/with-react/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/imageviewer/androidApp/build.gradle.kts
+++ b/examples/imageviewer/androidApp/build.gradle.kts
@@ -20,7 +20,7 @@ android {
     compileSdk = 34
     namespace = "example.imageviewer"
     defaultConfig {
-        applicationId = "example.imageviewer.Imageviewer"
+        applicationId = "org.jetbrains.Imageviewer"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/examples/imageviewer/androidApp/build.gradle.kts
+++ b/examples/imageviewer/androidApp/build.gradle.kts
@@ -18,8 +18,9 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.imageviewer"
     defaultConfig {
-        applicationId = "org.jetbrains.Imageviewer"
+        applicationId = "org.jetbrains.imageviewer.Imageviewer"
         minSdk = 26
         targetSdk = 34
         versionCode = 1
@@ -28,6 +29,9 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }
 

--- a/examples/imageviewer/androidApp/build.gradle.kts
+++ b/examples/imageviewer/androidApp/build.gradle.kts
@@ -18,9 +18,9 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.imageviewer"
+    namespace = "example.imageviewer"
     defaultConfig {
-        applicationId = "org.jetbrains.imageviewer.Imageviewer"
+        applicationId = "example.imageviewer.Imageviewer"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/examples/imageviewer/androidApp/src/androidMain/AndroidManifest.xml
+++ b/examples/imageviewer/androidApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="example.imageviewer">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/examples/imageviewer/gradle.properties
+++ b/examples/imageviewer/gradle.properties
@@ -10,5 +10,5 @@ kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.0-rc04

--- a/examples/imageviewer/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/imageviewer/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
                 //implementation(compose.materialIconsExtended) // TODO not working on iOS for now
                 @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
                 implementation(compose.components.resources)
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
 
                 // Kotlin Coroutines 1.7.1 contains Dispatchers.IO for iOS
@@ -43,12 +43,12 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api("androidx.activity:activity-compose:1.7.0")
+                api("androidx.activity:activity-compose:1.7.2")
                 api("androidx.appcompat:appcompat:1.6.1")
-                api("androidx.core:core-ktx:1.9.0")
-                implementation("androidx.camera:camera-camera2:1.2.2")
-                implementation("androidx.camera:camera-lifecycle:1.2.2")
-                implementation("androidx.camera:camera-view:1.2.2")
+                api("androidx.core:core-ktx:1.10.1")
+                implementation("androidx.camera:camera-camera2:1.2.3")
+                implementation("androidx.camera:camera-lifecycle:1.2.3")
+                implementation("androidx.camera:camera-view:1.2.3")
                 implementation("com.google.accompanist:accompanist-permissions:0.29.2-rc")
                 implementation("com.google.android.gms:play-services-maps:18.1.0")
                 implementation("com.google.android.gms:play-services-location:21.0.1")
@@ -86,16 +86,19 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.imageviewer.shared"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -86,7 +86,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.imageviewer.shared"
+    namespace = "example.imageviewer.shared"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")

--- a/examples/imageviewer/shared/src/androidMain/AndroidManifest.xml
+++ b/examples/imageviewer/shared/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="example.imageviewer.shared">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/examples/intellij-plugin/build.gradle.kts
+++ b/examples/intellij-plugin/build.gradle.kts
@@ -25,6 +25,8 @@ intellij {
     version.set("2021.3")
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions.jvmTarget = "11"
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
 }

--- a/examples/intellij-plugin/build.gradle.kts
+++ b/examples/intellij-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.intellij") version "1.9.0"
+    id("org.jetbrains.intellij") version "1.15.0"
     java
     kotlin("jvm")
     id("org.jetbrains.compose")

--- a/examples/intellij-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/intellij-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/issues/android/build.gradle.kts
+++ b/examples/issues/android/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         minSdk = 26
         targetSdk = 34
-        applicationId = "org.jetbrains.issues.Issues"
+        applicationId = "org.jetbrains.Issues"
         versionCode = 1
         versionName = "1.0"
     }

--- a/examples/issues/android/build.gradle.kts
+++ b/examples/issues/android/build.gradle.kts
@@ -6,21 +6,24 @@ plugins {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.issues"
 
     defaultConfig {
         minSdk = 26
         targetSdk = 34
+        applicationId = "org.jetbrains.issues.Issues"
         versionCode = 1
         versionName = "1.0"
     }
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }
 
 dependencies {
     implementation(project(":common"))
-    implementation("androidx.activity:activity-compose:1.5.0")
 }

--- a/examples/issues/android/build.gradle.kts
+++ b/examples/issues/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.issues"
+    namespace = "com.example.myapplication"
 
     defaultConfig {
         minSdk = 26

--- a/examples/issues/android/src/main/AndroidManifest.xml
+++ b/examples/issues/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.myapplication">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/examples/issues/common/build.gradle.kts
+++ b/examples/issues/common/build.gradle.kts
@@ -22,8 +22,9 @@ kotlin {
         named("androidMain") {
             kotlin.srcDirs("src/jvmAndAndroidMain/kotlin")
             dependencies {
-                api("androidx.appcompat:appcompat:1.5.1")
-                api("androidx.core:core-ktx:1.8.0")
+                api("androidx.activity:activity-compose:1.7.2")
+                api("androidx.appcompat:appcompat:1.6.1")
+                api("androidx.core:core-ktx:1.10.1")
             }
         }
         named("desktopMain") {
@@ -39,17 +40,18 @@ apollo {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.issues.common"
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
     }
-
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
-
+    kotlin {
+        jvmToolchain(11)
+    }
     sourceSets {
         named("main") {
             manifest.srcFile("src/androidMain/AndroidManifest.xml")

--- a/examples/issues/common/build.gradle.kts
+++ b/examples/issues/common/build.gradle.kts
@@ -40,7 +40,7 @@ apollo {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.issues.common"
+    namespace = "com.example.myapplication.common"
 
     defaultConfig {
         minSdk = 26

--- a/examples/issues/common/src/androidMain/AndroidManifest.xml
+++ b/examples/issues/common/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.example.myapplication.common"/>
+<manifest />

--- a/examples/issues/gradle.properties
+++ b/examples/issues/gradle.properties
@@ -20,5 +20,5 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 kotlin.version=1.9.0
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.0-rc04

--- a/examples/issues/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/issues/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/minesweeper/androidApp/build.gradle.kts
+++ b/examples/minesweeper/androidApp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {
@@ -17,8 +17,9 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.composeminesweeper"
     defaultConfig {
-        applicationId = "org.jetbrains.ComposeMinesweeper"
+        applicationId = "org.jetbrains.composeminesweeper.ComposeMinesweeper"
         minSdk = 26
         targetSdk = 34
         versionCode = 1
@@ -27,5 +28,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/minesweeper/androidApp/build.gradle.kts
+++ b/examples/minesweeper/androidApp/build.gradle.kts
@@ -17,9 +17,9 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.composeminesweeper"
+    namespace = "org.jetbrains.minesweeper"
     defaultConfig {
-        applicationId = "org.jetbrains.composeminesweeper.ComposeMinesweeper"
+        applicationId = "org.jetbrains.ComposeMinesweeper"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/examples/minesweeper/androidApp/src/androidMain/AndroidManifest.xml
+++ b/examples/minesweeper/androidApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jetbrains.minesweeper">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/examples/minesweeper/gradle.properties
+++ b/examples/minesweeper/gradle.properties
@@ -10,7 +10,7 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.0-rc04
 
 # TODO: remove when switching to 1.9.10. See: https://youtrack.jetbrains.com/issue/KT-60852

--- a/examples/minesweeper/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/minesweeper/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/minesweeper/shared/build.gradle.kts
+++ b/examples/minesweeper/shared/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 version = "1.0-SNAPSHOT"
 
 kotlin {
-    android()
+    androidTarget()
 
     jvm("desktop")
 
@@ -73,9 +73,9 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api("androidx.activity:activity-compose:1.6.1")
+                api("androidx.activity:activity-compose:1.7.2")
                 api("androidx.appcompat:appcompat:1.6.1")
-                api("androidx.core:core-ktx:1.9.0")
+                api("androidx.core:core-ktx:1.10.1")
             }
         }
         val iosMain by creating {
@@ -117,16 +117,19 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.composeminesweeper.shared"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/minesweeper/shared/build.gradle.kts
+++ b/examples/minesweeper/shared/build.gradle.kts
@@ -117,7 +117,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.composeminesweeper.shared"
+    namespace = "org.jetbrains.minesweeper"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")

--- a/examples/minesweeper/shared/src/androidMain/AndroidManifest.xml
+++ b/examples/minesweeper/shared/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.jetbrains.minesweeper"/>
+<manifest />

--- a/examples/notepad/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/notepad/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/todoapp-lite/androidApp/build.gradle.kts
+++ b/examples/todoapp-lite/androidApp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {
@@ -18,8 +18,9 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.todoapplite"
     defaultConfig {
-        applicationId = "org.jetbrains.TodoAppLite"
+        applicationId = "org.jetbrains.todoapplite.TodoAppLite"
         minSdk = 26
         targetSdk = 34
         versionCode = 1
@@ -28,5 +29,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/todoapp-lite/androidApp/build.gradle.kts
+++ b/examples/todoapp-lite/androidApp/build.gradle.kts
@@ -18,9 +18,9 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.todoapplite"
+    namespace = "example.todoapp.lite"
     defaultConfig {
-        applicationId = "org.jetbrains.todoapplite.TodoAppLite"
+        applicationId = "org.jetbrains.TodoAppLite"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/examples/todoapp-lite/androidApp/src/androidMain/AndroidManifest.xml
+++ b/examples/todoapp-lite/androidApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="example.todoapp.lite">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/examples/todoapp-lite/gradle.properties
+++ b/examples/todoapp-lite/gradle.properties
@@ -10,5 +10,5 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.0-rc04

--- a/examples/todoapp-lite/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/todoapp-lite/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/todoapp-lite/shared/build.gradle.kts
+++ b/examples/todoapp-lite/shared/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.todoapplite.shared"
+    namespace = "example.todoapp.lite.common"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")

--- a/examples/todoapp-lite/shared/build.gradle.kts
+++ b/examples/todoapp-lite/shared/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 version = "1.0-SNAPSHOT"
 
 kotlin {
-    android()
+    androidTarget()
 
     jvm("desktop")
 
@@ -36,9 +36,9 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api("androidx.activity:activity-compose:1.6.1")
+                api("androidx.activity:activity-compose:1.7.2")
                 api("androidx.appcompat:appcompat:1.6.1")
-                api("androidx.core:core-ktx:1.9.0")
+                api("androidx.core:core-ktx:1.10.1")
             }
         }
         val iosMain by creating {
@@ -63,16 +63,19 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.todoapplite.shared"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/todoapp-lite/shared/src/androidMain/AndroidManifest.xml
+++ b/examples/todoapp-lite/shared/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="example.todoapp.lite.common"/>
+<manifest />

--- a/examples/visual-effects/androidApp/build.gradle.kts
+++ b/examples/visual-effects/androidApp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {
@@ -17,8 +17,9 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.visualeffects"
     defaultConfig {
-        applicationId = "org.jetbrains.VisualEffects"
+        applicationId = "org.jetbrains.visualeffects.VisualEffects"
         minSdk = 26
         targetSdk = 34
         versionCode = 1
@@ -27,5 +28,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/visual-effects/androidApp/build.gradle.kts
+++ b/examples/visual-effects/androidApp/build.gradle.kts
@@ -17,9 +17,9 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.visualeffects"
+    namespace = "org.jetbrains.compose.demo.visuals"
     defaultConfig {
-        applicationId = "org.jetbrains.visualeffects.VisualEffects"
+        applicationId = "org.jetbrains.VisualEffects"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/examples/visual-effects/androidApp/src/androidMain/AndroidManifest.xml
+++ b/examples/visual-effects/androidApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jetbrains.compose.demo.visuals">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/examples/visual-effects/gradle.properties
+++ b/examples/visual-effects/gradle.properties
@@ -10,5 +10,5 @@ kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.0-rc04

--- a/examples/visual-effects/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/visual-effects/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/visual-effects/shared/build.gradle.kts
+++ b/examples/visual-effects/shared/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 version = "1.0-SNAPSHOT"
 
 kotlin {
-    android()
+    androidTarget()
 
     jvm("desktop")
 
@@ -35,9 +35,9 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api("androidx.activity:activity-compose:1.6.1")
+                api("androidx.activity:activity-compose:1.7.2")
                 api("androidx.appcompat:appcompat:1.6.1")
-                api("androidx.core:core-ktx:1.9.0")
+                api("androidx.core:core-ktx:1.10.1")
             }
         }
         val iosMain by creating {
@@ -62,16 +62,19 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.visualeffects.shared"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/visual-effects/shared/build.gradle.kts
+++ b/examples/visual-effects/shared/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.visualeffects.shared"
+    namespace = "org.jetbrains.visualeffects"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")

--- a/examples/visual-effects/shared/src/androidMain/AndroidManifest.xml
+++ b/examples/visual-effects/shared/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.jetbrains.visualeffects"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/examples/widgets-gallery/androidApp/build.gradle.kts
+++ b/examples/widgets-gallery/androidApp/build.gradle.kts
@@ -17,9 +17,9 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.widgetsgallery"
+    namespace = "org.jetbrains.compose.demo.widgets"
     defaultConfig {
-        applicationId = "org.jetbrains.widgetsgallery.WidgetsGallery"
+        applicationId = "org.jetbrains.WidgetsGallery"
         minSdk = 26
         targetSdk = 34
         versionCode = 1

--- a/examples/widgets-gallery/androidApp/build.gradle.kts
+++ b/examples/widgets-gallery/androidApp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {
@@ -17,8 +17,9 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.widgetsgallery"
     defaultConfig {
-        applicationId = "org.jetbrains.WidgetsGallery"
+        applicationId = "org.jetbrains.widgetsgallery.WidgetsGallery"
         minSdk = 26
         targetSdk = 34
         versionCode = 1
@@ -27,5 +28,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/widgets-gallery/androidApp/src/androidMain/AndroidManifest.xml
+++ b/examples/widgets-gallery/androidApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jetbrains.compose.demo.widgets">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/examples/widgets-gallery/gradle.properties
+++ b/examples/widgets-gallery/gradle.properties
@@ -10,5 +10,5 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.0
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.0-rc04

--- a/examples/widgets-gallery/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/widgets-gallery/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/widgets-gallery/shared/build.gradle.kts
+++ b/examples/widgets-gallery/shared/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 version = "1.0-SNAPSHOT"
 
 kotlin {
-    android()
+    androidTarget()
 
     jvm("desktop")
 
@@ -37,9 +37,9 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                api("androidx.activity:activity-compose:1.6.1")
+                api("androidx.activity:activity-compose:1.7.2")
                 api("androidx.appcompat:appcompat:1.6.1")
-                api("androidx.core:core-ktx:1.9.0")
+                api("androidx.core:core-ktx:1.10.1")
             }
         }
         val iosMain by creating {
@@ -64,16 +64,19 @@ kotlin {
 
 android {
     compileSdk = 34
+    namespace = "org.jetbrains.widgetsgallery.shared"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 34
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlin {
+        jvmToolchain(11)
     }
 }

--- a/examples/widgets-gallery/shared/build.gradle.kts
+++ b/examples/widgets-gallery/shared/build.gradle.kts
@@ -64,7 +64,7 @@ kotlin {
 
 android {
     compileSdk = 34
-    namespace = "org.jetbrains.widgetsgallery.shared"
+    namespace = "org.jetbrains.compose.demo.widgets.platform"
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")

--- a/examples/widgets-gallery/shared/src/androidMain/AndroidManifest.xml
+++ b/examples/widgets-gallery/shared/src/androidMain/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.jetbrains.compose.demo.widgets.platform"/>
+<manifest />


### PR DESCRIPTION
- Update Gradle to 8.2.1 (for non-Android project as well)
- Update AGP to 8.0.2
  - add jvmToolchain for Android projects (it is required now)
  - removed targetSdk from shared modules (it is deprecated for com.android.library projects)
  - move "package" from manifset to "namespace " in Gradle (required by AGP)
- rename android to androidTarget (android is deprecated in latest Kotlin)
- update Android dependencies versions

I checked - Android/iOS/web still work. HTML/IDE projects also work after updating Gradle.

Works in the latest stable IDEA and Android Studio

updated templates:
https://github.com/JetBrains/compose-multiplatform-ios-android-template/pull/21
https://github.com/JetBrains/compose-multiplatform-template/pull/19
https://github.com/JetBrains/compose-multiplatform-desktop-template/pull/8
https://github.com/JetBrains/compose-multiplatform-html-library-template/pull/3