### PR TITLE
Add kotlin 2.0.0-Beta1 to ComposeCompilerCompatibility

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
@@ -21,6 +21,7 @@ internal object ComposeCompilerCompatibility {
         "1.9.20-RC" to "1.5.2.1-rc01",
         "1.9.20-RC2" to "1.5.3-rc01",
         "1.9.20" to "1.5.3",
+        "2.0.0-Beta1" to "1.5.4-dev1-kt2.0.0-Beta1",
     )
 
     fun compilerVersionFor(kotlinVersion: String): String {


### PR DESCRIPTION
I decided to add the kotlin version name to the name of our artefact to make it more obvious. 