### PR TITLE
COMPOSE-338 Remove iOS experimental flag in gradle.properties

### DIFF
--- a/examples/chat/gradle.properties
+++ b/examples/chat/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/cocoapods-ios-example/gradle.properties
+++ b/examples/cocoapods-ios-example/gradle.properties
@@ -16,7 +16,6 @@ android.targetSdk=34
 android.minSdk=24
 
 #Compose
-org.jetbrains.compose.experimental.uikit.enabled=true
 
 #Versions
 kotlin.version=1.9.20

--- a/examples/codeviewer/gradle.properties
+++ b/examples/codeviewer/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/graphics-2d/gradle.properties
+++ b/examples/graphics-2d/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/imageviewer/gradle.properties
+++ b/examples/imageviewer/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.useEmbeddableCompilerJar=true
 # Enable kotlin/native experimental memory model

--- a/examples/interop/ios-compose-in-swiftui/gradle.properties
+++ b/examples/interop/ios-compose-in-swiftui/gradle.properties
@@ -1,6 +1,5 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.version=1.9.20
 compose.version=1.5.10

--- a/examples/interop/ios-compose-in-uikit/gradle.properties
+++ b/examples/interop/ios-compose-in-uikit/gradle.properties
@@ -1,7 +1,6 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
-org.jetbrains.compose.experimental.uikit.enabled=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.20

--- a/examples/interop/ios-swiftui-in-compose/gradle.properties
+++ b/examples/interop/ios-swiftui-in-compose/gradle.properties
@@ -1,7 +1,6 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
-org.jetbrains.compose.experimental.uikit.enabled=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.20

--- a/examples/interop/ios-uikit-in-compose/gradle.properties
+++ b/examples/interop/ios-uikit-in-compose/gradle.properties
@@ -1,7 +1,6 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
-org.jetbrains.compose.experimental.uikit.enabled=true
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.20

--- a/examples/todoapp-lite/gradle.properties
+++ b/examples/todoapp-lite/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model

--- a/examples/widgets-gallery/gradle.properties
+++ b/examples/widgets-gallery/gradle.properties
@@ -4,7 +4,6 @@ android.useAndroidX=true
 org.gradle.jvmargs=-Xmx3g
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.useEmbeddableCompilerJar=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
 # Enable kotlin/native experimental memory model


### PR DESCRIPTION
Because iOS target is in Alpha status, since version 1.5.10 we don't need flag in gradle properties.
`org.jetbrains.compose.experimental.uikit.enabled=true`

https://youtrack.jetbrains.com/issue/COMPOSE-338/remove-iOS-experimental-flag-after-1.5.10-release