### PR TITLE
Enable Windows ARM64 publication

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -132,6 +132,7 @@ abstract class ComposePlugin : Plugin<Project> {
         val linux_x64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-linux-x64")
         val linux_arm64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-linux-arm64")
         val windows_x64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-windows-x64")
+        val windows_arm64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-windows-arm64")
         val macos_x64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-macos-x64")
         val macos_arm64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-macos-arm64")
 


### PR DESCRIPTION
Everything is already configured but we didn't publish desktop-windows-arm64 "helper" dependency for another users that use "compose.desktop.currentOs" DSL.

The publication was configured in https://github.com/JetBrains/compose-multiplatform-core/pull/322 and in https://github.com/JetBrains/skiko/pull/610

Resolves https://youtrack.jetbrains.com/issue/COMPOSE-223/Finish-Windows-ARM-64-support

core PR: https://github.com/JetBrains/compose-multiplatform-core/pull/853

TODO: Test Compose on a real Windows ARM64 machine