### PR TITLE
COMPOSE-338 Remove uikit experimental flag in gradle.properties

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/checkExperimentalTargets.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/checkExperimentalTargets.kt
@@ -25,7 +25,6 @@ private class TargetType(
 private val TargetType.gradlePropertyName get() = "org.jetbrains.compose.experimental.$id.enabled"
 
 private val EXPERIMENTAL_TARGETS: Set<TargetType> = setOf(
-    TargetType("uikit", presets = listOf("iosSimulatorArm64", "iosArm64", "iosX64")),
     TargetType("macos", presets = listOf("macosX64", "macosArm64")),
     TargetType("jscanvas", presets = listOf("jsIr", "js")),
 )


### PR DESCRIPTION
Issue https://youtrack.jetbrains.com/issue/COMPOSE-338/remove-iOS-experimental-flag 
No more need this line:
`org.jetbrains.compose.experimental.uikit.enabled=true`