### PR TITLE
update ImageViewer build file

### DIFF
--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -54,18 +54,6 @@ kotlin {
                 implementation("com.google.maps.android:maps-compose:2.11.2")
             }
         }
-        val iosMain by creating {
-            dependsOn(commonMain)
-        }
-        val iosX64Main by getting {
-            dependsOn(iosMain)
-        }
-        val iosArm64Main by getting {
-            dependsOn(iosMain)
-        }
-        val iosSimulatorArm64Main by getting {
-            dependsOn(iosMain)
-        }
 
         val desktopMain by getting {
             dependencies {


### PR DESCRIPTION
As I understood according to https://kotlinlang.org/docs/whatsnew1920.html#set-up-the-target-hierarchy those `dependsOn` calls are no longer needed

Tested on iOS, MacOS and Android. It works as before