### PR TITLE
Add API to not apply the Compose Compiler plugin

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeExtension.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeExtension.kt
@@ -10,7 +10,9 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.jetbrains.compose.internal.utils.nullableProperty
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import javax.inject.Inject
 
 abstract class ComposeExtension @Inject constructor(
@@ -41,5 +43,26 @@ abstract class ComposeExtension @Inject constructor(
      */
     val kotlinCompilerPluginArgs: ListProperty<String> = objects.listProperty(String::class.java)
 
+    /**
+     * A set of kotlin platform types to which the Compose Compiler plugin will be applied.
+     * By default, it contains all KotlinPlatformType values.
+     * It can be used to disable the Compose Compiler plugin for one or more targets:
+     * ```
+     * platformTypes.set(platformTypes.get() - KotlinPlatformType.native)
+     * ```
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    val platformTypes: SetProperty<KotlinPlatformType> = objects.setProperty(KotlinPlatformType::class.java).also {
+        it.set(KotlinPlatformType.values().toMutableSet())
+    }
+
     val dependencies = ComposePlugin.Dependencies(project)
+
+    /**
+     * @param platformType - the type of platform(s) which should not have the Compose Compiler plugin applied.
+     * Removes [platformType] from [platformTypes].
+     */
+    fun excludePlatform(vararg platformType: KotlinPlatformType) {
+        platformTypes.set(platformTypes.get() - platformType.toSet())
+    }
 }


### PR DESCRIPTION
This a solution for https://github.com/JetBrains/compose-multiplatform/issues/3695

Usage:
```
compose {
    excludePlatform(KotlinPlatformType.js, KotlinPlatformType.native)
}
```

or 
```
compose {
    platformTypes.set(platformTypes.get() - setOf(KotlinPlatformType.js, KotlinPlatformType.native))
}
```

2nd sample seems to be too verbose, so maybe we can make `platformTypes` private.
___

**Note:** 
this solution will make it possible to disable the Compose Compiler plugin for all targets which have given `KotlinPlatformType`. 
A project can have many targets with the same KotlinPlatformType:

```
jvm("backend) {}
jvm("frontend") {}
// etc

```

`compose.excludePlatform(KotlinPlatformType.jvm)` will disable the compose compiler plugin for all jvm targets.
While we don't have a use case for now where it can be a problem, I wanted to highlight this.


