### PR TITLE
Update kotlin version in components/resources library

### DIFF
--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -7,8 +7,8 @@ org.gradle.caching=true
 android.useAndroidX=true
 
 #Versions
-kotlin.version=1.9.10
-compose.version=1.5.3
+kotlin.version=1.9.21
+compose.version=1.6.0-dev1323
 agp.version=8.1.2
 
 #Compose


### PR DESCRIPTION
Reason: newer compose-core libs were built with kotlin 1.9.21. Previous kotlin/native version 1.9.10 is not compatible with it.