### PR TITLE
Fixed a crash when selecting empty rows in codeviewer example

### DIFF
--- a/examples/codeviewer/shared/src/commonMain/kotlin/org/jetbrains/codeviewer/ui/editor/EditorView.kt
+++ b/examples/codeviewer/shared/src/commonMain/kotlin/org/jetbrains/codeviewer/ui/editor/EditorView.kt
@@ -1,7 +1,15 @@
 package org.jetbrains.codeviewer.ui.editor
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.selection.DisableSelection
@@ -172,6 +180,7 @@ private fun codeString(str: String) = buildAnnotatedString {
         addStyle(AppTheme.code.value, strFormatted, Regex("[0-9]+"))
         addStyle(AppTheme.code.annotation, strFormatted, Regex("^@[a-zA-Z_]*"))
         addStyle(AppTheme.code.comment, strFormatted, Regex("^\\s*//.*"))
+        append("\n")
     }
 }
 

--- a/examples/codeviewer/shared/src/commonMain/kotlin/org/jetbrains/codeviewer/ui/editor/EditorView.kt
+++ b/examples/codeviewer/shared/src/commonMain/kotlin/org/jetbrains/codeviewer/ui/editor/EditorView.kt
@@ -180,6 +180,9 @@ private fun codeString(str: String) = buildAnnotatedString {
         addStyle(AppTheme.code.value, strFormatted, Regex("[0-9]+"))
         addStyle(AppTheme.code.annotation, strFormatted, Regex("^@[a-zA-Z_]*"))
         addStyle(AppTheme.code.comment, strFormatted, Regex("^\\s*//.*"))
+        
+        // Keeps copied lines separated and fixes crash during selection:
+        // https://partnerissuetracker.corp.google.com/issues/199919707
         append("\n")
     }
 }


### PR DESCRIPTION
Due to [known problem](https://partnerissuetracker.corp.google.com/issues/199919707), the application crashes when selecting lines with empty text.
The fix does 2 things:
- Prevents `SelectionContainer` from crashing
- Improves format of copied text by separating it into lines