### PR TITLE
Fix Qualifier density

### DIFF
--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/Qualifier.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/Qualifier.kt
@@ -41,7 +41,7 @@ enum class DensityQualifier(val dpi: Int) : Qualifier {
         fun selectByDensity(density: Float) = when {
             density <= 0.75 -> LDPI
             density <= 1.0 -> MDPI
-            density <= 1.33 -> HDPI
+            density <= 1.5 -> HDPI
             density <= 2.0 -> XHDPI
             density <= 3.0 -> XXHDPI
             else -> XXXHDPI


### PR DESCRIPTION
```
    LDPI(120), // 120/160 = 0.75
    MDPI(160), // 160/160 = 1.0
    HDPI(240), // 240/160 = 1.5
    XHDPI(320), // 320/160 = 2.0
    XXHDPI(480), // 480/160 = 3.0
    XXXHDPI(640); // 640/160 = 4.0
```