### PR TITLE
CfW: Allow web resource routing configuration

### DIFF
--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -5,7 +5,7 @@ kotlin.code.style=official
 # __KOTLIN_COMPOSE_VERSION__
 kotlin.version=1.8.22
 # __LATEST_COMPOSE_RELEASE_VERSION__
-compose.version=1.5.0-dev1112
+compose.version=1.5.10-rc01
 agp.version=7.3.1
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true

--- a/components/resources/demo/shared/build.gradle.kts
+++ b/components/resources/demo/shared/build.gradle.kts
@@ -109,3 +109,8 @@ android {
 compose.experimental {
     web.application {}
 }
+
+// TODO: remove this block after we update on a newer kotlin. Currently there is an error: `error:0308010C:digital envelope routines::unsupported`
+rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
+    rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.0.0"
+}

--- a/components/resources/demo/shared/src/jsMain/kotlin/main.js.kt
+++ b/components/resources/demo/shared/src/jsMain/kotlin/main.js.kt
@@ -23,7 +23,7 @@ fun main() {
     @OptIn(ExperimentalResourceApi::class)
     configureWebResources {
         // Not necessary - It's the same as the default. We add it here just to present this feature.
-        setResourceImplFactory { urlResource("./$it") }
+        setResourceFactory { urlResource("./$it") }
     }
     onWasmReady {
         Window("Resources demo") {

--- a/components/resources/demo/shared/src/jsMain/kotlin/main.js.kt
+++ b/components/resources/demo/shared/src/jsMain/kotlin/main.js.kt
@@ -11,10 +11,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.configureWebResources
 import org.jetbrains.compose.resources.demo.shared.UseResources
+import org.jetbrains.compose.resources.urlResource
 import org.jetbrains.skiko.wasm.onWasmReady
 
+
 fun main() {
+
+    @OptIn(ExperimentalResourceApi::class)
+    configureWebResources {
+        // Not necessary - It's the same as the default. We add it here just to present this feature.
+        setResourceImplFactory { urlResource("./$it") }
+    }
     onWasmReady {
         Window("Resources demo") {
             MainView()

--- a/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/Resource.js.kt
+++ b/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/Resource.js.kt
@@ -26,7 +26,10 @@ import kotlin.js.Promise
  */
 @Suppress("unused")
 @ExperimentalResourceApi
-class WebResourcesConfiguration internal constructor() {
+object WebResourcesConfiguration {
+
+    @ExperimentalResourceApi
+    internal var jsResourceImplFactory: (path: String) -> Resource = { urlResource("./$it") }
 
     /**
      * See [configureWebResources] for more details.
@@ -34,11 +37,6 @@ class WebResourcesConfiguration internal constructor() {
     @ExperimentalResourceApi
     fun setResourceImplFactory(factory: (path: String) -> Resource) {
         jsResourceImplFactory = factory
-    }
-
-    internal companion object {
-        @ExperimentalResourceApi
-        var jsResourceImplFactory: (path: String) -> Resource = { urlResource("./$it") }
     }
 }
 
@@ -63,9 +61,7 @@ class WebResourcesConfiguration internal constructor() {
 @Suppress("unused")
 @ExperimentalResourceApi
 fun configureWebResources(configure: WebResourcesConfiguration.() -> Unit) {
-    with(WebResourcesConfiguration()) {
-        configure()
-    }
+    WebResourcesConfiguration.configure()
 }
 
 /**

--- a/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/Resource.js.kt
+++ b/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/Resource.js.kt
@@ -13,50 +13,54 @@ import org.jetbrains.compose.resources.vector.xmldom.MalformedXMLException
 import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Int8Array
 import org.w3c.dom.parsing.DOMParser
-import org.w3c.xhr.ARRAYBUFFER
-import org.w3c.xhr.XMLHttpRequest
-import org.w3c.xhr.XMLHttpRequestResponseType
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
-import kotlin.js.Promise
 
 /**
- * WebResourcesConfiguration is used in [configureWebResources].
+ * Represents the configuration object for web resources.
+ *
+ * @see configureWebResources - for overriding the default configuration.
  */
 @Suppress("unused")
 @ExperimentalResourceApi
 object WebResourcesConfiguration {
 
+    /**
+     * An internal default factory method for creating [Resource] from a given path.
+     * It can be changed at runtime by using [setResourceFactory].
+     */
     @ExperimentalResourceApi
     internal var jsResourceImplFactory: (path: String) -> Resource = { urlResource("./$it") }
 
     /**
-     * See [configureWebResources] for more details.
+     * Sets a custom factory used by [resource] function for creating [Resource] instances.
+     * Basically, [factory] will become an implementation of [resource] function.
+     *
+     * @param factory - a lambda that takes a path and returns a [Resource] instance.
+     *
+     * @see configureWebResources for examples on how to use this function.
      */
     @ExperimentalResourceApi
-    fun setResourceImplFactory(factory: (path: String) -> Resource) {
+    fun setResourceFactory(factory: (path: String) -> Resource) {
         jsResourceImplFactory = factory
     }
 }
 
 /**
- * `configureWebResources` can be used to override the default configuration.
+ * Configures the web resources behavior.
  *
- * Usage example 1:
+ * Allows users to override default behavior and provide custom logic for generating [Resource] instances.
+ *
+ * @param configure Configuration lambda applied to [WebResourcesConfiguration].
+ * @see WebResourcesConfiguration For detailed configuration options.
+ *
+ * Examples:
  * ```
  *  configureWebResources {
- *     setResourceImplFactory { path -> urlResource("/myApp1/resources/$path") }
+ *     setResourceFactory { path -> urlResource("/myApp1/resources/$path") }
  *  }
- * ```
- *  Usage example 2:
- * ```
  *  configureWebResources {
- *     setResourceImplFactory { path -> urlResource("https://mycdn.com/myApp1/res/$path") }
+ *     setResourceFactory { path -> urlResource("https://mycdn.com/myApp1/res/$path") }
  *  }
  * ```
- *
- * The default resource implementation factory is: `{ urlResource("./$it") }`
  */
 @Suppress("unused")
 @ExperimentalResourceApi
@@ -65,14 +69,22 @@ fun configureWebResources(configure: WebResourcesConfiguration.() -> Unit) {
 }
 
 /**
- * Creates [Resource] instance. The [Resource] implementation can be changed by using [configureWebResources].
- * By default, it uses [urlResource] under the hood where [path] is relative to the current url segment: `urlResource("./$path")`
+ * Generates a [Resource] instance based on the provided [path].
+ *
+ * By default, the path is treated as relative to the current URL segment.
+ * The default behaviour can be overridden by using [configureWebResources].
+ *
+ * @param path The path or resource id used to generate the [Resource] instance.
+ * @return A [Resource] instance corresponding to the provided path.
  */
 @ExperimentalResourceApi
 actual fun resource(path: String): Resource = WebResourcesConfiguration.jsResourceImplFactory(path)
 
 /**
- * Creates [Resource] instance accessible by [url]
+ * Creates a [Resource] instance based on the provided [url].
+ *
+ * @param url The URL used to access the [Resource].
+ * @return A [Resource] instance accessible by the given URL.
  */
 @ExperimentalResourceApi
 fun urlResource(url: String): Resource = JSUrlResourceImpl(url)

--- a/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/Resource.js.kt
+++ b/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/Resource.js.kt
@@ -84,7 +84,11 @@ fun urlResource(url: String): Resource = JSUrlResourceImpl(url)
 @ExperimentalResourceApi
 private class JSUrlResourceImpl(url: String) : AbstractResourceImpl(url) {
     override suspend fun readBytes(): ByteArray {
-        return window.fetch(path).await().arrayBuffer().await().toByteArray()
+        val response = window.fetch(path).await()
+        if (!response.ok) {
+            throw MissingResourceException(path)
+        }
+        return response.arrayBuffer().await().toByteArray()
     }
 }
 

--- a/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/Resource.js.kt
+++ b/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/Resource.js.kt
@@ -31,11 +31,10 @@ object WebResourcesConfiguration {
     internal var jsResourceImplFactory: (path: String) -> Resource = { urlResource("./$it") }
 
     /**
-     * Sets a custom factory used by [resource] function for creating [Resource] instances.
-     * Basically, [factory] will become an implementation of [resource] function.
+     * Sets a custom factory for the [resource] function to create [Resource] instances.
+     * Once set, the [factory] will effectively define the implementation of the [resource] function.
      *
-     * @param factory - a lambda that takes a path and returns a [Resource] instance.
-     *
+     * @param factory A lambda that accepts a path and produces a [Resource] instance.
      * @see configureWebResources for examples on how to use this function.
      */
     @ExperimentalResourceApi


### PR DESCRIPTION
This commit changes the default resource routing behaviour:
- It used to search for a file in the root directory (on a domain level)
- After this change, it will search for a file relatively to the current url segment

Besides that, we add a small configuration to let developers change the default behaviour when needed.

___

usage examples:

```kotlin
// 1
configureWebResources {
   setResourceFactory { path -> urlResource("/myApp1/resources/$path") }
}

// 2
configureWebResources {
  setResourcelFactory { path -> urlResource("https://mycdn.com/myApp1/res/$path") }
}
 ```

___
This will fix https://github.com/JetBrains/compose-multiplatform/issues/3413 (currently it bothers our users)
