### PR TITLE
Prevent forUseAtConfigurationTimeSafe deprecation warning

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
@@ -36,7 +36,10 @@ internal fun ProviderFactory.valueOrNull(prop: String): Provider<String?> =
     }
 
 private fun Provider<String?>.forUseAtConfigurationTimeSafe(): Provider<String?> =
-    try {
+    // https://docs.gradle.org/current/userguide/upgrading_version_7.html
+    if (org.gradle.util.GradleVersion.current() >= org.gradle.util.GradleVersion.version("8.0")) {
+        this
+    } else try {
         forUseAtConfigurationTime()
     } catch (e: NoSuchMethodError) {
         // todo: remove once we drop support for Gradle 6.4


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3945

This became deprecated in Gradle 8.0. So just checks to see if gradle is 8.0 or higher and if so does not call it. (the gradle changelog says "Clients should simply remove the call.")