### PR TITLE
Added support to add files to jpackage resources argument

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.compose.desktop.application.dsl
 
 import org.gradle.api.Action
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import javax.inject.Inject
@@ -17,6 +18,7 @@ abstract class AbstractPlatformSettings {
     val iconFile: RegularFileProperty = objects.fileProperty()
     var packageVersion: String? = null
     var installationPath: String? = null
+    val jpackageResourceDir: DirectoryProperty = objects.directoryProperty()
 }
 
 abstract class AbstractMacOSPlatformSettings : AbstractPlatformSettings() {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -377,6 +377,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.linuxRpmLicenseType.set(provider { linux.rpmLicenseType })
                 packageTask.iconFile.set(linux.iconFile.orElse(defaultResources.get { linuxIcon }))
                 packageTask.installationPath.set(linux.installationPath)
+                packageTask.jpackageResourcesDir.set(linux.jpackageResourceDir)
             }
         }
         OS.Windows -> {
@@ -390,6 +391,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.winUpgradeUuid.set(provider { win.upgradeUuid })
                 packageTask.iconFile.set(win.iconFile.orElse(defaultResources.get { windowsIcon }))
                 packageTask.installationPath.set(win.installationPath)
+                packageTask.jpackageResourcesDir.set(win.jpackageResourceDir)
             }
         }
         OS.MacOS -> {
@@ -415,6 +417,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.nonValidatedMacSigningSettings = app.nativeDistributions.macOS.signing
                 packageTask.iconFile.set(mac.iconFile.orElse(defaultResources.get { macIcon }))
                 packageTask.installationPath.set(mac.installationPath)
+                packageTask.jpackageResourcesDir.set(mac.jpackageResourceDir)
             }
         }
     }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -276,6 +276,9 @@ abstract class AbstractJPackageTask @Inject constructor(
     @get:Internal
     val appResourcesDir: DirectoryProperty = objects.directoryProperty()
 
+    @get:Internal
+    val jpackageResourcesDir: DirectoryProperty = objects.directoryProperty()
+
     /**
      * Gradle runtime verification fails,
      * if InputDirectory is not null, but a directory does not exist.
@@ -509,6 +512,8 @@ abstract class AbstractJPackageTask @Inject constructor(
                     .writeToFile(jpackageResources.ioFile.resolve("product-def.plist"))
             }
         }
+
+        jpackageResourcesDir.ioFileOrNull?.copyRecursively(jpackageResources.ioFile, overwrite = true)
     }
 
     override fun jvmToolEnvironment(): MutableMap<String, String> =


### PR DESCRIPTION
I wanted to add a driver (udev rule) file to my Linux install and to do this I needed to override the `postinst` script that jpackage generates. This can be done by providing a `postinst` script in the directory pointed to by the `--resource-dir` flag.

This is currently not exposed and is used only by the MacOS target. 

I added an override that allows a directory to be supplied to each OS target. It may be better if this could be specified for each `TargetFormat` type instead of per OS but I don't think it matters as I think jpackage will ignore the files it doesn't recognize.

See https://docs.oracle.com/en/java/javase/20/jpackage/override-jpackage-resources.html for the relavant reasons to override this.