### PR TITLE
COMPOSE-338 Remove iOS experimental flag

### DIFF
--- a/benchmarks/ios/animation-from-template/gradle.properties
+++ b/benchmarks/ios/animation-from-template/gradle.properties
@@ -11,7 +11,6 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 
 #Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 
 #Android
 android.useAndroidX=true

--- a/benchmarks/ios/animation-from-template/gradle.properties
+++ b/benchmarks/ios/animation-from-template/gradle.properties
@@ -10,7 +10,6 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 #Compose
-org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Android
 android.useAndroidX=true

--- a/benchmarks/ios/animation-from-template/gradle.properties
+++ b/benchmarks/ios/animation-from-template/gradle.properties
@@ -10,6 +10,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 #Compose
+org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Android
 android.useAndroidX=true

--- a/benchmarks/ios/jvm-vs-kotlin-native/gradle.properties
+++ b/benchmarks/ios/jvm-vs-kotlin-native/gradle.properties
@@ -13,3 +13,4 @@ android.useAndroidX=true
 kotlin.js.webpack.major.version=4
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true

--- a/benchmarks/ios/jvm-vs-kotlin-native/gradle.properties
+++ b/benchmarks/ios/jvm-vs-kotlin-native/gradle.properties
@@ -3,7 +3,6 @@ kotlin.version=1.8.20
 agp.version=7.0.4
 org.gradle.jvmargs=-Xmx3g
 kotlin.code.style=official
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableGranularSourceSetsMetadata=true

--- a/benchmarks/ios/jvm-vs-kotlin-native/gradle.properties
+++ b/benchmarks/ios/jvm-vs-kotlin-native/gradle.properties
@@ -13,4 +13,3 @@ android.useAndroidX=true
 kotlin.js.webpack.major.version=4
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true

--- a/benchmarks/ios/scroll-lazy-grid/gradle.properties
+++ b/benchmarks/ios/scroll-lazy-grid/gradle.properties
@@ -11,7 +11,6 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 
 #Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 
 #Android
 android.useAndroidX=true

--- a/benchmarks/ios/scroll-lazy-grid/gradle.properties
+++ b/benchmarks/ios/scroll-lazy-grid/gradle.properties
@@ -10,7 +10,6 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 #Compose
-org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Android
 android.useAndroidX=true

--- a/benchmarks/ios/scroll-lazy-grid/gradle.properties
+++ b/benchmarks/ios/scroll-lazy-grid/gradle.properties
@@ -10,6 +10,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 #Compose
+org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Android
 android.useAndroidX=true

--- a/benchmarks/ios/scroll-lazy-list/gradle.properties
+++ b/benchmarks/ios/scroll-lazy-list/gradle.properties
@@ -11,7 +11,6 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 
 #Compose
 org.jetbrains.compose.experimental.uikit.enabled=true
-kotlin.native.cacheKind=none
 
 #Android
 android.useAndroidX=true

--- a/benchmarks/ios/scroll-lazy-list/gradle.properties
+++ b/benchmarks/ios/scroll-lazy-list/gradle.properties
@@ -10,7 +10,6 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 #Compose
-org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Android
 android.useAndroidX=true

--- a/benchmarks/ios/scroll-lazy-list/gradle.properties
+++ b/benchmarks/ios/scroll-lazy-list/gradle.properties
@@ -10,6 +10,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 
 #Compose
+org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Android
 android.useAndroidX=true

--- a/benchmarks/ios/visual-effects-ny/gradle.properties
+++ b/benchmarks/ios/visual-effects-ny/gradle.properties
@@ -7,7 +7,6 @@ org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental

--- a/benchmarks/ios/visual-effects-ny/gradle.properties
+++ b/benchmarks/ios/visual-effects-ny/gradle.properties
@@ -5,6 +5,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model

--- a/benchmarks/ios/visual-effects-ny/gradle.properties
+++ b/benchmarks/ios/visual-effects-ny/gradle.properties
@@ -5,7 +5,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model

--- a/benchmarks/kn-performance/gradle.properties
+++ b/benchmarks/kn-performance/gradle.properties
@@ -7,3 +7,4 @@ android.useAndroidX=true
 kotlin.js.webpack.major.version=4
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true

--- a/benchmarks/kn-performance/gradle.properties
+++ b/benchmarks/kn-performance/gradle.properties
@@ -7,4 +7,3 @@ android.useAndroidX=true
 kotlin.js.webpack.major.version=4
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true

--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -9,7 +9,6 @@ compose.version=1.5.0-dev1112
 agp.version=7.3.1
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.native.enableDependencyPropagation=false

--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -9,6 +9,7 @@ compose.version=1.5.0-dev1112
 agp.version=7.3.1
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.native.enableDependencyPropagation=false

--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -11,7 +11,6 @@ org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 
-kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.native.enableDependencyPropagation=false
 kotlin.mpp.enableGranularSourceSetsMetadata=true

--- a/compose/integrations/composable-test-cases/gradle.properties
+++ b/compose/integrations/composable-test-cases/gradle.properties
@@ -5,7 +5,6 @@ android.useAndroidX=true
 kotlin.version=1.9.10
 agp.version=7.3.0
 compose.version=1.5.1
-kotlin.native.cacheKind=none
 
 #empty by default - a default version will be used
 compose.kotlinCompilerPluginVersion=1.5.2

--- a/compose/integrations/compose-with-ktx-serialization/gradle.properties
+++ b/compose/integrations/compose-with-ktx-serialization/gradle.properties
@@ -4,6 +4,7 @@ android.useAndroidX=true
 kotlin.version=1.8.10
 agp.version=7.3.0
 compose.version=1.3.1
+org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 kotlinx.serializationCore=1.4.1

--- a/compose/integrations/compose-with-ktx-serialization/gradle.properties
+++ b/compose/integrations/compose-with-ktx-serialization/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 kotlin.version=1.8.10
 agp.version=7.3.0
 compose.version=1.3.1
-org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 kotlinx.serializationCore=1.4.1

--- a/examples/chat/gradle.properties
+++ b/examples/chat/gradle.properties
@@ -4,6 +4,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/chat/gradle.properties
+++ b/examples/chat/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/cocoapods-ios-example/gradle.properties
+++ b/examples/cocoapods-ios-example/gradle.properties
@@ -16,7 +16,6 @@ android.targetSdk=34
 android.minSdk=24
 
 #Compose
-org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Versions
 kotlin.version=1.9.10

--- a/examples/cocoapods-ios-example/gradle.properties
+++ b/examples/cocoapods-ios-example/gradle.properties
@@ -16,6 +16,7 @@ android.targetSdk=34
 android.minSdk=24
 
 #Compose
+org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Versions
 kotlin.version=1.9.10

--- a/examples/codeviewer/gradle.properties
+++ b/examples/codeviewer/gradle.properties
@@ -4,6 +4,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/codeviewer/gradle.properties
+++ b/examples/codeviewer/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/falling-balls/gradle.properties
+++ b/examples/falling-balls/gradle.properties
@@ -4,6 +4,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/falling-balls/gradle.properties
+++ b/examples/falling-balls/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/imageviewer/gradle.properties
+++ b/examples/imageviewer/gradle.properties
@@ -4,6 +4,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model

--- a/examples/imageviewer/gradle.properties
+++ b/examples/imageviewer/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model

--- a/examples/interop/ios-compose-in-swiftui/gradle.properties
+++ b/examples/interop/ios-compose-in-swiftui/gradle.properties
@@ -1,6 +1,5 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.version=1.9.10
 compose.version=1.5.1

--- a/examples/interop/ios-compose-in-swiftui/gradle.properties
+++ b/examples/interop/ios-compose-in-swiftui/gradle.properties
@@ -1,5 +1,6 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.version=1.9.10
 compose.version=1.5.1

--- a/examples/interop/ios-compose-in-uikit/gradle.properties
+++ b/examples/interop/ios-compose-in-uikit/gradle.properties
@@ -1,7 +1,6 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
-org.jetbrains.compose.experimental.uikit.enabled=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.10

--- a/examples/interop/ios-compose-in-uikit/gradle.properties
+++ b/examples/interop/ios-compose-in-uikit/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
+org.jetbrains.compose.experimental.uikit.enabled=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.10

--- a/examples/interop/ios-swiftui-in-compose/gradle.properties
+++ b/examples/interop/ios-swiftui-in-compose/gradle.properties
@@ -1,7 +1,6 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
-org.jetbrains.compose.experimental.uikit.enabled=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.10

--- a/examples/interop/ios-swiftui-in-compose/gradle.properties
+++ b/examples/interop/ios-swiftui-in-compose/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
+org.jetbrains.compose.experimental.uikit.enabled=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.10

--- a/examples/interop/ios-uikit-in-compose/gradle.properties
+++ b/examples/interop/ios-uikit-in-compose/gradle.properties
@@ -1,7 +1,6 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
-org.jetbrains.compose.experimental.uikit.enabled=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.10

--- a/examples/interop/ios-uikit-in-compose/gradle.properties
+++ b/examples/interop/ios-uikit-in-compose/gradle.properties
@@ -1,6 +1,7 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
+org.jetbrains.compose.experimental.uikit.enabled=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.10

--- a/examples/minesweeper/gradle.properties
+++ b/examples/minesweeper/gradle.properties
@@ -4,6 +4,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/minesweeper/gradle.properties
+++ b/examples/minesweeper/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/todoapp-lite/gradle.properties
+++ b/examples/todoapp-lite/gradle.properties
@@ -4,6 +4,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/todoapp-lite/gradle.properties
+++ b/examples/todoapp-lite/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/visual-effects/gradle.properties
+++ b/examples/visual-effects/gradle.properties
@@ -4,6 +4,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model

--- a/examples/visual-effects/gradle.properties
+++ b/examples/visual-effects/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model

--- a/examples/widgets-gallery/gradle.properties
+++ b/examples/widgets-gallery/gradle.properties
@@ -4,6 +4,7 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/widgets-gallery/gradle.properties
+++ b/examples/widgets-gallery/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/COMPOSE-338/remove-iOS-experimental-flag

We should merge it after updating version of Compose 1.5.10-dev (or beta) with needed fix in Gradle plugin.
Related PR with fix: https://github.com/JetBrains/compose-multiplatform/pull/3747