### PR TITLE
Avoid applying compiler plugin to unsupported native targets

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -8,10 +8,12 @@ package org.jetbrains.compose
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.compose.internal.ComposeCompilerArtifactProvider
+import org.jetbrains.compose.internal.SUPPORTED_NATIVE_TARGETS
 import org.jetbrains.compose.internal.mppExtOrNull
 import org.jetbrains.compose.internal.service.ConfigurationProblemReporterService
 import org.jetbrains.compose.internal.webExt
 import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 
 class ComposeCompilerKotlinSupportPlugin : KotlinCompilerPluginSupportPlugin {
@@ -68,7 +70,7 @@ class ComposeCompilerKotlinSupportPlugin : KotlinCompilerPluginSupportPlugin {
             KotlinPlatformType.jvm -> true
             KotlinPlatformType.js -> isApplicableJsTarget(kotlinCompilation.target)
             KotlinPlatformType.androidJvm -> true
-            KotlinPlatformType.native -> true
+            KotlinPlatformType.native -> (kotlinCompilation.target as KotlinNativeTarget).konanTarget in SUPPORTED_NATIVE_TARGETS
             KotlinPlatformType.wasm -> false
         }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/configureNativeCompilerCaching.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/configureNativeCompilerCaching.kt
@@ -7,6 +7,7 @@ package org.jetbrains.compose.experimental.internal
 
 import org.gradle.api.Project
 import org.jetbrains.compose.internal.KOTLIN_MPP_PLUGIN_ID
+import org.jetbrains.compose.internal.SUPPORTED_NATIVE_TARGETS
 import org.jetbrains.compose.internal.mppExt
 import org.jetbrains.compose.internal.service.ConfigurationProblemReporterService
 import org.jetbrains.compose.internal.utils.KGPPropertyProvider
@@ -18,15 +19,6 @@ import org.jetbrains.kotlin.konan.target.presetName
 private const val PROJECT_CACHE_KIND_PROPERTY_NAME = "kotlin.native.cacheKind"
 private const val COMPOSE_NATIVE_MANAGE_CACHE_KIND = "compose.kotlin.native.manageCacheKind"
 private const val NONE_VALUE = "none"
-
-private val SUPPORTED_NATIVE_TARGETS = setOf(
-    KonanTarget.IOS_ARM32,
-    KonanTarget.IOS_X64,
-    KonanTarget.IOS_ARM64,
-    KonanTarget.IOS_SIMULATOR_ARM64,
-    KonanTarget.MACOS_X64,
-    KonanTarget.MACOS_ARM64,
-)
 
 internal val SUPPORTED_NATIVE_CACHE_KIND_PROPERTIES =
     SUPPORTED_NATIVE_TARGETS.map { it.targetCacheKindPropertyName } +

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/nativeTargets.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/nativeTargets.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.compose.internal
+
+import org.jetbrains.kotlin.konan.target.KonanTarget
+
+internal val SUPPORTED_NATIVE_TARGETS = setOf(
+    KonanTarget.IOS_ARM32,
+    KonanTarget.IOS_X64,
+    KonanTarget.IOS_ARM64,
+    KonanTarget.IOS_SIMULATOR_ARM64,
+    KonanTarget.MACOS_X64,
+    KonanTarget.MACOS_ARM64,
+)


### PR DESCRIPTION
Otherwise, we get:

e: Compilation failed: Cannot find the Composer class in the classpath