### PR TITLE
Update ComposeCompilerCompatibility.kt

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
@@ -16,7 +16,7 @@ internal object ComposeCompilerCompatibility {
         "1.9.0-RC" to "1.4.8-beta",
         "1.9.0" to "1.5.1",
         "1.9.10" to "1.5.2",
-        "1.9.20-Beta" to "1.5.2.1-Beta"
+        "1.9.20-Beta" to "1.5.2.1-Beta2"
     )
 
     fun compilerVersionFor(kotlinVersion: String): String {


### PR DESCRIPTION
1.5.2.1-Beta2 includes a fix for k/js decoys - https://github.com/JetBrains/compose-multiplatform-core/commit/8473a4d57ad645938c5dd07277c2edd397bbb911