### PR TITLE
UIKitViewController with Compose 1.6.0 dev versions

### DIFF
--- a/examples/interop/ios-swiftui-in-compose/gradle.properties
+++ b/examples/interop/ios-swiftui-in-compose/gradle.properties
@@ -1,7 +1,5 @@
 kotlin.code.style=official
 xcodeproj=./iosApp
 org.gradle.jvmargs=-Xmx3g
-# Enable kotlin/native experimental memory model
-kotlin.native.binary.memoryModel=experimental
 kotlin.version=1.9.21
-compose.version=1.5.11
+compose.version=1.6.0-dev1347

--- a/examples/interop/ios-swiftui-in-compose/iosApp/iosApp/ComposeViewControllerRepresentable.swift
+++ b/examples/interop/ios-swiftui-in-compose/iosApp/iosApp/ComposeViewControllerRepresentable.swift
@@ -5,35 +5,17 @@ import MapKit
 
 struct ComposeViewControllerRepresentable: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        return Main_iosKt.ComposeEntryPointWithUIView(createUIView: { () -> UIView in
-            SwiftUIInUIView(
-                content: VStack {
-                    Text("SwiftUI in Compose Multiplatform")
-                }
+        return Main_iosKt.ComposeEntryPointWithUIView(createUIViewController: { () -> UIViewController in
+            let hostingController = UIHostingController(
+                rootView:
+                    VStack {
+                        Text("SwiftUI in Compose Multiplatform")
+                    }
             )
+            return hostingController
         })
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
-    }
-}
-
-private class SwiftUIInUIView<Content: View>: UIView {
-
-    init(content: Content) {
-        super.init(frame: CGRect())
-        let hostingController = UIHostingController(rootView: content)
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(hostingController.view)
-        NSLayoutConstraint.activate([
-            hostingController.view.topAnchor.constraint(equalTo: topAnchor),
-            hostingController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
-            hostingController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
-            hostingController.view.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/examples/interop/ios-swiftui-in-compose/shared/src/iosMain/kotlin/main.ios.kt
+++ b/examples/interop/ios-swiftui-in-compose/shared/src/iosMain/kotlin/main.ios.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.interop.UIKitViewController
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -12,7 +13,7 @@ import platform.UIKit.UIView
 import platform.UIKit.UIViewController
 
 @OptIn(ExperimentalForeignApi::class)
-fun ComposeEntryPointWithUIView(createUIView: () -> UIView): UIViewController =
+fun ComposeEntryPointWithUIView(createUIViewController: () -> UIViewController): UIViewController =
     ComposeUIViewController {
         Column(
             Modifier
@@ -21,8 +22,8 @@ fun ComposeEntryPointWithUIView(createUIView: () -> UIView): UIViewController =
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text("How to use SwiftUI inside Compose Multiplatform")
-            UIKitView(
-                factory = createUIView,
+            UIKitViewController(
+                factory = createUIViewController,
                 modifier = Modifier.size(300.dp).border(2.dp, Color.Blue),
             )
         }


### PR DESCRIPTION
This PR needs for future documentation changes.
@elijah-semyonov made a second implementation UIKitViewController to interop with UIViewController. And this is preferred way to interop with SwiftUI inside Compose.

Also may helps with Issue https://github.com/JetBrains/compose-multiplatform/issues/3942