### PR TITLE
Support for additional launchers

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/AbstractDistributions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/AbstractDistributions.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.compose.desktop.application.dsl
 
+import org.gradle.api.Action
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
@@ -35,5 +36,13 @@ abstract class AbstractDistributions {
     var targetFormats: Set<TargetFormat> = EnumSet.noneOf(TargetFormat::class.java)
     open fun targetFormats(vararg formats: TargetFormat) {
         targetFormats = EnumSet.copyOf(formats.toList())
+    }
+
+    internal val additionalLauncherSettings = objects.mapProperty(String::class.java, String::class.java)
+
+    fun additionalLauncher(name: String, fn: Action<AdditionalLauncherArguments>) {
+        val settings = objects.newInstance(AdditionalLauncherArguments::class.java)
+        fn.execute(settings)
+        additionalLauncherSettings.put(name, settings.getFileContent())
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/AdditionalLauncherArguments.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/AdditionalLauncherArguments.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020-2023 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.compose.desktop.application.dsl
+
+abstract class AdditionalLauncherArguments {
+    private val options: MutableList<String> = mutableListOf()
+
+    fun add(key: String, value: String) {
+        if (ValidKeys.contains(key)) {
+            options.add("$key=$value")
+        } else {
+            error("Key \"$key\" is invalid. Valid keys are: ${ValidKeys.joinToString(", ")}")
+        }
+    }
+
+    internal fun getFileContent(): String {
+        return options.joinToString("\n")
+    }
+
+    companion object {
+        val ValidKeys = listOf(
+            "module", "main-jar", "main-class", "description", "arguments", "java-options", "app-version",
+            "icon", "launcher-as-service", "win-console", "win-shortcut", "win-menu", "linux-app-category",
+            "linux-shortcut"
+        )
+    }
+}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -324,6 +324,7 @@ private fun JvmApplicationContext.configurePackageTask(
         packageTask.packageVendor.set(packageTask.provider { executables.vendor })
         packageTask.packageVersion.set(packageVersionFor(packageTask.targetFormat))
         packageTask.licenseFile.set(executables.licenseFile)
+        packageTask.additionalLaunchers.set(executables.additionalLauncherSettings)
     }
 
     packageTask.destinationDir.set(app.nativeDistributions.outputBaseDir.map {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -347,8 +347,6 @@ private fun JvmApplicationContext.configurePackageTask(
     packageTask.launcherMainClass.set(provider { app.mainClass })
     packageTask.launcherJvmArgs.set(provider { defaultJvmArgs + app.jvmArgs })
     packageTask.launcherArgs.set(provider { app.args })
-
-
 }
 
 internal fun JvmApplicationContext.configureCommonNotarizationSettings(

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -69,7 +69,7 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:InputDirectory
     @get:Optional
-            /** @see internal/wixToolset.kt */
+    /** @see internal/wixToolset.kt */
     val wixToolsetDir: DirectoryProperty = objects.directoryProperty()
 
     @get:Input
@@ -310,8 +310,8 @@ abstract class AbstractJPackageTask @Inject constructor(
     override fun makeArgs(tmpDir: File): MutableList<String> = super.makeArgs(tmpDir).apply {
         fun appDir(vararg pathParts: String): String {
             /** For windows we need to pass '\\' to jpackage file, each '\' need to be escaped.
-            Otherwise '$APPDIR\resources' is passed to jpackage,
-            and '\r' is treated as a special character at run time.
+                Otherwise '$APPDIR\resources' is passed to jpackage,
+                and '\r' is treated as a special character at run time.
              */
             val separator = if (currentTarget.os == OS.Windows) "\\\\" else "/"
             return listOf("${'$'}APPDIR", *pathParts).joinToString(separator) { it }
@@ -384,7 +384,6 @@ abstract class AbstractJPackageTask @Inject constructor(
                     cliArg("--linux-menu-group", linuxMenuGroup)
                     cliArg("--linux-rpm-license-type", linuxRpmLicenseType)
                 }
-
                 OS.Windows -> {
                     cliArg("--win-dir-chooser", winDirChooser)
                     cliArg("--win-per-user-install", winPerUserInstall)
@@ -393,7 +392,6 @@ abstract class AbstractJPackageTask @Inject constructor(
                     cliArg("--win-menu-group", winMenuGroup)
                     cliArg("--win-upgrade-uuid", winUpgradeUuid)
                 }
-
                 OS.MacOS -> {}
             }
         }
@@ -614,8 +612,7 @@ abstract class AbstractJPackageTask @Inject constructor(
         val packageVersion = packageVersion.get()!!
         plist[PlistKeys.CFBundleShortVersionString] = packageVersion
         // If building for the App Store, use "utilities" as default just like jpackage.
-        val category =
-            macAppCategory.orNull ?: (if (macAppStore.orNull == true) "public.app-category.utilities" else null)
+        val category = macAppCategory.orNull ?: (if (macAppStore.orNull == true) "public.app-category.utilities" else null)
         plist[PlistKeys.LSApplicationCategoryType] = category ?: "Unknown"
         val packageBuildVersion = packageBuildVersion.orNull ?: packageVersion
         plist[PlistKeys.CFBundleVersion] = packageBuildVersion


### PR DESCRIPTION
For my application I need the installer to include two launchers with different arguments. It turns out JPackage supports this so I added support to add the necessary flags.

WIth this addition, you can specify additional launchers in the `nativeDistributions` block like this.

```
compose.desktop {
    application {
        mainClass = "com.alchitry.labs.MainKt"
        nativeDistributions {
            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
            packageName = "Alchitry Labs"
            packageVersion = (version as String).split("-").first()
            vendor = "Alchitry"

            additionalLauncher("Alchitry Loader") {
                add("arguments","loader")
            }
        }
    }
}
```

You pass arguments to add to the properties file through the `add` function.

Here's the relevant doc for the add-launcher flag.

> --add-launcher name=path
> Name of launcher, and a path to a Properties file that contains a list of key, value pairs
> 
> (absolute path or relative to the current directory)
> 
> The keys "module", "main-jar", "main-class", "description", "arguments", "java-options", "app-version", "icon", "launcher-as-service", "win-console", "win-shortcut", "win-menu", "linux-app-category", and "linux-shortcut" can be used.
> 
> These options are added to, or used to overwrite, the original command line options to build an additional alternative launcher. The main application launcher will be built from the command line options. Additional alternative launchers can be built using this option, and this option can be used multiple times to build multiple additional launchers.