### PR TITLE
[resources] Fix regionCode crash on iOS before 17

### DIFF
--- a/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.ios.kt
+++ b/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.ios.kt
@@ -8,14 +8,16 @@ import platform.UIKit.UIUserInterfaceStyle
 internal actual fun getSystemEnvironment(): ResourceEnvironment {
     val locale = NSLocale.currentLocale()
 
+    val languageCode = locale.languageCode
+    val regionCode = locale.objectForKey(NSLocaleCountryCode) as? String
     val mainScreen = UIScreen.mainScreen
     val isDarkTheme = mainScreen.traitCollection().userInterfaceStyle == UIUserInterfaceStyle.UIUserInterfaceStyleDark
 
     //there is no an API to get a physical screen size and calculate a real DPI
     val density = mainScreen.scale.toFloat()
     return ResourceEnvironment(
-        language = LanguageQualifier(locale.languageCode),
-        region = RegionQualifier(locale.regionCode.orEmpty()),
+        language = LanguageQualifier(languageCode),
+        region = RegionQualifier(regionCode.orEmpty()),
         theme = ThemeQualifier.selectByValue(isDarkTheme),
         density = DensityQualifier.selectByDensity(density)
     )


### PR DESCRIPTION
The regionCode API
```
NSLocale.currentLocale().regionCode
```
was published in iOS 17: https://developer.apple.com/documentation/foundation/nslocale/4172868-regioncode?language=objc

to make it works on all iOS versions we have to use:
```
NSLocale.currentLocale().objectForKey(NSLocaleCountryCode) as? String
```

fixes https://github.com/JetBrains/compose-multiplatform/issues/4469