### PR TITLE
Accumulate characters when parsing xml element

### DIFF
--- a/components/resources/library/src/nativeMain/kotlin/org/jetbrains/compose/resources/vector/xmldom/DomXmlParser.kt
+++ b/components/resources/library/src/nativeMain/kotlin/org/jetbrains/compose/resources/vector/xmldom/DomXmlParser.kt
@@ -94,7 +94,10 @@ private class DomXmlParser : NSObject(), NSXMLParserDelegateProtocol {
     }
 
     override fun parser(parser: NSXMLParser, foundCharacters: String) {
-        nodeStack.lastOrNull()?.textContent = foundCharacters
+        nodeStack.lastOrNull()?.let { node ->
+            node.textContent = node.textContent?.let { it + foundCharacters }
+                ?: foundCharacters
+        }
     }
 
     override fun parser(


### PR DESCRIPTION
Documentation for [XmlParserDelegate](https://developer.apple.com/documentation/foundation/xmlparserdelegate/1412539-parser) says that `parser(_:foundCharacters:)` may be called multiple times with only a part of the element.

This seems to occurs with accentuated characters in the element like :
```
    <string name="lbl_create_room">Créer une table</string>
```
Before this change this will return `éer une table` instead of `Créer une table`
