### PR TITLE
Add possibility to modify the macOs minimum version

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -26,6 +26,7 @@ abstract class AbstractMacOSPlatformSettings : AbstractPlatformSettings() {
     var dmgPackageVersion: String? = null
     var dmgPackageBuildVersion: String? = null
     var appCategory: String? = null
+    var minimumSystemVersion: String? = null
 
 
     /**

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -393,6 +393,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 )
                 packageTask.macAppStore.set(mac.appStore)
                 packageTask.macAppCategory.set(mac.appCategory)
+                packageTask.macMinimumSystemVersion.set(mac.minimumSystemVersion)
                 val defaultEntitlements = defaultResources.get { defaultEntitlements }
                 packageTask.macEntitlementsFile.set(mac.entitlementsFile.orElse(defaultEntitlements))
                 packageTask.macRuntimeEntitlementsFile.set(mac.runtimeEntitlementsFile.orElse(defaultEntitlements))

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -162,6 +162,10 @@ abstract class AbstractJPackageTask @Inject constructor(
     @get:Optional
     val macAppCategory: Property<String?> = objects.nullableProperty()
 
+    @get:Input
+    @get:Optional
+    val macMinimumSystemVersion: Property<String?> = objects.nullableProperty()
+
     @get:InputFile
     @get:Optional
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
@@ -499,11 +503,12 @@ abstract class AbstractJPackageTask @Inject constructor(
                 .writeToFile(jpackageResources.ioFile.resolve("Info.plist"))
 
             if (macAppStore.orNull == true) {
+                val systemVersion = macMinimumSystemVersion.orNull ?: "10.13"
                 val productDefPlistXml = """
-                    <key>os</key>
-                    <array>
-                        <string>10.13</string>
-                    </array>
+                <key>os</key>
+                <array>
+                <string>$systemVersion</string>
+                </array>
                 """.trimIndent()
                 InfoPlistBuilder(productDefPlistXml)
                     .writeToFile(jpackageResources.ioFile.resolve("product-def.plist"))
@@ -581,7 +586,8 @@ abstract class AbstractJPackageTask @Inject constructor(
     private fun setInfoPlistValues(plist: InfoPlistBuilder) {
         check(currentOS == OS.MacOS) { "Current OS is not macOS: $currentOS" }
 
-        plist[PlistKeys.LSMinimumSystemVersion] = "10.13"
+        val systemVersion = macMinimumSystemVersion.orNull ?: "10.13"
+        plist[PlistKeys.LSMinimumSystemVersion] = systemVersion
         plist[PlistKeys.CFBundleDevelopmentRegion] = "English"
         plist[PlistKeys.CFBundleAllowMixedLocalizations] = "true"
         val packageName = packageName.get()

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
@@ -39,6 +39,10 @@ abstract class AbstractNativeMacApplicationPackageAppDirTask : AbstractNativeMac
     @get:Optional
     val copyright: Property<String?> = objects.nullableProperty()
 
+    @get:Input
+    @get:Optional
+    val minimumSystemVersion: Property<String?> = objects.nullableProperty()
+
     override fun createPackage(destinationDir: File, workingDir: File) {
         val packageName = packageName.get()
         val appDir = destinationDir.resolve("$packageName.app").apply { mkdirs() }
@@ -60,7 +64,7 @@ abstract class AbstractNativeMacApplicationPackageAppDirTask : AbstractNativeMac
     }
 
     private fun InfoPlistBuilder.setupInfoPlist(executableName: String) {
-        this[PlistKeys.LSMinimumSystemVersion] = KOTLIN_NATIVE_MIN_SUPPORTED_MAC_OS
+        this[PlistKeys.LSMinimumSystemVersion] = minimumSystemVersion.getOrElse(KOTLIN_NATIVE_MIN_SUPPORTED_MAC_OS)
         this[PlistKeys.CFBundleDevelopmentRegion] = "English"
         this[PlistKeys.CFBundleAllowMixedLocalizations] = "true"
         this[PlistKeys.CFBundleExecutable] = executableName

--- a/gradle-plugins/compose/src/test/test-projects/application/macOptions/Expected-Info.plist
+++ b/gradle-plugins/compose/src/test/test-projects/application/macOptions/Expected-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
  <dict>
   <key>LSMinimumSystemVersion</key>
-  <string>10.13</string>
+  <string>12.0</string>
   <key>CFBundleDevelopmentRegion</key>
   <string>English</string>
   <key>CFBundleAllowMixedLocalizations</key>

--- a/gradle-plugins/compose/src/test/test-projects/application/macOptions/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/macOptions/build.gradle
@@ -30,6 +30,7 @@ compose.desktop {
             packageName = "TestPackage"
             macOS {
                 dockName = "CustomDockName"
+                minimumSystemVersion = "12.0"
                 infoPlist {
                     extraKeysRawXml = extraInfoPlistKeys
                 }

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -442,6 +442,8 @@ The following platform-specific options are available
     * `packageName` — a name of the application;
     * `dockName` — a name of the application displayed in the menu bar, the "About <App>" menu item, in the dock, etc. 
       Equals to `packageName` by default.
+    * `minimumSystemVersion` — a minimum macOS version required to run the application.
+      See [LSMinimumSystemVersion](https://developer.apple.com/documentation/bundleresources/information_property_list/lsminimumsystemversion) for details;
     * `signing`, `notarization`, `provisioningProfile`, and `runtimeProvisioningProfile` — see
       [the corresponding tutorial](/tutorials/Signing_and_notarization_on_macOS/README.md) 
       for details;


### PR DESCRIPTION
Hi all 👋 

I recently tried to publish my macOS app to the App Store and the publishing failed because I wasn't including an Intel version
<img width="609" alt="Screenshot 2024-02-04 at 17 31 52" src="https://github.com/JetBrains/compose-multiplatform/assets/9467705/a3f421ed-ca77-460b-bc2e-7ceafb3ca1c0">

The alternative could be publishing a Universal binary, but it's not quite supported now (see #1599). But by setting the minimum version of macOS to 12, it's possible to upload only arm version.

So, I've added the possibility of changing the minimum macOS version.
