### PR TITLE
Imageviewer. Fix compilation of Android target

### DIFF
--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -72,6 +72,10 @@ android {
     defaultConfig {
         minSdk = 26
     }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
     kotlin {
         jvmToolchain(17)
     }


### PR DESCRIPTION
Fix regression after https://github.com/JetBrains/compose-multiplatform/pull/4433

`./gradlew compileReleaseKotlinAndroid` in `imageviewer` fails with:
```
* What went wrong:
Execution failed for task ':shared:compileReleaseKotlinAndroid'.
> Inconsistent JVM-target compatibility detected for tasks 'compileReleaseJavaWithJavac' (1.8) and 'compileReleaseKotlinAndroid' (17).
```
(JAVA_HOME points to JDK 17)