### PR TITLE
build(kn-performance): use compose 1.5.10 to fix the build

### DIFF
--- a/benchmarks/kn-performance/gradle.properties
+++ b/benchmarks/kn-performance/gradle.properties
@@ -1,4 +1,4 @@
-compose.version=1.5.1
+compose.version=1.5.10
 kotlin.version=1.9.20
 org.gradle.jvmargs=-Xmx3g
 kotlin.native.useEmbeddableCompilerJar=true


### PR DESCRIPTION
Error: Compose Multiplatform 1.5.1 doesn't support Kotlin 1.9.20.