### PR TITLE
Gradle Plugin: Force kotlinx-coroutines version 1.8.0-RC2 for web targets in user projects

### DIFF
--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -204,16 +204,3 @@ afterEvaluate {
         if (name == "compileWebMainKotlinMetadata") enabled = false
     }
 }
-
-// TODO: remove this (https://youtrack.jetbrains.com/issue/COMPOSE-939)
-configurations.all {
-    val isWeb = name.startsWith("wasmJs") || name.startsWith("js")
-    if (isWeb) {
-        resolutionStrategy.eachDependency {
-            if (requested.group.startsWith("org.jetbrains.kotlinx") &&
-                requested.name.startsWith("kotlinx-coroutines-")) {
-                useVersion("1.8.0-RC2")
-            }
-        }
-    }
-}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -87,6 +87,23 @@ abstract class ComposePlugin : Plugin<Project> {
 
             disableSignatureClashCheck(project)
         }
+
+        // TODO: remove this (https://youtrack.jetbrains.com/issue/COMPOSE-939)
+        // we substitute the coroutines version for web targets in user projects,
+        // so they don't need to do that manually
+        project.configurations.all {
+            val isWeb = it.name.startsWith("wasmJs") || it.name.startsWith("js")
+            if (isWeb) {
+                it.resolutionStrategy.eachDependency {
+                    if (it.requested.group.startsWith("org.jetbrains.kotlinx") &&
+                        it.requested.name.startsWith("kotlinx-coroutines-")) {
+                        if (it.requested.version?.startsWith("1.8") != true) {
+                            it.useVersion("1.8.0-RC2")
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun disableSignatureClashCheck(project: Project) {


### PR DESCRIPTION
Removed such the version substituion from the resources library. The versions will be subtituted now by gradle plugin.