### PR TITLE
HTML. Rollback Kotlin to 1.8.21

### DIFF
--- a/html/buildSrc/gradle.properties
+++ b/html/buildSrc/gradle.properties
@@ -1,1 +1,1 @@
-kotlin.version=1.8.20
+kotlin.version=1.8.21

--- a/html/buildSrc/gradle.properties
+++ b/html/buildSrc/gradle.properties
@@ -1,1 +1,1 @@
-kotlin.version=1.9.10
+kotlin.version=1.8.20


### PR DESCRIPTION
1. It fixes CI errors: https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_PublishFast_2GradlePluginTest/4303621?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true
2. We still need to support 1.8.21 in Compose 1.5 versions

Regression after https://github.com/JetBrains/compose-multiplatform/pull/3631