### PR TITLE
[resources] Fix Res class generation if the library is declared as 'api'

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesGenerator.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesGenerator.kt
@@ -140,12 +140,14 @@ private fun Project.configureResourceGenerator(commonComposeResourcesDir: File, 
         if (ComposeProperties.alwaysGenerateResourceAccessors(project).get()) {
             true
         } else {
-            configurations
-                .getByName(commonSourceSet.implementationConfigurationName)
-                .allDependencies.any { dep ->
-                    val depStringNotation = dep.let { "${it.group}:${it.name}:${it.version}" }
-                    depStringNotation == ComposePlugin.CommonComponentsDependencies.resources
-                }
+            configurations.run {
+                //because the implementation configuration doesn't extend the api in the KGP ¯\_(ツ)_/¯
+                getByName(commonSourceSet.implementationConfigurationName).allDependencies +
+                        getByName(commonSourceSet.apiConfigurationName).allDependencies
+            }.any { dep ->
+                val depStringNotation = dep.let { "${it.group}:${it.name}:${it.version}" }
+                depStringNotation == ComposePlugin.CommonComponentsDependencies.resources
+            }
         }
     }
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -237,8 +237,8 @@ class ResourcesTest : GradlePluginTestBase() {
 
         modifyText("build.gradle.kts") { str ->
             str.replace(
-                "implementation(compose.components.resources)",
-                "//implementation(compose.components.resources)"
+                "api(compose.components.resources)",
+                "//api(compose.components.resources)"
             )
         }
         gradle("prepareKotlinIdeaImport").checks {
@@ -253,8 +253,8 @@ class ResourcesTest : GradlePluginTestBase() {
 
         modifyText("build.gradle.kts") { str ->
             str.replace(
-                "//implementation(compose.components.resources)",
-                "implementation(compose.components.resources)"
+                "//api(compose.components.resources)",
+                "api(compose.components.resources)"
             )
         }
         gradle("prepareKotlinIdeaImport").checks {

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/build.gradle.kts
@@ -21,7 +21,9 @@ kotlin {
             dependencies {
                 implementation(compose.runtime)
                 implementation(compose.material)
-                implementation(compose.components.resources)
+                //there is the api to check correctness of the api configuration
+                //https://github.com/JetBrains/compose-multiplatform/issues/4405
+                api(compose.components.resources)
             }
         }
     }


### PR DESCRIPTION
fixes https://github.com/JetBrains/compose-multiplatform/issues/4405