### PR TITLE
Option to pack jars as uber JAR, support Proguard for uber JAR

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
@@ -23,4 +23,5 @@ abstract class ProguardSettings @Inject constructor(
     val isEnabled: Property<Boolean> = objects.notNullProperty(false)
     val obfuscate: Property<Boolean> = objects.notNullProperty(false)
     val optimize: Property<Boolean> = objects.notNullProperty(true)
+    val joinOutputJars: Property<Boolean> = objects.notNullProperty(false)
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -458,14 +458,14 @@ private fun JvmApplicationContext.configureFlattenJars(
 ) {
     if (runProguard != null) {
         flattenJars.dependsOn(runProguard)
-        flattenJars.inputFiles.from(project.fileTree(runProguard.flatMap { it.destinationDir }))
+        flattenJars.inputFiles.from(runProguard.flatMap { it.destinationDir })
     } else {
         flattenJars.useAppRuntimeFiles { (runtimeJars, _) ->
             inputFiles.from(runtimeJars)
         }
     }
 
-    flattenJars.destinationDir.set(appTmpDir.dir("flattenJars"))
+    flattenJars.flattenedJar.set(appTmpDir.file("flattenJars/flattened.jar"))
 }
 
 private fun JvmApplicationContext.configurePackageUberJarForCurrentOS(
@@ -473,7 +473,7 @@ private fun JvmApplicationContext.configurePackageUberJarForCurrentOS(
     flattenJars: Provider<AbstractJarsFlattenTask>
 ) {
     jar.dependsOn(flattenJars)
-    jar.from(flattenJars.flatMap { it.destinationDir })
+    jar.from(project.zipTree(flattenJars.flatMap { it.flattenedJar }))
 
     app.mainClass?.let { jar.manifest.attributes["Main-Class"] = it }
     jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractComposeDesktopTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractComposeDesktopTask.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.compose.desktop.tasks
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.model.ObjectFactory
@@ -32,6 +33,9 @@ abstract class AbstractComposeDesktopTask : DefaultTask() {
 
     @get:Inject
     protected abstract val fileOperations: FileSystemOperations
+
+    @get:Inject
+    protected abstract val archiveOperations: ArchiveOperations
 
     @get:LocalState
     protected val logsDir: Provider<Directory> = project.layout.buildDirectory.dir("compose/logs/$name")

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractJarsFlattenTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractJarsFlattenTask.kt
@@ -6,40 +6,81 @@
 package org.jetbrains.compose.desktop.tasks
 
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import org.jetbrains.compose.internal.utils.clearDirs
+import org.jetbrains.compose.desktop.application.internal.files.copyZipEntry
+import org.jetbrains.compose.desktop.application.internal.files.isJarFile
+import org.jetbrains.compose.internal.utils.delete
+import org.jetbrains.compose.internal.utils.ioFile
 import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 
+
+/**
+ * This task flattens all jars from the input directory into the single one,
+ * which is used later as a single source for uberjar.
+ *
+ * This task is necessary because the standard Jar/Zip task evaluates own `from()` args eagerly
+ * [in the configuration phase](https://discuss.gradle.org/t/why-is-the-closure-in-from-method-of-copy-task-evaluated-in-config-phase/23469/4)
+ * and snapshots an empty list of files in the Proguard destination directory,
+ * instead of a list of real jars after Proguard task execution.
+ *
+ * Also, we use output to the single jar instead of flattening to the directory in the filesystem because:
+ * - Windows filesystem is case-sensitive and not every jar can be unzipped without losing files
+ * - it's just faster
+ */
 abstract class AbstractJarsFlattenTask : AbstractComposeDesktopTask() {
 
     @get:InputFiles
     val inputFiles: ConfigurableFileCollection = objects.fileCollection()
 
-    @get:OutputDirectory
-    val destinationDir: DirectoryProperty = objects.directoryProperty()
+    @get:OutputFile
+    val flattenedJar: RegularFileProperty = objects.fileProperty()
+
+    @get:Internal
+    val entries = hashSetOf<String>()
 
     @TaskAction
     fun execute() {
-        fileOperations.clearDirs(destinationDir)
+        entries.clear()
+        fileOperations.delete(flattenedJar)
 
-        fileOperations.copy {
-            it.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-            it.from(flattenJars(inputFiles))
-            it.into(destinationDir)
+        ZipOutputStream(FileOutputStream(flattenedJar.ioFile).buffered()).use { outputStream ->
+            inputFiles.asFileTree.visit {
+                when {
+                    !it.isDirectory && it.file.isJarFile -> outputStream.writeJarContent(it.file)
+                    !it.isDirectory -> outputStream.writeFile(it.file)
+                }
+            }
         }
     }
 
-    private fun flattenJars(files: FileCollection) = files.map {
-        when {
-            it.isZipOrJar() -> this.archiveOperations.zipTree(it)
-            else -> it
+    private fun ZipOutputStream.writeJarContent(jarFile: File) =
+        ZipInputStream(FileInputStream(jarFile)).use { inputStream ->
+            var inputEntry: ZipEntry? = inputStream.nextEntry
+            while (inputEntry != null) {
+                writeEntryIfNotSeen(inputEntry, inputStream)
+                inputEntry = inputStream.nextEntry
+            }
+        }
+
+    private fun ZipOutputStream.writeFile(file: File) =
+        FileInputStream(file).use { inputStream ->
+            writeEntryIfNotSeen(ZipEntry(file.name), inputStream)
+        }
+
+    private fun ZipOutputStream.writeEntryIfNotSeen(entry: ZipEntry, inputStream: InputStream) {
+        if (entry.name !in entries) {
+            copyZipEntry(entry, inputStream, this)
+            entries += entry.name
         }
     }
-
-    private fun File.isZipOrJar() = name.endsWith(".jar", ignoreCase = true) || name.endsWith(".zip", ignoreCase = true)
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractJarsFlattenTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractJarsFlattenTask.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020-2024 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.compose.desktop.tasks
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.jetbrains.compose.internal.utils.clearDirs
+import java.io.File
+
+abstract class AbstractJarsFlattenTask : AbstractComposeDesktopTask() {
+
+    @get:InputFiles
+    val inputFiles: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:OutputDirectory
+    val destinationDir: DirectoryProperty = objects.directoryProperty()
+
+    @TaskAction
+    fun execute() {
+        fileOperations.clearDirs(destinationDir)
+
+        fileOperations.copy {
+            it.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            it.from(flattenJars(inputFiles))
+            it.into(destinationDir)
+        }
+    }
+
+    private fun flattenJars(files: FileCollection) = files.map {
+        when {
+            it.isZipOrJar() -> this.archiveOperations.zipTree(it)
+            else -> it
+        }
+    }
+
+    private fun File.isZipOrJar() = name.endsWith(".jar", ignoreCase = true) || name.endsWith(".zip", ignoreCase = true)
+}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractJarsFlattenTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractJarsFlattenTask.kt
@@ -34,7 +34,7 @@ import java.util.zip.ZipOutputStream
  * instead of a list of real jars after Proguard task execution.
  *
  * Also, we use output to the single jar instead of flattening to the directory in the filesystem because:
- * - Windows filesystem is case-sensitive and not every jar can be unzipped without losing files
+ * - Windows filesystem is case-insensitive and not every jar can be unzipped without losing files
  * - it's just faster
  */
 abstract class AbstractJarsFlattenTask : AbstractComposeDesktopTask() {
@@ -46,11 +46,11 @@ abstract class AbstractJarsFlattenTask : AbstractComposeDesktopTask() {
     val flattenedJar: RegularFileProperty = objects.fileProperty()
 
     @get:Internal
-    val entries = hashSetOf<String>()
+    val seenEntryNames = hashSetOf<String>()
 
     @TaskAction
     fun execute() {
-        entries.clear()
+        seenEntryNames.clear()
         fileOperations.delete(flattenedJar)
 
         ZipOutputStream(FileOutputStream(flattenedJar.ioFile).buffered()).use { outputStream ->
@@ -78,9 +78,9 @@ abstract class AbstractJarsFlattenTask : AbstractComposeDesktopTask() {
         }
 
     private fun ZipOutputStream.writeEntryIfNotSeen(entry: ZipEntry, inputStream: InputStream) {
-        if (entry.name !in entries) {
+        if (entry.name !in seenEntryNames) {
             copyZipEntry(entry, inputStream, this)
-            entries += entry.name
+            seenEntryNames += entry.name
         }
     }
 }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -208,7 +208,12 @@ class DesktopApplicationTest : GradlePluginTestBase() {
             if (distributionDir == null || !distributionDir.exists()) {
                 error("Invalid distribution path: $distributionDir")
             }
-            val appDir = distributionDir.resolve("TestPackage/app")
+            val appDirSubPath = when (currentOS) {
+                OS.Linux -> "TestPackage/lib/app"
+                OS.Windows -> "TestPackage/app"
+                OS.MacOS -> "TestPackage.app/Contents/app"
+            }
+            val appDir = distributionDir.resolve(appDirSubPath)
             val jarsCount = appDir.listFiles()?.count { it.name.endsWith(".jar", ignoreCase = true) } ?: 0
             assert(jarsCount == 1)
         }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -32,9 +32,15 @@ class DesktopApplicationTest : GradlePluginTestBase() {
                     tasks.getByName("run").doFirst {
                         throw new StopExecutionException("Skip run task")
                     }
+                    tasks.getByName("runRelease").doFirst {
+                        throw new StopExecutionException("Skip runRelease task")
+                    }
                     
                     tasks.getByName("runDistributable").doFirst {
                         throw new StopExecutionException("Skip runDistributable task")
+                    }
+                    tasks.getByName("runReleaseDistributable").doFirst {
+                        throw new StopExecutionException("Skip runReleaseDistributable task")
                     }
                 }
             """.trimIndent()
@@ -42,9 +48,16 @@ class DesktopApplicationTest : GradlePluginTestBase() {
         gradle("run").checks {
             check.taskSuccessful(":run")
         }
+        gradle("runRelease").checks {
+            check.taskSuccessful(":runRelease")
+        }
         gradle("runDistributable").checks {
             check.taskSuccessful(":createDistributable")
             check.taskSuccessful(":runDistributable")
+        }
+        gradle("runReleaseDistributable").checks {
+            check.taskSuccessful(":createReleaseDistributable")
+            check.taskSuccessful(":runReleaseDistributable")
         }
     }
 
@@ -55,9 +68,18 @@ class DesktopApplicationTest : GradlePluginTestBase() {
             check.taskSuccessful(":run")
             check.logContains(logLine)
         }
+        gradle("runRelease").checks {
+            check.taskSuccessful(":runRelease")
+            check.logContains(logLine)
+        }
         gradle("runDistributable").checks {
             check.taskSuccessful(":createDistributable")
             check.taskSuccessful(":runDistributable")
+            check.logContains(logLine)
+        }
+        gradle("runReleaseDistributable").checks {
+            check.taskSuccessful(":createReleaseDistributable")
+            check.taskSuccessful(":runReleaseDistributable")
             check.logContains(logLine)
         }
     }
@@ -166,6 +188,33 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     }
 
     @Test
+    fun joinOutputJarsJvm() = with(testProject(TestProjects.jvm)) {
+        joinOutputJars()
+    }
+
+    @Test
+    fun joinOutputJarsMpp() = with(testProject(TestProjects.mpp)) {
+        joinOutputJars()
+    }
+
+    private fun TestProject.joinOutputJars() {
+        enableJoinOutputJars()
+        gradle(":createReleaseDistributable").checks {
+            check.taskSuccessful(":createReleaseDistributable")
+
+            val distributionPathPattern = "The distribution is written to (.*)".toRegex()
+            val m = distributionPathPattern.find(check.log)
+            val distributionDir = m?.groupValues?.get(1)?.let(::File)
+            if (distributionDir == null || !distributionDir.exists()) {
+                error("Invalid distribution path: $distributionDir")
+            }
+            val appDir = distributionDir.resolve("TestPackage/app")
+            val jarsCount = appDir.listFiles()?.count { it.name.endsWith(".jar", ignoreCase = true) } ?: 0
+            assert(jarsCount == 1)
+        }
+    }
+
+    @Test
     fun gradleBuildCache() = with(testProject(TestProjects.jvm)) {
         modifyGradleProperties {
             setProperty("org.gradle.caching", "true")
@@ -265,19 +314,39 @@ class DesktopApplicationTest : GradlePluginTestBase() {
 
     @Test
     fun packageUberJarForCurrentOSJvm() = with(testProject(TestProjects.jvm)) {
-        testPackageUberJarForCurrentOS()
+        testPackageUberJarForCurrentOS(false)
     }
 
     @Test
     fun packageUberJarForCurrentOSMpp() = with(testProject(TestProjects.mpp)) {
-        testPackageUberJarForCurrentOS()
+        testPackageUberJarForCurrentOS(false)
     }
 
-    private fun TestProject.testPackageUberJarForCurrentOS() {
-        gradle(":packageUberJarForCurrentOS").checks {
-            check.taskSuccessful(":packageUberJarForCurrentOS")
+    @Test
+    fun packageReleaseUberJarForCurrentOSJvm() = with(testProject(TestProjects.jvm)) {
+        testPackageUberJarForCurrentOS(true)
+    }
 
-            val resultJarFile = file("build/compose/jars/TestPackage-${currentTarget.id}-1.0.0.jar")
+    @Test
+    fun packageReleaseUberJarForCurrentOSMpp() = with(testProject(TestProjects.mpp)) {
+        testPackageUberJarForCurrentOS(true)
+    }
+
+    private fun TestProject.testPackageUberJarForCurrentOS(release: Boolean) {
+        val task = when {
+            release -> ":packageReleaseUberJarForCurrentOS"
+            else -> ":packageUberJarForCurrentOS"
+        }
+
+        val jarFileName = when {
+            release -> "build/compose/jars/TestPackage-${currentTarget.id}-1.0.0-release.jar"
+            else -> "build/compose/jars/TestPackage-${currentTarget.id}-1.0.0.jar"
+        }
+
+        gradle(task).checks {
+            check.taskSuccessful(task)
+
+            val resultJarFile = file(jarFileName)
             resultJarFile.checkExists()
 
             JarFile(resultJarFile).use { jar ->
@@ -470,25 +539,33 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     }
 
     @Test
-    fun testUnpackSkiko() {
-        with(testProject(TestProjects.unpackSkiko)) {
-            gradle(":runDistributable").checks {
-                check.taskSuccessful(":runDistributable")
+    fun testUnpackSkiko() = with(testProject(TestProjects.unpackSkiko)) {
+        testUnpackSkiko(":runDistributable")
+    }
 
-                val libraryPathPattern = "Read skiko library path: '(.*)'".toRegex()
-                val m = libraryPathPattern.find(check.log)
-                val skikoDir = m?.groupValues?.get(1)?.let(::File)
-                if (skikoDir == null || !skikoDir.exists()) {
-                    error("Invalid skiko path: $skikoDir")
-                }
-                val filesToFind = when (currentOS) {
-                    OS.Linux -> listOf("libskiko-linux-${currentArch.id}.so")
-                    OS.Windows -> listOf("skiko-windows-${currentArch.id}.dll", "icudtl.dat")
-                    OS.MacOS -> listOf("libskiko-macos-${currentArch.id}.dylib")
-                }
-                for (fileName in filesToFind) {
-                    skikoDir.resolve(fileName).checkExists()
-                }
+    @Test
+    fun testUnpackSkikoFromUberJar() = with(testProject(TestProjects.unpackSkiko)) {
+        enableJoinOutputJars()
+        testUnpackSkiko(":runReleaseDistributable")
+    }
+
+    private fun TestProject.testUnpackSkiko(runDistributableTask: String) {
+        gradle(runDistributableTask).checks {
+            check.taskSuccessful(runDistributableTask)
+
+            val libraryPathPattern = "Read skiko library path: '(.*)'".toRegex()
+            val m = libraryPathPattern.find(check.log)
+            val skikoDir = m?.groupValues?.get(1)?.let(::File)
+            if (skikoDir == null || !skikoDir.exists()) {
+                error("Invalid skiko path: $skikoDir")
+            }
+            val filesToFind = when (currentOS) {
+                OS.Linux -> listOf("libskiko-linux-${currentArch.id}.so")
+                OS.Windows -> listOf("skiko-windows-${currentArch.id}.dll", "icudtl.dat")
+                OS.MacOS -> listOf("libskiko-macos-${currentArch.id}.dylib")
+            }
+            for (fileName in filesToFind) {
+                skikoDir.resolve(fileName).checkExists()
             }
         }
     }
@@ -517,5 +594,18 @@ class DesktopApplicationTest : GradlePluginTestBase() {
                 file("wix311").checkNotExists()
             }
         }
+    }
+
+    private fun TestProject.enableJoinOutputJars() {
+        val enableJoinOutputJars = """
+                    compose.desktop {
+                        application {
+                            buildTypes.release.proguard {
+                                joinOutputJars.set(true)
+                            }
+                        }
+                    }
+                """.trimIndent()
+        file("build.gradle").modify { "$it\n$enableJoinOutputJars" }
     }
 }

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -596,15 +596,16 @@ that is developed by [Guardsquare](https://www.guardsquare.com/).
 
 The Gradle plugin provides a *release* task for each corresponding *default* packaging task:
 
-Default task (w/o ProGuard)| Release task (w. ProGuard)       |Description
----------------------------|----------------------------------|-----------
-`createDistributable`      | `createReleaseDistributable`     |Creates an application image with bundled JDK & resources
-`runDistributable`         | `runReleaseDistributable`        |Runs an application image with bundled JDK & resources
-`run`                      | `runRelease`                     |Runs a non-packaged application `jar` using Gradle JDK
-`package<FORMAT_NAME>`     | `packageRelease<FORMAT_NAME>`    |Packages an application image into a `<FORMAT_NAME>` file
-`packageForCurrentOS`      | `packageReleaseForCurrentOS`     |Packages an application image into a format compatible with current OS
-`notarize<FORMAT_NAME>`    | `notarizeRelease<FORMAT_NAME>`   |Uploads a `<FORMAT_NAME>` application image for notarization (macOS only)
-`checkNotarizationStatus`  | `checkReleaseNotarizationStatus` |Checks if notarization succeeded (macOS only)
+ Default task (w/o ProGuard)       | Release task (w. ProGuard)               | Description
+-----------------------------------|------------------------------------------|--------------------------------------------------------------------------
+ `createDistributable`             | `createReleaseDistributable`             | Creates an application image with bundled JDK & resources
+ `runDistributable`                | `runReleaseDistributable`                | Runs an application image with bundled JDK & resources
+ `run`                             | `runRelease`                             | Runs a non-packaged application `jar` using Gradle JDK
+ `package<FORMAT_NAME>`            | `packageRelease<FORMAT_NAME>`            | Packages an application image into a `<FORMAT_NAME>` file
+ `packageDistributionForCurrentOS` | `packageReleaseDistributionForCurrentOS` | Packages an application image into a format compatible with current OS
+ `packageUberJarForCurrentOS`      | `packageReleaseUberJarForCurrentOS`      | Packages an application image into an uber (fat) JAR
+ `notarize<FORMAT_NAME>`           | `notarizeRelease<FORMAT_NAME>`           | Uploads a `<FORMAT_NAME>` application image for notarization (macOS only)
+ `checkNotarizationStatus`         | `checkReleaseNotarizationStatus`         | Checks if notarization succeeded (macOS only)
 
 The default configuration adds a few ProGuard rules:
 * an application image is minified, i.e. non-used classes are removed;
@@ -646,6 +647,18 @@ compose.desktop {
     application {
         buildTypes.release.proguard {
             optimize.set(false)
+        }
+    }
+}
+```
+
+Joining to the uber JAR is disabled by default - ProGuard produces the corresponding JAR for every input JAR.
+To enable it, set the following property via Gradle DSL:
+```
+compose.desktop {
+    application {
+        buildTypes.release.proguard {
+            joinOutputJars.set(true)
         }
     }
 }

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -596,16 +596,15 @@ that is developed by [Guardsquare](https://www.guardsquare.com/).
 
 The Gradle plugin provides a *release* task for each corresponding *default* packaging task:
 
- Default task (w/o ProGuard)       | Release task (w. ProGuard)               | Description
------------------------------------|------------------------------------------|--------------------------------------------------------------------------
- `createDistributable`             | `createReleaseDistributable`             | Creates an application image with bundled JDK & resources
- `runDistributable`                | `runReleaseDistributable`                | Runs an application image with bundled JDK & resources
- `run`                             | `runRelease`                             | Runs a non-packaged application `jar` using Gradle JDK
- `package<FORMAT_NAME>`            | `packageRelease<FORMAT_NAME>`            | Packages an application image into a `<FORMAT_NAME>` file
- `packageDistributionForCurrentOS` | `packageReleaseDistributionForCurrentOS` | Packages an application image into a format compatible with current OS
- `packageUberJarForCurrentOS`      | `packageReleaseUberJarForCurrentOS`      | Packages an application image into an uber (fat) JAR
- `notarize<FORMAT_NAME>`           | `notarizeRelease<FORMAT_NAME>`           | Uploads a `<FORMAT_NAME>` application image for notarization (macOS only)
- `checkNotarizationStatus`         | `checkReleaseNotarizationStatus`         | Checks if notarization succeeded (macOS only)
+Default task (w/o ProGuard)| Release task (w. ProGuard)       |Description
+---------------------------|----------------------------------|-----------
+`createDistributable`      | `createReleaseDistributable`     |Creates an application image with bundled JDK & resources
+`runDistributable`         | `runReleaseDistributable`        |Runs an application image with bundled JDK & resources
+`run`                      | `runRelease`                     |Runs a non-packaged application `jar` using Gradle JDK
+`package<FORMAT_NAME>`     | `packageRelease<FORMAT_NAME>`    |Packages an application image into a `<FORMAT_NAME>` file
+`packageForCurrentOS`      | `packageReleaseForCurrentOS`     |Packages an application image into a format compatible with current OS
+`notarize<FORMAT_NAME>`    | `notarizeRelease<FORMAT_NAME>`   |Uploads a `<FORMAT_NAME>` application image for notarization (macOS only)
+`checkNotarizationStatus`  | `checkReleaseNotarizationStatus` |Checks if notarization succeeded (macOS only)
 
 The default configuration adds a few ProGuard rules:
 * an application image is minified, i.e. non-used classes are removed;
@@ -647,18 +646,6 @@ compose.desktop {
     application {
         buildTypes.release.proguard {
             optimize.set(false)
-        }
-    }
-}
-```
-
-Joining to the uber JAR is disabled by default - ProGuard produces the corresponding JAR for every input JAR.
-To enable it, set the following property via Gradle DSL:
-```
-compose.desktop {
-    application {
-        buildTypes.release.proguard {
-            joinOutputJars.set(true)
         }
     }
 }


### PR DESCRIPTION
## Proposed changes
1. Added support to join JARs to the uber JAR with ProGuard, disabled by default:
```
compose.desktop {
    application {
        buildTypes.release.proguard {
            joinOutputJars.set(true)
        }
    }
}
```
2. All 'release' tasks now really depend on ProGuard, as stated in [tutorial](https://github.com/JetBrains/compose-multiplatform/tree/master/tutorials/Native_distributions_and_local_execution#minification--obfuscation).

## Testing
- A new auto test

- Manual:
1. Test on Windows/macOs/Linux
2. Test the new Gradle parameter `joinOutputJars`:
```
compose.desktop {
    application {
        buildTypes.release.proguard {
            joinOutputJars.set(true)
        }
    }
}
```
`false` (by default) should generate multiple jars (except for `package*UberJarForCurrentOS`)
`true` should generate a single jar in a result distribution
3. Test debug tasks:
```
run
runDistributable
createDistributable
packageUberJarForCurrentOS
```
4. Test release tasks:
```
runRelease
runReleaseDistributable
createReleaseDistributable
packageReleaseUberJarForCurrentOS
```
The jars should be reduced in size (because Proguard is enabled in the release mode)

This should be test by QA.

## Issues fixed
Fixes https://github.com/JetBrains/compose-multiplatform/issues/4129