### PR TITLE
Fix package name of generated `Res` file when project is building for JsTarget (#4295)

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesGenerator.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesGenerator.kt
@@ -124,7 +124,7 @@ private fun Project.configureResourceGenerator(commonComposeResourcesDir: File, 
             val group = project.group.toString().lowercase().asUnderscoredIdentifier()
             append(group)
             if (group.isNotEmpty()) append(".")
-            append(project.name.lowercase())
+            append(project.name.lowercase().asUnderscoredIdentifier())
             append(".generated.resources")
         }
     }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -341,4 +341,22 @@ class ResourcesTest : GradlePluginTestBase() {
             .map { it.toPath().relativeTo(actualPath) }.sorted().joinToString("\n")
         assertEquals(expectedFilesCount, actualFilesCount)
     }
+
+    @Test
+    fun `test package name with hyphens is replaced by underscores`(): Unit = with(testProject("misc/commonResources")) {
+        modifyText("settings.gradle.kts") { str ->
+            str.replace(
+                "rootProject.name = \"resources_test\"",
+                "rootProject.name = \"resources-test\""
+            )
+        }
+        gradle("generateComposeResClass").checks {
+            check.taskSuccessful(":generateComposeResClass")
+            assertTrue(file("settings.gradle.kts").readText().contains("rootProject.name = \"resources-test\""))
+            assertEqualTextFiles(
+                file("build/generated/compose/resourceGenerator/kotlin/app/group/resources_test/generated/resources/Res.kt"),
+                file("expected/Res.kt")
+            )
+        }
+    }
 }


### PR DESCRIPTION
Fix package name of generated `Res` file when project is building for JsTarget (#4295)