### PR TITLE
Add option to disable compose resources generation

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesExtension.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesExtension.kt
@@ -17,17 +17,19 @@ abstract class ResourcesExtension {
      */
     var packageOfResClass: String = ""
 
-    enum class ResourceClassGeneration { Auto, Always }
+    enum class ResourceClassGeneration { Auto, Always, Never }
 
     //to support groovy DSL
     val auto = ResourceClassGeneration.Auto
     val always = ResourceClassGeneration.Always
+    val never = ResourceClassGeneration.Never
 
     /**
      * The mode of resource class generation.
      *
      * - `auto`: The Res class will be generated if the current project has an explicit "implementation" or "api" dependency on the resource's library.
      * - `always`: Unconditionally generate the Res class. This may be useful when the resources library is available transitively.
+     * - `never`: Never generate the Res class.
      */
     var generateResClass: ResourceClassGeneration = auto
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesGenerator.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesGenerator.kt
@@ -323,6 +323,9 @@ private fun Project.configureResourceGenerator(
             ResourcesExtension.ResourceClassGeneration.Always -> {
                 true
             }
+            ResourcesExtension.ResourceClassGeneration.Never -> {
+                false
+            }
         }
     }
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -511,4 +511,20 @@ class ResourcesTest : GradlePluginTestBase() {
             .map { it.toPath().relativeTo(actualPath) }.sorted().joinToString("\n")
         assertEquals(expectedFilesCount, actualFilesCount)
     }
+
+    @Test
+    fun testResourcesTaskDisabled() = with(testProject("misc/commonResources")) {
+        file("build.gradle.kts").appendText(
+            """
+                compose {
+                    resources {
+                        generateResClass = never
+                    }
+                }
+            """.trimIndent()
+        )
+        gradle("generateComposeResClass").checks {
+            check.logContains("Generation Res class is disabled")
+        }
+    }
 }


### PR DESCRIPTION
# Changes

* Add `Never` to `enum class ResourceClassGeneration` to disable the generation of Res class in the gradle plugin

# Motivation

As the [comment in issue 4229](https://github.com/JetBrains/compose-multiplatform/issues/4229#issuecomment-2008626808) said, my team is not in the ecosystem of gradle, but organize the build steps in bazel. We want to follow the files layout but just disable the generation task of gradle and handle it by outself.