### PR TITLE
Fix Compose Gradle plugin Issue with daemon in Issue 3933

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/service/ConfigurationProblemReporterService.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/service/ConfigurationProblemReporterService.kt
@@ -43,7 +43,10 @@ abstract class ConfigurationProblemReporterService : AbstractComposeMultiplatfor
     }
     companion object {
         fun init(project: Project) {
-            registerServiceIfAbsent<ConfigurationProblemReporterService, Parameters>(project)
+            registerServiceIfAbsent<ConfigurationProblemReporterService, Parameters>(project) {
+                // WORKAROUND! Call getter at least once, because of Issue: https://github.com/gradle/gradle/issues/27099
+                warnings
+            }
         }
 
         private inline fun configureParameters(project: Project, fn: Parameters.() -> Unit) {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/service/GradlePropertySnapshotService.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/service/GradlePropertySnapshotService.kt
@@ -24,6 +24,9 @@ internal abstract class GradlePropertySnapshotService : AbstractComposeMultiplat
     companion object {
         fun init(project: Project) {
             registerServiceIfAbsent<GradlePropertySnapshotService, Parameters>(project) {
+                // WORKAROUND! Call getter at least once, because of Issue: https://github.com/gradle/gradle/issues/27099
+                gradlePropertiesCacheKindSnapshot
+                localPropertiesCacheKindSnapshot
                 initParams(project)
             }
         }


### PR DESCRIPTION
Fix for Issue https://github.com/JetBrains/compose-multiplatform/issues/3933

Applyed workaround described in Gradle Issue: https://github.com/gradle/gradle/issues/27099
We just need to call all functions (getters in our case) in our interface based on BuildServiceParameters at least once