### PR TITLE
Fix Gradle MPP tests (android.useAndroidX)

### DIFF
--- a/gradle-plugins/compose/src/test/test-projects/application/mpp/gradle.properties
+++ b/gradle-plugins/compose/src/test/test-projects/application/mpp/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
It fails with:
```
Configuration `:jvmRuntimeClasspath` contains AndroidX dependencies, but the `android.useAndroidX` property is not enabled, which may cause runtime issues.

  :jvmRuntimeClasspath -> org.jetbrains.compose.desktop:desktop-jvm-linux-x64:0.0.0-dev1418 -> org.jetbrains.compose.desktop:desktop:0.0.0-dev1418 -> org.jetbrains.compose.desktop:desktop-jvm:0.0.0-dev1418 -> org.jetbrains.compose.material:material:0.0.0-dev1418 -> org.jetbrains.compose.material:material-desktop:0.0.0-dev1418 -> org.jetbrains.compose.annotation-internal:annotation:0.0.0-dev1418 -> androidx.annotation:annotation:1.7.1
  :jvmRuntimeClasspath -> org.jetbrains.compose.desktop:desktop-jvm-linux-x64:0.0.0-dev1418 -> org.jetbrains.compose.desktop:desktop:0.0.0-dev1418 -> org.jetbrains.compose.desktop:desktop-jvm:0.0.0-dev1418 -> org.jetbrains.compose.material:material:0.0.0-dev1418 -> org.jetbrains.compose.material:material-desktop:0.0.0-dev1418 -> org.jetbrains.compose.annotation-internal:annotation:0.0.0-dev1418 -> androidx.annotation:annotation:1.7.1 -> androidx.annotation:annotation-jvm:1.7.1
  :jvmRuntimeClasspath -> org.jetbrains.compose.desktop:desktop-jvm-linux-x64:0.0.0-dev1418 -> org.jetbrains.compose.desktop:desktop:0.0.0-dev1418 -> org.jetbrains.compose.desktop:desktop-jvm:0.0.0-dev1418 -> org.jetbrains.compose.foundation:foundation:0.0.0-dev1418 -> org.jetbrains.compose.foundation:foundation-desktop:0.0.0-dev1418 -> org.jetbrains.compose.collection-internal:collection:0.0.0-dev1418 -> androidx.collection:collection:1.4.0
  :jvmRuntimeClasspath -> org.jetbrains.compose.desktop:desktop-jvm-linux-x64:0.0.0-dev1418 -> org.jetbrains.compose.desktop:desktop:0.0.0-dev1418 -> org.jetbrains.compose.desktop:desktop-jvm:0.0.0-dev1418 -> org.jetbrains.compose.foundation:foundation:0.0.0-dev1418 -> org.jetbrains.compose.foundation:foundation-desktop:0.0.0-dev1418 -> org.jetbrains.compose.collection-internal:collection:0.0.0-dev1418 -> androidx.collection:collection:1.4.0 -> androidx.collection:collection-jvm:1.4.0
```
(https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_All_2/4484004?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true&expandBuildDeploymentsSection=false&expandBuildProblemsSection=true)

after we added annotation/collection to desktop target dependencies.

It seems that Android plugin checks all JVM classpathes, including pure JVM (desktop) ones. And fails, if the project doesn't have this property.

Adding this property, as the Android fails without it as well.