### PR TITLE
Refactor composable-test-cases to get rid of dependency on compose-multiplatform-gradle-plugin

### DIFF
--- a/compose/integrations/composable-test-cases/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/build.gradle.kts
@@ -1,3 +1,4 @@
+import internal.InternalComposeSupportPlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 
@@ -13,15 +14,21 @@ allprojects {
         // mavenLocal()
     }
 
+    this.apply<InternalComposeSupportPlugin>()
+
     afterEvaluate {
+        val pluginOptionPrefix = "plugin:androidx.compose.compiler.plugins.kotlin:"
         val project = this
-        val compilerPluginVersion = project.properties["compose.kotlinCompilerPluginVersion"] as? String
         val kotlinVersion = project.properties["kotlin.version"] as? String
-        project.extensions.findByType<org.jetbrains.compose.ComposeExtension>()?.also {
-            if (!compilerPluginVersion.isNullOrEmpty()) {
-                println("${project.name} is using compilerPluginVersion = $compilerPluginVersion")
-                it.kotlinCompilerPlugin.set(compilerPluginVersion)
-                it.kotlinCompilerPluginArgs.add("suppressKotlinVersionCompatibilityCheck=$kotlinVersion")
+
+        project.tasks.withType(KotlinCompile::class.java).configureEach {
+            kotlinOptions.apply {
+                freeCompilerArgs +=
+                    listOf(
+                        "-P",
+                        "${pluginOptionPrefix}suppressKotlinVersionCompatibilityCheck=$kotlinVersion"
+                    )
+
             }
         }
 
@@ -40,7 +47,6 @@ allprojects {
 
 plugins {
     kotlin("multiplatform") apply false
-    id("org.jetbrains.compose") apply false
 }
 
 fun Project.disableYarnLockMismatchReport() {

--- a/compose/integrations/composable-test-cases/buildSrc/src/main/kotlin/internal/ComposeCompilerArtifactProvider.kt
+++ b/compose/integrations/composable-test-cases/buildSrc/src/main/kotlin/internal/ComposeCompilerArtifactProvider.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package internal
+
+import internal.ComposeCompilerArtifactProvider.DefaultCompiler.pluginArtifact
+import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
+
+// Partially copy-pasted from https://github.com/JetBrains/compose-multiplatform/tree/master/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose
+internal class ComposeCompilerArtifactProvider(
+    private val customPluginString: () -> String
+) {
+    val compilerArtifact: SubpluginArtifact by lazy {
+        val customPlugin = customPluginString()
+        val customCoordinates = customPlugin.split(":")
+        when (customCoordinates.size) {
+            1 -> {
+                val customVersion = customCoordinates[0]
+                check(customVersion.isNotBlank()) { "'compose.kotlinCompilerPlugin' cannot be blank!" }
+                pluginArtifact(version = customVersion)
+            }
+            3 -> pluginArtifact(
+                version = customCoordinates[2],
+                groupId = customCoordinates[0],
+                artifactId = customCoordinates[1],
+            )
+            else -> error("""
+                        Illegal format of 'compose.kotlinCompilerPlugin' property.
+                        Expected format: either '<VERSION>' or '<GROUP_ID>:<ARTIFACT_ID>:<VERSION>'
+                        Actual value: '$customPlugin'
+                """.trimIndent())
+        }
+    }
+
+    val compilerHostedArtifact: SubpluginArtifact
+        get() = compilerArtifact.run {
+            val newArtifactId =
+                if (groupId == DefaultCompiler.GROUP_ID && artifactId == DefaultCompiler.ARTIFACT_ID) {
+                    DefaultCompiler.HOSTED_ARTIFACT_ID
+                } else artifactId
+
+            copy(artifactId = newArtifactId)
+        }
+
+    internal object DefaultCompiler {
+        const val GROUP_ID = "org.jetbrains.compose.compiler"
+        const val ARTIFACT_ID = "compiler"
+        const val HOSTED_ARTIFACT_ID = "compiler-hosted"
+
+        fun pluginArtifact(
+            version: String,
+            groupId: String = GROUP_ID,
+            artifactId: String = ARTIFACT_ID,
+        ): SubpluginArtifact =
+            SubpluginArtifact(groupId = groupId, artifactId = artifactId, version = version)
+    }
+}
+
+internal fun SubpluginArtifact.copy(
+    groupId: String? = null,
+    artifactId: String? = null,
+    version: String? = null
+): SubpluginArtifact =
+    SubpluginArtifact(
+        groupId = groupId ?: this.groupId,
+        artifactId = artifactId ?: this.artifactId,
+        version = version ?: this.version
+    )

--- a/compose/integrations/composable-test-cases/buildSrc/src/main/kotlin/internal/InternalComposeSupportPlugin.kt
+++ b/compose/integrations/composable-test-cases/buildSrc/src/main/kotlin/internal/InternalComposeSupportPlugin.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020-2021 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package internal
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.plugin.*
+
+// Partially copy-pasted from https://github.com/JetBrains/compose-multiplatform/tree/master/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose
+class InternalComposeSupportPlugin : KotlinCompilerPluginSupportPlugin {
+    private lateinit var composeCompilerArtifactProvider: ComposeCompilerArtifactProvider
+
+    override fun apply(target: Project) {
+        super.apply(target)
+
+        val composeCompilerVersion = target.properties["compose.kotlinCompilerPluginVersion"] as? String
+            ?: error("'compose.kotlinCompilerPluginVersion' is not defined")
+        composeCompilerArtifactProvider = ComposeCompilerArtifactProvider { composeCompilerVersion }
+    }
+
+    override fun getCompilerPluginId(): String = "androidx.compose.compiler.plugins.kotlin"
+
+    override fun getPluginArtifact(): SubpluginArtifact =
+        composeCompilerArtifactProvider.compilerArtifact
+
+    override fun getPluginArtifactForNative(): SubpluginArtifact =
+        composeCompilerArtifactProvider.compilerHostedArtifact
+
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
+
+    override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
+        val target = kotlinCompilation.target
+        return target.project.provider { emptyList() }
+    }
+
+    private fun options(vararg options: Pair<String, String>): List<SubpluginOption> =
+        options.map { SubpluginOption(it.first, it.second) }
+}
+
+val Project.composeVersion: String
+    get() = properties["compose.version"] as? String
+        ?: error("'compose.version' is not defined")
+
+val Project.composeRuntimeDependency: String
+    get() = properties["compose.runtime.artifactId"] as? String
+        ?: properties["compose.runtime.groupId"]?.let { it.toString() + ":runtime:$composeVersion" }
+        ?: "org.jetbrains.compose.runtime:runtime:${composeVersion}"

--- a/compose/integrations/composable-test-cases/common/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/common/build.gradle.kts
@@ -1,6 +1,7 @@
+import internal.composeRuntimeDependency
+
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 group = "com.example"
@@ -12,7 +13,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
+                api(project.composeRuntimeDependency)
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
             }
         }

--- a/compose/integrations/composable-test-cases/gradle.properties
+++ b/compose/integrations/composable-test-cases/gradle.properties
@@ -3,7 +3,11 @@ kotlin.code.style=official
 android.useAndroidX=true
 kotlin.version=1.9.22
 agp.version=7.3.0
+
+# a version of compose libraries. In this project the only dependency is compose-runtime.
 compose.version=1.6.0-rc03
+# a group id for compose-runtime. Keep it as a parameter to easily change it on CI.
+compose.runtime.groupId=org.jetbrains.compose.runtime
 
 kotlinx.coroutines.version=1.8.0
 

--- a/compose/integrations/composable-test-cases/settings.gradle.kts
+++ b/compose/integrations/composable-test-cases/settings.gradle.kts
@@ -7,10 +7,6 @@ pluginManagement {
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
         mavenLocal()
     }
-
-    plugins {
-        id("org.jetbrains.compose").version(extra["compose.version"] as String)
-    }
 }
 
 rootProject.name = "composable-test-cases"

--- a/compose/integrations/composable-test-cases/testcases/anonymousObjects/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/anonymousObjects/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/anonymousObjects/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/anonymousObjects/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }

--- a/compose/integrations/composable-test-cases/testcases/constructors/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/constructors/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/constructors/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/constructors/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }

--- a/compose/integrations/composable-test-cases/testcases/expectActual/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/expectActual/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/expectActual/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/expectActual/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }

--- a/compose/integrations/composable-test-cases/testcases/inheritance/composableInterface/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/inheritance/composableInterface/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/inheritance/composableInterface/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/inheritance/composableInterface/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }

--- a/compose/integrations/composable-test-cases/testcases/inheritance/funInterface/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/inheritance/funInterface/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/inheritance/funInterface/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/inheritance/funInterface/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }

--- a/compose/integrations/composable-test-cases/testcases/lambdas/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/lambdas/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/lambdas/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/lambdas/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }

--- a/compose/integrations/composable-test-cases/testcases/rememberAnonymousObj/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/rememberAnonymousObj/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/rememberAnonymousObj/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/rememberAnonymousObj/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }

--- a/compose/integrations/composable-test-cases/testcases/stability/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/stability/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/stability/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/stability/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }

--- a/compose/integrations/composable-test-cases/testcases/template/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/template/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/template/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/template/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }

--- a/compose/integrations/composable-test-cases/testcases/valueClass/lib/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/valueClass/lib/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
             }
         }

--- a/compose/integrations/composable-test-cases/testcases/valueClass/main/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/testcases/valueClass/main/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose")
 }
 
 kotlin {
@@ -9,7 +8,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(compose.runtime)
                 implementation(getCommonLib())
                 implementation(getLibDependencyForMain())
             }


### PR DESCRIPTION
This is a preparation to move these tests to kotlin project.