### PR TITLE
Make desktop preview task fully configuration cache compliant

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/internal/configurePreview.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/internal/configurePreview.kt
@@ -34,6 +34,7 @@ private fun registerConfigurePreviewTask(
     ) { previewTask ->
         runtimeFiles.configureUsageBy(previewTask) { (runtimeJars, _) ->
             previewClasspath = runtimeJars
+            skikoRuntime = tryGetSkikoRuntimeIfNeeded()
         }
     }
 }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -322,9 +322,9 @@ class GradlePluginTest : GradlePluginTestBase() {
             connectionThread.join(5000)
         }
 
-        val expectedReceivedConfigCount = 2
+        val expectedReceivedConfigCount = 3
         val actualReceivedConfigCount = receivedConfigCount.get()
-        check(actualReceivedConfigCount == 2) {
+        check(actualReceivedConfigCount == expectedReceivedConfigCount) {
             "Expected to receive $expectedReceivedConfigCount preview configs, got $actualReceivedConfigCount"
         }
     }
@@ -342,6 +342,11 @@ class GradlePluginTest : GradlePluginTestBase() {
             val mppTask = ":mpp:configureDesktopPreviewDesktop"
             gradle(mppTask, portProperty, previewTargetProperty).checks {
                 check.taskSuccessful(mppTask)
+            }
+
+            val commonTask = ":common:configureDesktopPreviewDesktop"
+            gradle(commonTask, portProperty, previewTargetProperty).checks {
+                check.taskSuccessful(commonTask)
             }
         }
     }

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmPreview/common/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmPreview/common/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'org.jetbrains.kotlin.multiplatform'
+    id 'org.jetbrains.compose'
+}
+
+kotlin {
+    jvm('desktop') {}
+
+    sourceSets {
+        commonMain.dependencies {
+            api compose.runtime
+            api compose.foundation
+            api compose.material
+            api compose.uiTooling
+        }
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmPreview/common/src/commonMain/kotlin/composable.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmPreview/common/src/commonMain/kotlin/composable.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020-2021 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+import androidx.compose.material.Text
+import androidx.compose.material.Button
+import androidx.compose.runtime.*
+
+@Composable
+fun ExampleComposable() {
+    var text by remember { mutableStateOf("Hello, World!") }
+
+    Button(onClick = {
+        text = "Hello, $platformName!"
+    }) {
+        Text(text)
+    }
+}
+
+val platformName: String = "Desktop"

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmPreview/common/src/commonMain/kotlin/preview.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmPreview/common/src/commonMain/kotlin/preview.kt
@@ -1,0 +1,8 @@
+import androidx.compose.runtime.Composable
+import androidx.compose.desktop.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+fun ExamplePreview() {
+    ExampleComposable()
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmPreview/settings.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmPreview/settings.gradle
@@ -13,4 +13,4 @@ pluginManagement {
     }
 }
 rootProject.name = 'jvmPreview'
-include(':jvm', ':mpp')
+include(':common', ':jvm', ':mpp')


### PR DESCRIPTION
The issue was in a case where there wasn't a direct dependency on the skiko artifact, the task would attempt to get one at task execution time. This moves that to task configuration time.