### PR TITLE
Add org.gradle.toolchains.foojay-resolver-convention to the examples with Android target

### DIFF
--- a/ci/templates/multiplatform-template/android/build.gradle.kts
+++ b/ci/templates/multiplatform-template/android/build.gradle.kts
@@ -5,18 +5,21 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlin {
+        jvmToolchain(17)
     }
 }
 

--- a/ci/templates/multiplatform-template/common/build.gradle.kts
+++ b/ci/templates/multiplatform-template/common/build.gradle.kts
@@ -28,18 +28,18 @@ kotlin {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
     }
-
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
-
+    kotlin {
+        jvmToolchain(17)
+    }
     sourceSets {
         named("main") {
             manifest.srcFile("src/androidMain/AndroidManifest.xml")

--- a/ci/templates/multiplatform-template/gradle.properties
+++ b/ci/templates/multiplatform-template/gradle.properties
@@ -3,5 +3,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
 kotlin.version=1.9.10
-agp.version=7.1.3
+agp.version=8.0.2
 compose.version=1.5.1

--- a/ci/templates/multiplatform-template/settings.gradle.kts
+++ b/ci/templates/multiplatform-template/settings.gradle.kts
@@ -15,4 +15,8 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 include(":common", ":android", ":desktop")

--- a/examples/chat/androidApp/build.gradle.kts
+++ b/examples/chat/androidApp/build.gradle.kts
@@ -26,10 +26,10 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/chat/settings.gradle.kts
+++ b/examples/chat/settings.gradle.kts
@@ -20,6 +20,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = "chat-mpp"
 
 include(":androidApp")

--- a/examples/chat/shared/build.gradle.kts
+++ b/examples/chat/shared/build.gradle.kts
@@ -103,10 +103,10 @@ android {
         minSdk = 26
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/cocoapods-ios-example/androidApp/build.gradle.kts
+++ b/examples/cocoapods-ios-example/androidApp/build.gradle.kts
@@ -29,10 +29,10 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/cocoapods-ios-example/settings.gradle.kts
+++ b/examples/cocoapods-ios-example/settings.gradle.kts
@@ -26,6 +26,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 dependencyResolutionManagement {
     repositories {
         google()

--- a/examples/cocoapods-ios-example/shared/build.gradle.kts
+++ b/examples/cocoapods-ios-example/shared/build.gradle.kts
@@ -58,10 +58,10 @@ android {
         minSdk = (findProperty("android.minSdk") as String).toInt()
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/codeviewer/androidApp/build.gradle.kts
+++ b/examples/codeviewer/androidApp/build.gradle.kts
@@ -26,10 +26,10 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/codeviewer/settings.gradle.kts
+++ b/examples/codeviewer/settings.gradle.kts
@@ -21,6 +21,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = "codeviewer"
 
 include(":androidApp")

--- a/examples/codeviewer/shared/build.gradle.kts
+++ b/examples/codeviewer/shared/build.gradle.kts
@@ -73,10 +73,10 @@ android {
         minSdk = 26
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/falling-balls/androidApp/build.gradle.kts
+++ b/examples/falling-balls/androidApp/build.gradle.kts
@@ -26,10 +26,10 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/falling-balls/settings.gradle.kts
+++ b/examples/falling-balls/settings.gradle.kts
@@ -20,6 +20,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = "falling-balls-mpp"
 
 include(":androidApp")

--- a/examples/falling-balls/shared/build.gradle.kts
+++ b/examples/falling-balls/shared/build.gradle.kts
@@ -116,10 +116,10 @@ android {
         minSdk = 26
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/imageviewer/androidApp/build.gradle.kts
+++ b/examples/imageviewer/androidApp/build.gradle.kts
@@ -27,11 +27,11 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }
 

--- a/examples/imageviewer/settings.gradle.kts
+++ b/examples/imageviewer/settings.gradle.kts
@@ -21,6 +21,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = "imageviewer"
 
 include(":androidApp")

--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -95,10 +95,10 @@ android {
         minSdk = 26
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/issues/android/build.gradle.kts
+++ b/examples/issues/android/build.gradle.kts
@@ -16,11 +16,11 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }
 

--- a/examples/issues/common/build.gradle.kts
+++ b/examples/issues/common/build.gradle.kts
@@ -46,11 +46,11 @@ android {
         minSdk = 26
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
     sourceSets {
         named("main") {

--- a/examples/issues/settings.gradle.kts
+++ b/examples/issues/settings.gradle.kts
@@ -19,4 +19,8 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 include(":common", ":android", ":desktop")

--- a/examples/minesweeper/androidApp/build.gradle.kts
+++ b/examples/minesweeper/androidApp/build.gradle.kts
@@ -26,10 +26,10 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/minesweeper/settings.gradle.kts
+++ b/examples/minesweeper/settings.gradle.kts
@@ -20,6 +20,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = "minesweeper"
 
 include(":androidApp")

--- a/examples/minesweeper/shared/build.gradle.kts
+++ b/examples/minesweeper/shared/build.gradle.kts
@@ -126,10 +126,10 @@ android {
         minSdk = 26
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/todoapp-lite/androidApp/build.gradle.kts
+++ b/examples/todoapp-lite/androidApp/build.gradle.kts
@@ -27,10 +27,10 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/todoapp-lite/settings.gradle.kts
+++ b/examples/todoapp-lite/settings.gradle.kts
@@ -19,6 +19,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = "todoapp-lite"
 
 include(":androidApp")

--- a/examples/todoapp-lite/shared/build.gradle.kts
+++ b/examples/todoapp-lite/shared/build.gradle.kts
@@ -72,10 +72,10 @@ android {
         minSdk = 26
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/visual-effects/androidApp/build.gradle.kts
+++ b/examples/visual-effects/androidApp/build.gradle.kts
@@ -26,10 +26,10 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/visual-effects/settings.gradle.kts
+++ b/examples/visual-effects/settings.gradle.kts
@@ -20,6 +20,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = "visual-effects"
 
 include(":androidApp")

--- a/examples/visual-effects/shared/build.gradle.kts
+++ b/examples/visual-effects/shared/build.gradle.kts
@@ -71,10 +71,10 @@ android {
         minSdk = 26
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/widgets-gallery/androidApp/build.gradle.kts
+++ b/examples/widgets-gallery/androidApp/build.gradle.kts
@@ -26,10 +26,10 @@ android {
         versionName = "1.0"
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }

--- a/examples/widgets-gallery/settings.gradle.kts
+++ b/examples/widgets-gallery/settings.gradle.kts
@@ -20,6 +20,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 rootProject.name = "widgets-gallery"
 
 include(":androidApp")

--- a/examples/widgets-gallery/shared/build.gradle.kts
+++ b/examples/widgets-gallery/shared/build.gradle.kts
@@ -73,10 +73,10 @@ android {
         minSdk = 26
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 }


### PR DESCRIPTION
According to https://developer.android.com/build/jdks we should:

1. [use JDK 17 for API 34](https://developer.android.com/build/jdks#compileSdk)
2. [use toolchain](https://developer.android.com/build/jdks#toolchain):
```
We recommend that you always specify the Java toolchain, and either ensure that the specified JDK is installed, or add a toolchain resolver to your build.
```

As we don't want to force people to have JDK 17 on their machine, we apply toolchain resolver that is recommended by Gradle:
```
id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
```

It will download the toolchain itself.

## Test
1. Remove JDK 17 from the computer, remove `jvmToolchain(17)`
2. Run `./gradlew assembleDebug`
3. It should fail with:
```
> Could not create task ':androidApp:compileDebugJavaWithJavac'.
   > Failed to calculate the value of task ':androidApp:compileDebugJavaWithJavac' property 'javaCompiler'.
      > No matching toolchains found for requested specification: {languageVersion=17, vendor=any, implementation=vendor-specific} for WINDOWS on x86_64.
         > No locally installed toolchains match and toolchain download repositories have not been configured.
```
4. restore `jvmToolchain(17)`
5. Run `./gradlew assembleDebug` again
6. It should succeed

## Issues
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3615