### PR TITLE
Fix the bug that AsyncImage demo cannot update new images

### DIFF
--- a/tutorials/Image_And_Icons_Manipulations/README.md
+++ b/tutorials/Image_And_Icons_Manipulations/README.md
@@ -68,7 +68,7 @@ fun main() = singleWindowApplication {
     Column {
         AsyncImage(
             load = { loadImageBitmap(File("sample.png")) },
-            painterFor = { remember { BitmapPainter(it) } },
+            painterFor = { remember(it) { BitmapPainter(it) } },
             contentDescription = "Sample",
             modifier = Modifier.width(200.dp)
         )
@@ -97,7 +97,7 @@ fun <T> AsyncImage(
     modifier: Modifier = Modifier,
     contentScale: ContentScale = ContentScale.Fit,
 ) {
-    val image: T? by produceState<T?>(null) {
+    val image: T? by produceState<T?>(null, load) {
         value = withContext(Dispatchers.IO) {
             try {
                 load()


### PR DESCRIPTION
"val image: T? by produceState<T?>()" should use "load" as a key, or else it won't be re-launched for the new "load".
And "painterFor = { remember { BitmapPainter(it) } }" should use "it" as a key for the "remember", or else the "painterFor" won't update for the new "image" loaded by "produceState".