### PR TITLE
Fix Proguard error on CI

### DIFF
--- a/ci/templates/desktop-template/build.gradle.kts
+++ b/ci/templates/desktop-template/build.gradle.kts
@@ -19,7 +19,8 @@ dependencies {
     implementation(compose.desktop.currentOs)
 
     // Include the Test API
-    implementation(compose.desktop.uiTestJUnit4)
+    // compileOnly instead of testImplementation for checking compilation of the tutorials
+    compileOnly(compose.desktop.uiTestJUnit4)
 }
 
 compose.desktop {


### PR DESCRIPTION
The error:
```
java.io.IOException: Please correct the above warnings first.
```
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_AllGitHubRelease/4312357?expandBuildProblemsSection=true&hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=4312349_1096_787&logFilter=debug&logView=flowAware

Regression after https://github.com/JetBrains/compose-multiplatform/pull/3628

We don't need `implementation` here, `compileOnly` works for our case

## Test
These commands should pass
```
cd ./ci/templates/desktop-template/
./gradlew packageReleaseDistributionForCurrentOS
```
```
cd ./tutorials/checker/
./gradlew check
```