### PR TITLE
[resources] Use first of preferred locales instead of a current on iOS

### DIFF
--- a/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.ios.kt
+++ b/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.ios.kt
@@ -6,7 +6,9 @@ import platform.UIKit.UIUserInterfaceStyle
 
 @OptIn(InternalResourceApi::class)
 internal actual fun getSystemEnvironment(): ResourceEnvironment {
-    val locale = NSLocale.currentLocale()
+    val locale = NSLocale.preferredLanguages.firstOrNull()
+        ?.let { NSLocale(it as String) }
+        ?: NSLocale.currentLocale
 
     val languageCode = locale.languageCode
     val regionCode = locale.objectForKey(NSLocaleCountryCode) as? String


### PR DESCRIPTION
There is a bug on iOS:
```
NSLocale.currentLocale() -> 'en-US'
NSLocale.preferredLanguages().first().let { NSLocale(it as String) } -> 'ru'
```

An equal result was expected!
the first method was used in a non-compose code and another one in the compose code.
The PR fixes behavior in a non-compose environment.