### PR TITLE
Provide a better message for erroneous values folder files

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
@@ -96,10 +96,14 @@ internal abstract class GenerateResClassTask : DefaultTask() {
             return null
         }
 
-        if (typeString == "values" && file.name.equals("strings.xml", true)) {
-            val stringIds = getStringIds(file)
-            return stringIds.map { strId ->
-                ResourceItem(ResourceType.STRING, qualifiers, strId.asUnderscoredIdentifier(), path)
+        if (typeString == "values") {
+            if (file.name.equals("strings.xml", true)) {
+                val stringIds = getStringIds(file)
+                return stringIds.map { strId ->
+                    ResourceItem(ResourceType.STRING, qualifiers, strId.asUnderscoredIdentifier(), path)
+                }
+            } else {
+                error("Forbidden file name '${file.name}'! Only a file for string resources named 'strings.xml' is valid in the 'values' folder.")
             }
         }
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -119,7 +119,21 @@ class ResourcesTest : GradlePluginTestBase() {
             )
         }
 
+        file("src/commonMain/composeResources/values/strings.xml").renameTo(
+            file("src/commonMain/composeResources/values/colors.xml")
+        )
+        gradle("generateComposeResClass").checks {
+            check.logContains(
+                """
+                Forbidden file name 'colors.xml'! Only a file for string resources named 'strings.xml' is valid in the 'values' folder.
+            """.trimIndent()
+            )
+        }
+
         //restore defaults
+        file("src/commonMain/composeResources/values/colors.xml").renameTo(
+            file("src/commonMain/composeResources/values/strings.xml")
+        )
         file("src/commonMain/composeResources/string-us").renameTo(
             file("src/commonMain/composeResources/drawable-en")
         )


### PR DESCRIPTION
The task generateComposeResClass created an error message that didn't help the user to understand the problem if files other than strings.xml were in the values folder. This fix improves on the message so that users can quickly fix the underlying issue.

The old message was "Unknown resource type: 'values'." But not values is the problem, but a file like - in my case - colors.xml which I copied from an existing Android project (well, yeah, I shouldn't have done that, but anyway, the message was not helpful).

The new message would be "Forbidden file name 'colors.xml'! Only a file for string resources named 'strings.xml' is valid in the 'values' folder." I also added a check for this in the ResourcesTest's `testGeneratedAccessors()` method.