### PR TITLE
Fix crash in Codeviewer on Android

### DIFF
--- a/examples/codeviewer/shared/src/jvmMain/kotlin/org/jetbrains/codeviewer/platform/JvmFile.kt
+++ b/examples/codeviewer/shared/src/jvmMain/kotlin/org/jetbrains/codeviewer/platform/JvmFile.kt
@@ -65,7 +65,9 @@ fun java.io.File.toProjectFile(): File = object : File {
 
             override fun get(index: Int): String {
                 val position = lineRange(index)
-                val slice = byteBuffer.slice(position.first, position.last - position.first)
+                byteBuffer.position(position.first)
+                val slice = byteBuffer.slice()
+                slice.limit(position.last - position.first)
                 return StandardCharsets.UTF_8.decode(slice).toString()
             }
 


### PR DESCRIPTION
It crashes on Android, because it doesn't have slice method yet (only starting from API 34):
```
 java.lang.NoSuchMethodError: No virtual method slice(II)Ljava/nio/MappedByteBuffer; in class Ljava/nio/MappedByteBuffer; or its super classes (declaration of 'java.nio.MappedByteBuffer' appears in /apex/com.android.art/javalib/core-oj.jar)
                                                                                                    	at org.jetbrains.codeviewer.platform.JvmFileKt$toProjectFile$1$readLines$2.get(JvmFile.kt:68)
                                                                                                    	at org.jetbrains.codeviewer.ui.editor.EditorKt$Editor$1.invoke$content(Editor.kt:47)
                                                                                                    	at org.jetbrains.codeviewer.ui.editor.EditorKt$Editor$1.access$invoke$content(Editor.kt:37)
                                                                                                    	at org.jetbrains.codeviewer.ui.editor.EditorKt$Editor$1$1.get(Editor.kt:57)
                                                                                                    	at org.jetbrains.codeviewer.ui.editor.EditorViewKt$Lines$1$1$1$1.invoke(EditorView.kt:84)
                                                                                                    	at org.jetbrains.codeviewer.ui.editor.EditorViewKt$Lines$1$1$1$1.invoke(EditorView.kt:82)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:138)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
                                                                                                    	at androidx.compose.foundation.lazy.LazyListItemProviderImpl$Item$1.invoke(LazyListItemProvider.kt:79)
                                                                                                    	at androidx.compose.foundation.lazy.LazyListItemProviderImpl$Item$1.invoke(LazyListItemProvider.kt:77)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:108)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
                                                                                                    	at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:228)
                                                                                                    	at androidx.compose.foundation.lazy.layout.LazyLayoutPinnableItemKt.LazyLayoutPinnableItem(LazyLayoutPinnableItem.kt:54)
                                                                                                    	at androidx.compose.foundation.lazy.LazyListItemProviderImpl.Item(LazyListItemProvider.kt:77)
                                                                                                    	at androidx.compose.foundation.lazy.layout.LazyLayoutItemContentFactoryKt$SkippableItem$1.invoke(LazyLayoutItemContentFactory.kt:135)
                                                                                                    	at androidx.compose.foundation.lazy.layout.LazyLayoutItemContentFactoryKt$SkippableItem$1.invoke(LazyLayoutItemContentFactory.kt:134)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:108)
                                                                                                    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
```

The regression was introduced in #2975

Replacing with code that is available for Android