### PR TITLE
iOS examples. Returned the ContentView back to how it was

### DIFF
--- a/examples/chat/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/chat/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		1848823F43E447F9A8B4AC7C /* YetAnotherSwiftUIScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18488451271FAAD8FA34A2FB /* YetAnotherSwiftUIScreen.swift */; };
 		184882D8AF2A7A3642004010 /* ComposeInsideSwiftUIScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18488CAB0978B80826E5BBB4 /* ComposeInsideSwiftUIScreen.swift */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		3251B1342AA8C2AA001521C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251B1332AA8C2AA001521C0 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		18488CAB0978B80826E5BBB4 /* ComposeInsideSwiftUIScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeInsideSwiftUIScreen.swift; sourceTree = "<group>"; };
 		18488D89B8500CD7696A04EB /* KotlinToSwiftHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KotlinToSwiftHelper.swift; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		3251B1332AA8C2AA001521C0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* Chat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chat.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 				18488CAB0978B80826E5BBB4 /* ComposeInsideSwiftUIScreen.swift */,
 				18488451271FAAD8FA34A2FB /* YetAnotherSwiftUIScreen.swift */,
 				1848892FA748717E4087E7D7 /* GradientTemplate.swift */,
+				3251B1332AA8C2AA001521C0 /* ContentView.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -169,6 +172,7 @@
 			files = (
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				1848810122D49D4AD3668D91 /* ComposeViewControllerToSwiftUI.swift in Sources */,
+				3251B1342AA8C2AA001521C0 /* ContentView.swift in Sources */,
 				184880BA0E9910C2B5012412 /* KotlinToSwiftHelper.swift in Sources */,
 				184882D8AF2A7A3642004010 /* ComposeInsideSwiftUIScreen.swift in Sources */,
 				1848823F43E447F9A8B4AC7C /* YetAnotherSwiftUIScreen.swift in Sources */,

--- a/examples/chat/iosApp/iosApp/ContentView.swift
+++ b/examples/chat/iosApp/iosApp/ContentView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            ComposeInsideSwiftUIScreen()
+                .tabItem {
+                    Label("Group Chat", systemImage: "rectangle.3.group.bubble.left")
+                }
+
+            YetAnotherSwiftUIScreen()
+                .tabItem {
+                    Label("Settings", systemImage: "gear")
+                }
+
+        }
+            .accentColor(Color(red: 0.671, green: 0.365, blue: 0.792)).preferredColorScheme(.light)
+    }
+}
+
+let gradient = LinearGradient(
+        colors: [
+            Color(red: 0.933, green: 0.937, blue: 0.953),
+            Color(red: 0.902, green: 0.941, blue: 0.949)
+        ],
+        startPoint: .topLeading, endPoint: .bottomTrailing
+)

--- a/examples/chat/iosApp/iosApp/iOSApp.swift
+++ b/examples/chat/iosApp/iosApp/iOSApp.swift
@@ -1,30 +1,10 @@
 import SwiftUI
 
-let gradient = LinearGradient(
-        colors: [
-            Color(red: 0.933, green: 0.937, blue: 0.953),
-            Color(red: 0.902, green: 0.941, blue: 0.949)
-        ],
-        startPoint: .topLeading, endPoint: .bottomTrailing
-)
-
 @main
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            TabView {
-                ComposeInsideSwiftUIScreen()
-                    .tabItem {
-                        Label("Group Chat", systemImage: "rectangle.3.group.bubble.left")
-                    }
-
-                YetAnotherSwiftUIScreen()
-                    .tabItem {
-                        Label("Settings", systemImage: "gear")
-                    }
-
-            }
-                .accentColor(Color(red: 0.671, green: 0.365, blue: 0.792)).preferredColorScheme(.light)
+            ContentView()
         }
     }
 }

--- a/examples/cocoapods-ios-example/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/cocoapods-ios-example/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		3251B1362AA8C336001521C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251B1352AA8C336001521C0 /* ContentView.swift */; };
 		CFDB58B53BB94DE262B13C24 /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B1049432C0C2B312090ABF6 /* Pods_iosApp.framework */; };
 /* End PBXBuildFile section */
 
@@ -17,6 +18,7 @@
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		3251B1352AA8C336001521C0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		4FF3202A603A284706412EDC /* Pods-iosApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.debug.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.debug.xcconfig"; sourceTree = "<group>"; };
 		6B1049432C0C2B312090ABF6 /* Pods_iosApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iosApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF7B242A565900829871 /* My application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "My application.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -79,6 +81,7 @@
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
+				3251B1352AA8C336001521C0 /* ContentView.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -214,6 +217,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3251B1362AA8C336001521C0 /* ContentView.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/cocoapods-ios-example/iosApp/iosApp/ContentView.swift
+++ b/examples/cocoapods-ios-example/iosApp/iosApp/ContentView.swift
@@ -2,10 +2,14 @@ import UIKit
 import SwiftUI
 import shared
 
+
 struct ContentView: View {
     var body: some View {
-        ComposeView()
-            .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+        ZStack {
+            Color.white.ignoresSafeArea(.all) // status bar color
+            ComposeView()
+                .ignoresSafeArea(.all, edges: .bottom) // Compose has own keyboard handler
+        }.preferredColorScheme(.light)
     }
 }
 

--- a/examples/cocoapods-ios-example/iosApp/iosApp/iOSApp.swift
+++ b/examples/cocoapods-ios-example/iosApp/iosApp/iOSApp.swift
@@ -1,24 +1,10 @@
-import UIKit
 import SwiftUI
-import shared
 
 @main
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            ZStack {
-                Color.white.ignoresSafeArea(.all) // status bar color
-                ComposeView()
-                    .ignoresSafeArea(.all, edges: .bottom) // Compose has own keyboard handler
-            }.preferredColorScheme(.light)
+            ContentView()
         }
     }
-}
-
-struct ComposeView: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> UIViewController {
-        Main_iosKt.MainViewController()
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
 }

--- a/examples/codeviewer/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/codeviewer/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		3251B1382AA8CF70001521C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251B1372AA8CF70001521C0 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		3251B1372AA8CF70001521C0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* Codeviewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Codeviewer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -64,6 +66,7 @@
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
+				3251B1372AA8CF70001521C0 /* ContentView.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -168,6 +171,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3251B1382AA8CF70001521C0 /* ContentView.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/codeviewer/iosApp/iosApp/ContentView.swift
+++ b/examples/codeviewer/iosApp/iosApp/ContentView.swift
@@ -4,8 +4,11 @@ import shared
 
 struct ContentView: View {
     var body: some View {
-        ComposeView()
-            .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+        ZStack {
+            Color(#colorLiteral(red: 0.235, green: 0.247, blue: 0.255, alpha: 1)).ignoresSafeArea(.all)
+            ComposeView()
+                .ignoresSafeArea(.all, edges: .bottom) // Compose has own keyboard handler
+        }.preferredColorScheme(.dark)
     }
 }
 

--- a/examples/codeviewer/iosApp/iosApp/iOSApp.swift
+++ b/examples/codeviewer/iosApp/iosApp/iOSApp.swift
@@ -1,24 +1,11 @@
-import UIKit
 import SwiftUI
-import shared
 
 @main
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            ZStack {
-                Color(#colorLiteral(red: 0.235, green: 0.247, blue: 0.255, alpha: 1)).ignoresSafeArea(.all)
-                ComposeView()
-                    .ignoresSafeArea(.all, edges: .bottom) // Compose has own keyboard handler
-            }.preferredColorScheme(.dark)
+            ContentView()
         }
     }
 }
 
-struct ComposeView: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> UIViewController {
-        Main_iosKt.MainViewController()
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
-}

--- a/examples/imageviewer/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/imageviewer/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		3251B13A2AA8D738001521C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251B1392AA8D738001521C0 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		3251B1392AA8D738001521C0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* My Memories.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "My Memories.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
+				3251B1392AA8D738001521C0 /* ContentView.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -176,6 +179,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3251B13A2AA8D738001521C0 /* ContentView.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/imageviewer/iosApp/iosApp/ContentView.swift
+++ b/examples/imageviewer/iosApp/iosApp/ContentView.swift
@@ -1,0 +1,38 @@
+import UIKit
+import SwiftUI
+import shared
+
+struct ContentView: View {
+    var body: some View {
+        ZStack {
+            ComposeView()
+                    .ignoresSafeArea(.all) // Compose has own keyboard handler
+            VStack {
+                gradient.ignoresSafeArea(edges: .top).frame(height: 0)
+                Spacer()
+            }
+        }.preferredColorScheme(.dark)
+    }
+}
+
+struct ComposeView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        let controller = Main_iosKt.MainViewController()
+        controller.overrideUserInterfaceStyle = .light
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+}
+
+let gradient = LinearGradient(
+    colors: [
+        Color.black.opacity(0.6),
+        Color.black.opacity(0.6),
+        Color.black.opacity(0.5),
+        Color.black.opacity(0.3),
+        Color.black.opacity(0.0),
+    ],
+    startPoint: .top, endPoint: .bottom
+)

--- a/examples/imageviewer/iosApp/iosApp/iOSApp.swift
+++ b/examples/imageviewer/iosApp/iosApp/iOSApp.swift
@@ -1,41 +1,10 @@
-import UIKit
 import SwiftUI
-import shared
-
-let gradient = LinearGradient(
-    colors: [
-        Color.black.opacity(0.6),
-        Color.black.opacity(0.6),
-        Color.black.opacity(0.5),
-        Color.black.opacity(0.3),
-        Color.black.opacity(0.0),
-    ],
-    startPoint: .top, endPoint: .bottom
-)
 
 @main
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            ZStack {
-                ComposeView()
-                        .ignoresSafeArea(.all) // Compose has own keyboard handler
-                VStack {
-                    gradient.ignoresSafeArea(edges: .top).frame(height: 0)
-                    Spacer()
-                }
-            }.preferredColorScheme(.dark)
+            ContentView()
         }
-    }
-}
-
-struct ComposeView: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> UIViewController {
-        let controller = Main_iosKt.MainViewController()
-        controller.overrideUserInterfaceStyle = .light
-        return controller
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
     }
 }

--- a/examples/interop/ios-compose-in-swiftui/README.md
+++ b/examples/interop/ios-compose-in-swiftui/README.md
@@ -2,7 +2,7 @@
 
 This example shows how to use Compose inside an iOS Application written in SwiftUI.
 
-Entry point is `struct iOSApp` in file [iosApp.swift](iosApp%2FiosApp%2FiosApp.swift).
+Entry point is `struct ContentView` in file [ContentView.swift](iosApp%2FiosApp%2FContentView.swift).
 
 Compose entry point is `fun ComposeEntryPoint(): UIViewController` in file [main.ios.kt](shared%2Fsrc%2FiosMain%2Fkotlin%2Fmain.ios.kt).
 

--- a/examples/interop/ios-compose-in-swiftui/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/interop/ios-compose-in-swiftui/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1848823F43E447F9A8B4AC7C /* YetAnotherSwiftUIScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18488451271FAAD8FA34A2FB /* YetAnotherSwiftUIScreen.swift */; };
 		184882D8AF2A7A3642004010 /* ComposeInSwiftUIScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18488CAB0978B80826E5BBB4 /* ComposeInSwiftUIScreen.swift */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		3251B13C2AA8D8EC001521C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251B13B2AA8D8EC001521C0 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,6 +21,7 @@
 		1848892FA748717E4087E7D7 /* ScreenTemplate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenTemplate.swift; sourceTree = "<group>"; };
 		18488CAB0978B80826E5BBB4 /* ComposeInSwiftUIScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeInSwiftUIScreen.swift; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		3251B13B2AA8D8EC001521C0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* ComposeInSwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ComposeInSwiftUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -62,6 +64,7 @@
 				18488CAB0978B80826E5BBB4 /* ComposeInSwiftUIScreen.swift */,
 				18488451271FAAD8FA34A2FB /* YetAnotherSwiftUIScreen.swift */,
 				1848892FA748717E4087E7D7 /* ScreenTemplate.swift */,
+				3251B13B2AA8D8EC001521C0 /* ContentView.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -166,6 +169,7 @@
 			files = (
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				1848810122D49D4AD3668D91 /* ComposeViewControllerInSwiftUI.swift in Sources */,
+				3251B13C2AA8D8EC001521C0 /* ContentView.swift in Sources */,
 				184882D8AF2A7A3642004010 /* ComposeInSwiftUIScreen.swift in Sources */,
 				1848823F43E447F9A8B4AC7C /* YetAnotherSwiftUIScreen.swift in Sources */,
 				184881FBE98BA5BF02A0A186 /* ScreenTemplate.swift in Sources */,

--- a/examples/interop/ios-compose-in-swiftui/iosApp/iosApp/ContentView.swift
+++ b/examples/interop/ios-compose-in-swiftui/iosApp/iosApp/ContentView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            ComposeInSwiftUIScreen()
+                .tabItem {
+                    Label("Compose in SwiftUI", systemImage: "star.fill")
+                }
+
+            YetAnotherSwiftUIScreen()
+                .tabItem {
+                    Label("SwiftUI", systemImage: "gear")
+                }
+        }
+    }
+}

--- a/examples/interop/ios-compose-in-swiftui/iosApp/iosApp/iOSApp.swift
+++ b/examples/interop/ios-compose-in-swiftui/iosApp/iosApp/iOSApp.swift
@@ -4,17 +4,7 @@ import SwiftUI
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            TabView {
-                ComposeInSwiftUIScreen()
-                    .tabItem {
-                        Label("Compose in SwiftUI", systemImage: "star.fill")
-                    }
-
-                YetAnotherSwiftUIScreen()
-                    .tabItem {
-                        Label("SwiftUI", systemImage: "gear")
-                    }
-            }
+            ContentView()
         }
     }
 }

--- a/examples/interop/ios-swiftui-in-compose/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/interop/ios-swiftui-in-compose/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -9,11 +9,13 @@
 /* Begin PBXBuildFile section */
 		1848810122D49D4AD3668D91 /* ComposeViewControllerRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18488656503C85EEDA66341D /* ComposeViewControllerRepresentable.swift */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		3251B13E2AA8D9AE001521C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251B13D2AA8D9AE001521C0 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		18488656503C85EEDA66341D /* ComposeViewControllerRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposeViewControllerRepresentable.swift; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		3251B13D2AA8D9AE001521C0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* SwiftUIInCompose.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIInCompose.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -53,6 +55,7 @@
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				18488656503C85EEDA66341D /* ComposeViewControllerRepresentable.swift */,
+				3251B13D2AA8D9AE001521C0 /* ContentView.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -157,6 +160,7 @@
 			files = (
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				1848810122D49D4AD3668D91 /* ComposeViewControllerRepresentable.swift in Sources */,
+				3251B13E2AA8D9AE001521C0 /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/examples/interop/ios-swiftui-in-compose/iosApp/iosApp/ContentView.swift
+++ b/examples/interop/ios-swiftui-in-compose/iosApp/iosApp/ContentView.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import shared
+import UIKit
+
+struct ContentView: View {
+    var body: some View {
+        ComposeViewControllerRepresentable()
+            .ignoresSafeArea(.all)
+    }
+}

--- a/examples/interop/ios-swiftui-in-compose/iosApp/iosApp/iOSApp.swift
+++ b/examples/interop/ios-swiftui-in-compose/iosApp/iosApp/iOSApp.swift
@@ -1,13 +1,10 @@
 import SwiftUI
-import shared
-import UIKit
 
 @main
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            ComposeViewControllerRepresentable()
-                .ignoresSafeArea(.all)
+            ContentView()
         }
     }
 }

--- a/examples/interop/ios-uikit-in-compose/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/interop/ios-uikit-in-compose/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -8,10 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		3251B1402AA8DA8F001521C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251B13F2AA8DA8F001521C0 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		3251B13F2AA8DA8F001521C0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* UIKitInCompose.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UIKitInCompose.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -50,6 +52,7 @@
 			children = (
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
+				3251B13F2AA8DA8F001521C0 /* ContentView.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -152,6 +155,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3251B1402AA8DA8F001521C0 /* ContentView.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/interop/ios-uikit-in-compose/iosApp/iosApp/ContentView.swift
+++ b/examples/interop/ios-uikit-in-compose/iosApp/iosApp/ContentView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import shared
+import UIKit
+
+struct ContentView: View {
+    var body: some View {
+        ComposeViewControllerToSwiftUI()
+            .ignoresSafeArea(.all)
+    }
+}
+
+struct ComposeViewControllerToSwiftUI: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        return Main_iosKt.ComposeEntryPoint()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+}

--- a/examples/interop/ios-uikit-in-compose/iosApp/iosApp/iOSApp.swift
+++ b/examples/interop/ios-uikit-in-compose/iosApp/iosApp/iOSApp.swift
@@ -1,22 +1,10 @@
 import SwiftUI
-import shared
-import UIKit
 
 @main
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            ComposeViewControllerToSwiftUI()
-                .ignoresSafeArea(.all)
+            ContentView()
         }
-    }
-}
-
-struct ComposeViewControllerToSwiftUI: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> UIViewController {
-        return Main_iosKt.ComposeEntryPoint()
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
     }
 }

--- a/examples/todoapp-lite/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/todoapp-lite/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		3251B1422AA8DC67001521C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251B1412AA8DC67001521C0 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		3251B1412AA8DC67001521C0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* TodoAppLite.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TodoAppLite.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -64,6 +66,7 @@
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
+				3251B1412AA8DC67001521C0 /* ContentView.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -168,6 +171,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3251B1422AA8DC67001521C0 /* ContentView.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/todoapp-lite/iosApp/iosApp/ContentView.swift
+++ b/examples/todoapp-lite/iosApp/iosApp/ContentView.swift
@@ -2,6 +2,7 @@ import UIKit
 import SwiftUI
 import shared
 
+
 struct ContentView: View {
     var body: some View {
         ComposeView()
@@ -14,5 +15,6 @@ struct ComposeView: UIViewControllerRepresentable {
         Main_iosKt.MainViewController()
     }
 
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
 }

--- a/examples/todoapp-lite/iosApp/iosApp/iOSApp.swift
+++ b/examples/todoapp-lite/iosApp/iosApp/iOSApp.swift
@@ -1,22 +1,10 @@
-import UIKit
 import SwiftUI
-import shared
 
 @main
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            ComposeView()
-                .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+            ContentView()
         }
-    }
-}
-
-struct ComposeView: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> UIViewController {
-        Main_iosKt.MainViewController()
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
     }
 }

--- a/examples/widgets-gallery/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/examples/widgets-gallery/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
+		3251B1442AA8DCBF001521C0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3251B1432AA8DCBF001521C0 /* ContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		2152FB032600AC8F00CF470E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		3251B1432AA8DCBF001521C0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF7B242A565900829871 /* WidgetsGallery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WidgetsGallery.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
+				3251B1432AA8DCBF001521C0 /* ContentView.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -176,6 +179,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3251B1442AA8DCBF001521C0 /* ContentView.swift in Sources */,
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/widgets-gallery/iosApp/iosApp/ContentView.swift
+++ b/examples/widgets-gallery/iosApp/iosApp/ContentView.swift
@@ -14,5 +14,6 @@ struct ComposeView: UIViewControllerRepresentable {
         Main_iosKt.MainViewController()
     }
 
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
 }

--- a/examples/widgets-gallery/iosApp/iosApp/iOSApp.swift
+++ b/examples/widgets-gallery/iosApp/iosApp/iOSApp.swift
@@ -1,22 +1,10 @@
-import UIKit
 import SwiftUI
-import shared
 
 @main
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            ComposeView()
-                .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+            ContentView()
         }
-    }
-}
-
-struct ComposeView: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> UIViewController {
-        Main_iosKt.MainViewController()
-    }
-
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
     }
 }


### PR DESCRIPTION
Previosly we removed ContentView in some iOS examples (PR: https://github.com/JetBrains/compose-multiplatform/pull/3609/files#diff-8d0f83db2e30c5c6d516b54778150df88fe98410bf3560f6418cb4c1801f9253L5-L10)

We decided to return it back.
Issue: https://youtrack.jetbrains.com/issue/COMPOSE-351/Add-struct-ContentView-to-iOS-examples
