### PR TITLE
Fix configuration cache for `syncComposeResourcesForIos`

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/tasks/SyncComposeResourcesForIosTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/tasks/SyncComposeResourcesForIosTask.kt
@@ -19,54 +19,57 @@ import kotlin.io.path.pathString
 import kotlin.io.path.relativeTo
 
 abstract class SyncComposeResourcesForIosTask : AbstractComposeIosTask() {
-    private fun missingTargetEnvAttributeError(attribute: String): Provider<Nothing> =
-        providers.provider {
-            error(
-                "Could not infer iOS target $attribute. Make sure to build " +
-                        "via XCode (directly or via Kotlin Multiplatform Mobile plugin for Android Studio)")
+
+    private fun Provider<String>.orElseThrowMissingAttributeError(attribute: String): Provider<String> {
+        val noProvidedValue = "__NO_PROVIDED_VALUE__"
+        return this.orElse(noProvidedValue).map {
+            if (it == noProvidedValue) {
+                error(
+                    "Could not infer iOS target $attribute. Make sure to build " +
+                            "via XCode (directly or via Kotlin Multiplatform Mobile plugin for Android Studio)")
+            }
+            it
         }
+    }
 
     @get:Input
-    val xcodeTargetPlatform: Provider<String> = project.provider {
+    val xcodeTargetPlatform: Provider<String> =
         providers.gradleProperty("compose.ios.resources.platform")
             .orElse(providers.environmentVariable("PLATFORM_NAME"))
-            .orElse(missingTargetEnvAttributeError("platform"))
-            .get()
-    }
+            .orElseThrowMissingAttributeError("platform")
+
 
     @get:Input
-    val xcodeTargetArchs: Provider<List<String>> = project.provider {
+    val xcodeTargetArchs: Provider<List<String>> =
         providers.gradleProperty("compose.ios.resources.archs")
             .orElse(providers.environmentVariable("ARCHS"))
-            .orElse(missingTargetEnvAttributeError("architectures"))
-            .map { it.split(",", " ").filter { it.isNotBlank() } }
-            .get()
-    }
+            .orElseThrowMissingAttributeError("architectures")
+            .map {
+                it.split(",", " ").filter { it.isNotBlank() }
+            }
 
     @get:Input
     internal val iosTargets: SetProperty<IosTargetResources> = objects.setProperty(IosTargetResources::class.java)
 
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputFiles
-    val resourceFiles: Provider<FileCollection> = project.provider {
-        xcodeTargetPlatform.zip(xcodeTargetArchs, ::Pair)
-            .map { (xcodeTargetPlatform, xcodeTargetArchs) ->
-                val allResources = objects.fileCollection()
-                val activeKonanTargets = determineIosKonanTargetsFromEnv(xcodeTargetPlatform, xcodeTargetArchs)
-                    .mapTo(HashSet()) { it.name }
-                val dirsToInclude = iosTargets.get()
-                    .filter { it.konanTarget.get() in activeKonanTargets }
-                    .flatMapTo(HashSet()) { it.dirs.get() }
-                for (dirPath in dirsToInclude) {
-                    val fileTree = objects.fileTree().apply {
-                        setDir(layout.projectDirectory.dir(dirPath))
-                        include("**/*")
-                    }
-                    allResources.from(fileTree)
+    val resourceFiles: Provider<FileCollection> = xcodeTargetPlatform.zip(xcodeTargetArchs, ::Pair)
+        .map { (xcodeTargetPlatform, xcodeTargetArchs) ->
+            val allResources = objects.fileCollection()
+            val activeKonanTargets = determineIosKonanTargetsFromEnv(xcodeTargetPlatform, xcodeTargetArchs)
+                .mapTo(HashSet()) { it.name }
+            val dirsToInclude = iosTargets.get()
+                .filter { it.konanTarget.get() in activeKonanTargets }
+                .flatMapTo(HashSet()) { it.dirs.get() }
+            for (dirPath in dirsToInclude) {
+                val fileTree = objects.fileTree().apply {
+                    setDir(layout.projectDirectory.dir(dirPath))
+                    include("**/*")
                 }
-                allResources
-            }.get()
-    }
+                allResources.from(fileTree)
+            }
+            allResources
+        }
 
     @get:OutputDirectory
     val outputDir: DirectoryProperty = objects.directoryProperty()

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -62,13 +62,18 @@ class GradlePluginTest : GradlePluginTestBase() {
         )
     }
 
+    // We rely on this property to use gradle configuration cache in some tests.
+    // Enabling configuration cache unconditionally breaks out tests with gradle 7.3.3.
+    // Old comment: 'for some reason configuration cache + test kit + custom vars does not work'
+    private val GradleVersion.isAtLeastGradle8
+        get() = this >= GradleVersion.version("8.0")
+
     @Test
     fun iosResources() {
         Assumptions.assumeTrue(currentOS == OS.MacOS)
         val iosTestEnv = iosTestEnv()
         val testEnv = defaultTestEnvironment.copy(
-            // for some reason configuration cache + test kit + custom vars does not work
-            useGradleConfigurationCache = false,
+            useGradleConfigurationCache = TestProperties.gradleBaseVersionForTests.isAtLeastGradle8,
             additionalEnvVars = iosTestEnv.envVars
         )
 
@@ -91,8 +96,7 @@ class GradlePluginTest : GradlePluginTestBase() {
         Assumptions.assumeTrue(currentOS == OS.MacOS)
         val iosTestEnv = iosTestEnv()
         val testEnv = defaultTestEnvironment.copy(
-            // for some reason configuration cache + test kit + custom vars does not work
-            useGradleConfigurationCache = false,
+            useGradleConfigurationCache = TestProperties.gradleBaseVersionForTests.isAtLeastGradle8,
             additionalEnvVars = iosTestEnv.envVars
         )
         with(testProject(TestProjects.iosMokoResources, testEnv)) {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -68,7 +68,7 @@ class GradlePluginTest : GradlePluginTestBase() {
         val iosTestEnv = iosTestEnv()
         val testEnv = defaultTestEnvironment.copy(
             // for some reason configuration cache + test kit + custom vars does not work
-            useGradleConfigurationCache = true,
+            useGradleConfigurationCache = false,
             additionalEnvVars = iosTestEnv.envVars
         )
 
@@ -92,7 +92,7 @@ class GradlePluginTest : GradlePluginTestBase() {
         val iosTestEnv = iosTestEnv()
         val testEnv = defaultTestEnvironment.copy(
             // for some reason configuration cache + test kit + custom vars does not work
-            useGradleConfigurationCache = true,
+            useGradleConfigurationCache = false,
             additionalEnvVars = iosTestEnv.envVars
         )
         with(testProject(TestProjects.iosMokoResources, testEnv)) {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -68,7 +68,7 @@ class GradlePluginTest : GradlePluginTestBase() {
         val iosTestEnv = iosTestEnv()
         val testEnv = defaultTestEnvironment.copy(
             // for some reason configuration cache + test kit + custom vars does not work
-            useGradleConfigurationCache = false,
+            useGradleConfigurationCache = true,
             additionalEnvVars = iosTestEnv.envVars
         )
 
@@ -92,7 +92,7 @@ class GradlePluginTest : GradlePluginTestBase() {
         val iosTestEnv = iosTestEnv()
         val testEnv = defaultTestEnvironment.copy(
             // for some reason configuration cache + test kit + custom vars does not work
-            useGradleConfigurationCache = false,
+            useGradleConfigurationCache = true,
             additionalEnvVars = iosTestEnv.envVars
         )
         with(testProject(TestProjects.iosMokoResources, testEnv)) {


### PR DESCRIPTION
Currently when `org.gradle.configuration-cache=true` we have an error:

> Configuration cache state could not be cached: field `resourceFiles` of task `:shared:syncComposeResourcesForIos` of type `org.jetbrains.compose.experimental.uikit.tasks.SyncComposeResourcesForIosTask`: error writing value of type 'org.gradle.api.internal.provider.TransformBackedProvider'

Old description (can be ignored):
_This PR attempts to fix it in SyncComposeResourcesForIosTask by wrapping inputs into providers. It seems that gradle configuration cache doesn't like some provider types produced by `.map`, `.zip`, `.orElse`, etc._

**Latest description:**
With configuration cache enabled, gradle runs all `orElse` providers during configuration (I don't know why yet). 
We used to throw an exception in `orElse` which led to the crash. This PR refactors SyncComposeResourcesForIosTask so it doesn't throw an exception immediately in orElse, but postpones it to later step. 
 