### PR TITLE
Fix Error in snippet at tutorials/UI_Testing/README.md:9

### DIFF
--- a/ci/templates/desktop-template/build.gradle.kts
+++ b/ci/templates/desktop-template/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
     // (in a separate module for demo project and in testMain).
     // With compose.desktop.common you will also lose @Preview functionality
     implementation(compose.desktop.currentOs)
+
+    // Include the Test API
+    implementation(compose.desktop.uiTestJUnit4)
 }
 
 compose.desktop {

--- a/ci/templates/desktop-template/gradle/wrapper/gradle-wrapper.properties
+++ b/ci/templates/desktop-template/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/UI_Testing/README.md
+++ b/tutorials/UI_Testing/README.md
@@ -5,7 +5,7 @@ The API for unit testing in Compose for Desktop is nearly identical to the [Jetp
 To start using the testing API, you will need to add the dependency on `compose.uiTestJUnit4` to your `build.gradle` file and create the directory for your tests. 
 
 If the module is desktop-only (`kotlin("jvm")` is applied), add the dependency via:
-```kotlin
+``` kotlin
 dependencies {
     testImplementation(compose.desktop.uiTestJUnit4)
     testImplementation(compose.desktop.currentOs)
@@ -16,7 +16,7 @@ and the directory for tests will be `src/test/kotlin`
 
 If the module is multiplatform (`kotlin(“multiplatform”)` is applied), add it via:
 
-```kotlin
+``` kotlin
 kotlin {
     sourceSets {
         val desktopTest by getting {


### PR DESCRIPTION
It crashes because the tutorial checker uses desktop-template without uiTesting module

See https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_AllGitHubRelease/4301157?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true

Also adding "``` kotlin" hack to avoid compilation of some snippets (we use it in another places)