### PR TITLE
Tooling maintenance

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -34,6 +34,7 @@ subprojects {
             // which is bundled to the oldest supported Gradle
             kotlinOptions.languageVersion = "1.5"
             kotlinOptions.apiVersion = "1.5"
+            kotlinOptions.jvmTarget = "1.8"
         }
     }
 

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -2,10 +2,11 @@ import com.gradle.publish.PluginBundleExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
-    val kotlinVersion = "1.7.20"
-    kotlin("jvm") version kotlinVersion apply false
-    kotlin("plugin.serialization") version kotlinVersion apply false
-    id("com.gradle.plugin-publish") version "0.17.0" apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.publish.plugin.portal) apply false
+    alias(libs.plugins.shadow.jar) apply false
+    alias(libs.plugins.download) apply false
 }
 
 subprojects {

--- a/gradle-plugins/buildSrc/src/main/kotlin/BuildProperties.kt
+++ b/gradle-plugins/buildSrc/src/main/kotlin/BuildProperties.kt
@@ -11,7 +11,6 @@ object BuildProperties {
     const val group = "org.jetbrains.compose"
     const val website = "https://www.jetbrains.com/lp/compose/"
     const val vcs = "https://github.com/JetBrains/compose-jb"
-    const val serializationVersion = "1.2.1"
     fun composeVersion(project: Project): String =
         System.getenv("COMPOSE_GRADLE_PLUGIN_COMPOSE_VERSION")
             ?: project.findProperty("compose.version") as String

--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -75,7 +75,9 @@ val shadow = tasks.named<ShadowJar>("shadowJar") {
     val fromPackage = "de.undercouch"
     val toPackage = "org.jetbrains.compose.$fromPackage"
     relocate(fromPackage, toPackage)
-    archiveClassifier.set("shadow")
+    archiveBaseName.set("shadow")
+    archiveClassifier.set("")
+    archiveVersion.set("")
     configurations = listOf(embeddedDependencies)
     exclude("META-INF/gradle-plugins/de.undercouch.download.properties")
     exclude("META-INF/versions/**")

--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -2,13 +2,13 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import de.undercouch.gradle.tasks.download.Download
 
 plugins {
-    kotlin("jvm")
-    kotlin("plugin.serialization")
-    id("com.gradle.plugin-publish")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.publish.plugin.portal)
     id("java-gradle-plugin")
     id("maven-publish")
-    id("com.github.johnrengelman.shadow") version "7.0.0"
-    id("de.undercouch.download") version "5.3.0"
+    alias(libs.plugins.shadow.jar)
+    alias(libs.plugins.download)
 }
 
 gradlePluginConfig {
@@ -63,12 +63,10 @@ dependencies {
     testImplementation(gradleTestKit())
     testImplementation(kotlin("gradle-plugin-api"))
 
-    // include relocated download task to avoid potential runtime conflicts
-    embedded("de.undercouch:gradle-download-task:5.3.0")
-
-    embedded("org.jetbrains.kotlinx:kotlinx-serialization-json:${BuildProperties.serializationVersion}")
-    embedded("org.jetbrains.kotlinx:kotlinx-serialization-core:${BuildProperties.serializationVersion}")
-    embedded("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:${BuildProperties.serializationVersion}")
+    embedded(libs.download.task)
+    embedded(libs.serialization.json)
+    embedded(libs.serialization.core)
+    embedded(libs.serialization.core.jvm)
     embedded(project(":preview-rpc"))
     embedded(project(":jdk-version-probe"))
 }

--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -35,7 +35,7 @@ tasks.named("compileKotlin") {
     dependsOn(buildConfig)
 }
 sourceSets.main.configure {
-    java.srcDir(buildConfigDir)
+    java.srcDir(buildConfig.flatMap { it.generatedOutputDir })
 }
 
 val embeddedDependencies by configurations.creating {
@@ -165,7 +165,7 @@ for (gradleVersion in supportedGradleVersions) {
 configureAllTests {
     dependsOn(":publishToMavenLocal")
     systemProperty("compose.tests.compose.gradle.plugin.version", BuildProperties.deployVersion(project))
-    val summaryDir = project.buildDir.resolve("test-summary")
+    val summaryDir = project.layout.buildDirectory.get().asFile.resolve("test-summary")
     systemProperty("compose.tests.summary.file", summaryDir.resolve("$name.md").absolutePath)
     systemProperties(project.properties.filter { it.key.startsWith("compose.") })
 }

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -10,7 +10,7 @@ compose.tests.compiler.compatible.kotlin.version=1.9.0
 # The latest version of Kotlin compatible with compose.tests.compiler.version for JS target. Used only on CI.
 compose.tests.js.compiler.compatible.kotlin.version=1.9.0
 # __SUPPORTED_GRADLE_VERSIONS__
-compose.tests.gradle.versions=7.3.3, 8.1
+compose.tests.gradle.versions=7.3.3, 8.3
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -1,0 +1,17 @@
+[versions]
+kotlin = "1.7.20"
+gradle-download-plugin = "5.3.0"
+kotlinx-serialization = "1.2.1"
+
+[libraries]
+download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }
+serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
+serialization-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core-jvm", version.ref = "kotlinx-serialization" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+shadow-jar = "com.github.johnrengelman.shadow:7.0.0"
+download = { id = "de.undercouch.download", version.ref = "gradle-download-plugin" }
+publish-plugin-portal = "com.gradle.plugin-publish:0.17.0"

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -12,6 +12,6 @@ serialization-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-serialization
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-shadow-jar = "com.github.johnrengelman.shadow:7.0.0"
+shadow-jar = "com.github.johnrengelman.shadow:8.1.1"
 download = { id = "de.undercouch.download", version.ref = "gradle-download-plugin" }
 publish-plugin-portal = "com.gradle.plugin-publish:0.17.0"

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.9.0"
-gradle-download-plugin = "5.3.0"
+gradle-download-plugin = "5.5.0"
 kotlinx-serialization = "1.2.1"
 
 [libraries]

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -14,4 +14,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 shadow-jar = "com.github.johnrengelman.shadow:8.1.1"
 download = { id = "de.undercouch.download", version.ref = "gradle-download-plugin" }
-publish-plugin-portal = "com.gradle.plugin-publish:0.17.0"
+publish-plugin-portal = "com.gradle.plugin-publish:1.2.1"

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.7.20"
+kotlin = "1.9.0"
 gradle-download-plugin = "5.3.0"
 kotlinx-serialization = "1.2.1"
 

--- a/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle-plugins/preview-rpc/build.gradle.kts
+++ b/gradle-plugins/preview-rpc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     id("maven-publish")
 }
 

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -2,9 +2,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.5.10"
-    id("org.jetbrains.intellij") version "1.12.0"
-    id("org.jetbrains.changelog") version "1.3.1"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.intellij.sdk)
+    alias(libs.plugins.intellij.changelog)
 }
 
 val projectProperties = ProjectProperties(project)

--- a/idea-plugin/gradle/libs.versions.toml
+++ b/idea-plugin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin =  "1.5.10"
+kotlin = "1.9.0"
 
 [libraries]
 

--- a/idea-plugin/gradle/libs.versions.toml
+++ b/idea-plugin/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+kotlin =  "1.5.10"
+
+[libraries]
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+intellij-sdk = "org.jetbrains.intellij:1.12.0"
+intellij-changelog = "org.jetbrains.changelog:1.3.1"

--- a/idea-plugin/gradle/libs.versions.toml
+++ b/idea-plugin/gradle/libs.versions.toml
@@ -5,5 +5,5 @@ kotlin = "1.9.0"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-intellij-sdk = "org.jetbrains.intellij:1.12.0"
-intellij-changelog = "org.jetbrains.changelog:1.3.1"
+intellij-sdk = "org.jetbrains.intellij:1.15.0"
+intellij-changelog = "org.jetbrains.changelog:2.2.0"

--- a/idea-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/idea-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle plugin:

* Update Gradle to 8.3;
* Update Gradle plugins;
* Start using version catalogs;
* Update dependencies;

Intellij plugin:

* Update Gradle to 8.3;
* Enable Configuration Cache;
* Start using version catalogs;