### PR TITLE
Tooling infrastucture maintenance

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -17,6 +17,14 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
+      - name: Limit Parallelism for integration tests on Windows
+        shell: bash
+#       GH Linux & Windows Agents have 7 Gb RAM.
+#       That's enough for simultaneous testing two versions of Gradle on Linux,
+#       but Windows agents fail
+        if: runner.os == 'Windows'
+        run: |
+          echo "compose.tests.gradle.maxParallelIntegrationTestTasks=1" >> gradle-plugins/gradle.properties
       - name: Test Gradle plugin
         shell: bash
         run: |

--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -29,8 +29,8 @@ jobs:
         shell: bash
         run: |
           cd gradle-plugins
-          ./gradlew assemble
-          ./gradlew :compose:check --continue
+          ./gradlew assemble testClasses --no-daemon
+          ./gradlew :compose:check --continue -Porg.gradle.jvmargs=-Xmx=256m -Pkotlin.daemon.jvmargs=-Xmx=512m
       - name: Print summary
         shell: bash
         if: always()

--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -17,14 +17,14 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-      - name: Limit Parallelism for integration tests on Windows
-        shell: bash
-#       GH Linux & Windows Agents have 7 Gb RAM.
-#       That's enough for simultaneous testing two versions of Gradle on Linux,
-#       but Windows agents fail
-        if: runner.os == 'Windows'
-        run: |
-          echo "compose.tests.gradle.maxParallelIntegrationTestTasks=1" >> gradle-plugins/gradle.properties
+#      - name: Limit Parallelism for integration tests on Windows
+#        shell: bash
+##       GH Linux & Windows Agents have 7 Gb RAM.
+##       That's enough for simultaneous testing two versions of Gradle on Linux,
+##       but Windows agents fail
+#        if: runner.os == 'Windows'
+#        run: |
+#          echo "compose.tests.gradle.maxParallelIntegrationTestTasks=1" >> gradle-plugins/gradle.properties
       - name: Test Gradle plugin
         shell: bash
         run: |

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -2,10 +2,11 @@ import com.gradle.publish.PluginBundleExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
-    val kotlinVersion = "1.7.20"
-    kotlin("jvm") version kotlinVersion apply false
-    kotlin("plugin.serialization") version kotlinVersion apply false
-    id("com.gradle.plugin-publish") version "0.17.0" apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.publish.plugin.portal) apply false
+    alias(libs.plugins.shadow.jar) apply false
+    alias(libs.plugins.download) apply false
 }
 
 subprojects {
@@ -33,6 +34,7 @@ subprojects {
             // which is bundled to the oldest supported Gradle
             kotlinOptions.languageVersion = "1.5"
             kotlinOptions.apiVersion = "1.5"
+            kotlinOptions.jvmTarget = "1.8"
         }
     }
 

--- a/gradle-plugins/buildSrc/src/main/kotlin/BuildProperties.kt
+++ b/gradle-plugins/buildSrc/src/main/kotlin/BuildProperties.kt
@@ -11,7 +11,6 @@ object BuildProperties {
     const val group = "org.jetbrains.compose"
     const val website = "https://www.jetbrains.com/lp/compose/"
     const val vcs = "https://github.com/JetBrains/compose-jb"
-    const val serializationVersion = "1.2.1"
     fun composeVersion(project: Project): String =
         System.getenv("COMPOSE_GRADLE_PLUGIN_COMPOSE_VERSION")
             ?: project.findProperty("compose.version") as String

--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -167,8 +167,10 @@ for (gradleVersion in supportedGradleVersions) {
 configureAllTests {
     dependsOn(":publishToMavenLocal")
     systemProperty("compose.tests.compose.gradle.plugin.version", BuildProperties.deployVersion(project))
-    val summaryDir = project.layout.buildDirectory.get().asFile.resolve("test-summary")
+    val buildDir = project.layout.buildDirectory.get().asFile
+    val summaryDir = buildDir.resolve("test-summary")
     systemProperty("compose.tests.summary.file", summaryDir.resolve("$name.md").absolutePath)
+    systemProperty("compose.tests.yarn.mutex.file", buildDir.resolve("yarn-mutex"))
     systemProperties(project.properties.filter { it.key.startsWith("compose.") })
 }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractProguardTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractProguardTask.kt
@@ -136,7 +136,7 @@ abstract class AbstractProguardTask : AbstractComposeDesktopTask() {
         val args = arrayListOf<String>().apply {
             val maxHeapSize = maxHeapSize.orNull
             if (maxHeapSize != null) {
-                add("-Xmx:$maxHeapSize")
+                add("-Xmx$maxHeapSize")
             }
             cliArg("-cp", proguardFiles.map { it.normalizedPath() }.joinToString(File.pathSeparator))
             add("proguard.ProGuard")

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
@@ -61,6 +61,7 @@ class TestProject(
             "-Porg.gradle.java.installations.paths=${testJdks.joinToString(",")}"
         },
         "-Porg.gradle.jvmargs=-Xmx=2g -XX:+UseParallelGC",
+        "-Pcompose.tests.yarn.mutex.file=${System.getProperty("compose.tests.yarn.mutex.file")}"
     )
 
     init {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
@@ -60,7 +60,7 @@ class TestProject(
         } else {
             "-Porg.gradle.java.installations.paths=${testJdks.joinToString(",")}"
         },
-        "-Porg.gradle.jvmargs=-Xmx=2g -XX:+UseParallelGC",
+        "-Porg.gradle.jvmargs=-Xmx=1g -XX:+UseParallelGC",
         "-Pcompose.tests.yarn.mutex.file=${System.getProperty("compose.tests.yarn.mutex.file")}"
     )
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
@@ -60,11 +60,13 @@ class TestProject(
         } else {
             "-Porg.gradle.java.installations.paths=${testJdks.joinToString(",")}"
         },
-        "-Porg.gradle.jvmargs=-Xmx=1g -XX:+UseSerialGC",
+        "-Porg.gradle.jvmargs=-Xmx=256m -XX:+UseSerialGC",
         "-Pkotlin.daemon.jvmargs=-Xmx=512m -XX:+UseSerialGC",
         // compile in-process, when a non-default Kotlin version is used, to avoid creating lots of Kotlin daemons,
         // which waste limited RAM on CI
-        "-Pkotlin.compiler.execution.strategy=in-process".takeIf { testEnvironment.kotlinVersion != TestKotlinVersions.Default },
+        "-Pkotlin.compiler.execution.strategy=out-of-process".takeIf { testEnvironment.kotlinVersion != TestKotlinVersions.Default },
+        "-Pkotlin.native.disableCompilerDaemon=true",
+        "-Pkotlin.native.jvmArgs=-Xmx1g -XX:+UseSerialGC",
         "-Pcompose.tests.yarn.mutex.file=${System.getProperty("compose.tests.yarn.mutex.file")}",
     )
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
@@ -59,7 +59,8 @@ class TestProject(
             null
         } else {
             "-Porg.gradle.java.installations.paths=${testJdks.joinToString(",")}"
-        }
+        },
+        "-Porg.gradle.jvmargs=-Xmx=2g -XX:+UseParallelGC",
     )
 
     init {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
@@ -60,8 +60,12 @@ class TestProject(
         } else {
             "-Porg.gradle.java.installations.paths=${testJdks.joinToString(",")}"
         },
-        "-Porg.gradle.jvmargs=-Xmx=1g -XX:+UseParallelGC",
-        "-Pcompose.tests.yarn.mutex.file=${System.getProperty("compose.tests.yarn.mutex.file")}"
+        "-Porg.gradle.jvmargs=-Xmx=1g -XX:+UseSerialGC",
+        "-Pkotlin.daemon.jvmargs=-Xmx=512m -XX:+UseSerialGC",
+        // compile in-process, when a non-default Kotlin version is used, to avoid creating lots of Kotlin daemons,
+        // which waste limited RAM on CI
+        "-Pkotlin.compiler.execution.strategy=in-process".takeIf { testEnvironment.kotlinVersion != TestKotlinVersions.Default },
+        "-Pcompose.tests.yarn.mutex.file=${System.getProperty("compose.tests.yarn.mutex.file")}",
     )
 
     init {

--- a/gradle-plugins/compose/src/test/test-projects/application/proguard/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/proguard/build.gradle
@@ -30,6 +30,7 @@ compose.desktop {
 
         buildTypes.release.proguard {
             configurationFiles.from("rules.pro")
+            maxHeapSize.set("256m")
         }
     }
 }

--- a/gradle-plugins/compose/src/test/test-projects/init.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/init.gradle
@@ -7,4 +7,13 @@ allprojects {
         }
         google()
     }
+
+    plugins.withId("org.jetbrains.kotlin.multiplatform") {
+        // Workaround for yarn concurrency issue - https://youtrack.jetbrains.com/issue/KT-43320
+        tasks.configureEach {
+            if (name == "kotlinNpmInstall") {
+                args.addAll(["--mutex", "file:${file(project.getProperty("compose.tests.yarn.mutex.file"))}".toString()])
+            }
+        }
+    }
 }

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -1,4 +1,6 @@
 org.gradle.parallel=true
+org.gradle.configuration-cache=true
+
 kotlin.code.style=official
 
 # Default version of Compose Libraries used by Gradle plugin
@@ -10,7 +12,7 @@ compose.tests.compiler.compatible.kotlin.version=1.9.0
 # The latest version of Kotlin compatible with compose.tests.compiler.version for JS target. Used only on CI.
 compose.tests.js.compiler.compatible.kotlin.version=1.9.0
 # __SUPPORTED_GRADLE_VERSIONS__
-compose.tests.gradle.versions=7.3.3, 8.1
+compose.tests.gradle.versions=7.3.3, 8.3
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -1,0 +1,17 @@
+[versions]
+kotlin = "1.9.0"
+gradle-download-plugin = "5.5.0"
+kotlinx-serialization = "1.2.1"
+
+[libraries]
+download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }
+serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+serialization-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm", version.ref = "kotlinx-serialization" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+shadow-jar = "com.github.johnrengelman.shadow:8.1.1"
+download = { id = "de.undercouch.download", version.ref = "gradle-download-plugin" }
+publish-plugin-portal = "com.gradle.plugin-publish:1.2.1"

--- a/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle-plugins/preview-rpc/build.gradle.kts
+++ b/gradle-plugins/preview-rpc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     id("maven-publish")
 }
 

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -2,9 +2,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.5.10"
-    id("org.jetbrains.intellij") version "1.12.0"
-    id("org.jetbrains.changelog") version "1.3.1"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.intellij.sdk)
+    alias(libs.plugins.intellij.changelog)
 }
 
 val projectProperties = ProjectProperties(project)

--- a/idea-plugin/gradle.properties
+++ b/idea-plugin/gradle.properties
@@ -1,6 +1,9 @@
+org.gradle.parallel=true
+org.gradle.configuration-cache=true
 # Opt-out flag for bundling Kotlin standard library.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
 kotlin.stdlib.default.dependency=false
+kotlin.code.style=official
 
 deploy.version=0.1-SNAPSHOT
 

--- a/idea-plugin/gradle/libs.versions.toml
+++ b/idea-plugin/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+kotlin = "1.9.0"
+
+[libraries]
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+intellij-sdk = "org.jetbrains.intellij:1.15.0"
+intellij-changelog = "org.jetbrains.changelog:2.2.0"

--- a/idea-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/idea-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle plugin:
* Update Gradle to 8.3;
* Enable Configuration Cache;
* Update Gradle plugins;
* Start using version catalogs;
* Update dependencies;
* Relocate Kotlinx Serialization (#3479)

Resolves #3479

Intellij plugin:
* Update Gradle to 8.3;
* Enable Configuration Cache;
* Start using version catalogs;