### PR TITLE
Support kotlin 1.9.10

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
@@ -14,7 +14,8 @@ internal object ComposeCompilerCompatibility {
         "1.8.22" to "1.4.8",
         "1.9.0-Beta" to "1.4.7.1-beta",
         "1.9.0-RC" to "1.4.8-beta",
-        "1.9.0" to "1.5.1"
+        "1.9.0" to "1.5.1",
+        "1.9.10" to "1.5.2"
     )
 
     fun compilerVersionFor(kotlinVersion: String): String {

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -4,11 +4,11 @@ kotlin.code.style=official
 # Default version of Compose Libraries used by Gradle plugin
 compose.version=1.5.0
 # The latest version of Compose Compiler used by Gradle plugin. Used only in tests/CI.
-compose.tests.compiler.version=1.5.1
+compose.tests.compiler.version=1.5.2
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
-compose.tests.compiler.compatible.kotlin.version=1.9.0
+compose.tests.compiler.compatible.kotlin.version=1.9.10
 # The latest version of Kotlin compatible with compose.tests.compiler.version for JS target. Used only on CI.
-compose.tests.js.compiler.compatible.kotlin.version=1.9.0
+compose.tests.js.compiler.compatible.kotlin.version=1.9.10
 # __SUPPORTED_GRADLE_VERSIONS__
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 compose.tests.gradle.versions=7.3.3, 8.3


### PR DESCRIPTION
Closes https://github.com/JetBrains/compose-multiplatform/issues/3570

Compose compiler plugin 1.5.2 was built from https://github.com/JetBrains/compose-multiplatform-core/tree/release/compiler-integration-1.5.2 which is based on JC compose compiler [1.5.3](https://android.googlesource.com/platform/frameworks/support/+log/ff1732b8405b315a030ae84e4e03416f36e75fad..738409b08051e4780768b4e7163348898f8d6c03/compose/compiler ) 