### PR TITLE
[resources] Fix readResourceBytes function on Android if font is located under qualified directory

### DIFF
--- a/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/ResourceReader.android.kt
+++ b/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/ResourceReader.android.kt
@@ -10,7 +10,7 @@ actual suspend fun readResourceBytes(path: String): ByteArray {
     val classLoader = Thread.currentThread().contextClassLoader ?: AndroidResourceReader.javaClass.classLoader
     val resource = classLoader.getResourceAsStream(path) ?: run {
         //try to find a font in the android assets
-        if (File(path).parentFile?.name.orEmpty() == "font") {
+        if (File(path).parentFile?.name.orEmpty().startsWith("font")) {
             classLoader.getResourceAsStream("assets/$path")
         } else null
     } ?: throw MissingResourceException(path)


### PR DESCRIPTION
Fix the problem when users try to read a font bytes under a qualified directory.