### PR TITLE
Fix package name of generated Res file when project is building for JsTarget (#4295)

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesGenerator.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesGenerator.kt
@@ -124,7 +124,7 @@ private fun Project.configureResourceGenerator(commonComposeResourcesDir: File, 
             val group = project.group.toString().lowercase().asUnderscoredIdentifier()
             append(group)
             if (group.isNotEmpty()) append(".")
-            append(project.name.lowercase())
+            append(project.name.lowercase().asUnderscoredIdentifier())
             append(".generated.resources")
         }
     }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -179,7 +179,7 @@ class ResourcesTest : GradlePluginTestBase() {
             checkAndroidApk("full", "debug", commonResourcesFiles)
             checkAndroidApk("full", "release", commonResourcesFiles)
 
-            val desktopJar = file("build/libs/resources_test-desktop.jar")
+            val desktopJar = file("build/libs/Resources-Test-desktop.jar")
             assertTrue(desktopJar.exists())
             ZipFile(desktopJar).use { zip ->
                 commonResourcesFiles.forEach { res ->
@@ -206,7 +206,7 @@ class ResourcesTest : GradlePluginTestBase() {
     }
 
     private fun TestProject.checkAndroidApk(flavor: String, type: String, commonResourcesFiles: Sequence<String>) {
-        val apk = file("build/outputs/apk/$flavor/$type/resources_test-$flavor-$type.apk")
+        val apk = file("build/outputs/apk/$flavor/$type/Resources-Test-$flavor-$type.apk")
         assertTrue(apk.exists())
         ZipFile(apk).use { zip ->
             commonResourcesFiles.forEach { res ->

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "resources_test"
+rootProject.name = "Resources-Test"
 pluginManagement {
     repositories {
         mavenLocal()


### PR DESCRIPTION
Origin: https://github.com/JetBrains/compose-multiplatform/pull/4296