### PR TITLE
Handle special characters for quantity strings

### DIFF
--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/StringResources.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/StringResources.kt
@@ -81,7 +81,7 @@ private suspend fun parseStringXml(path: String, resourceReader: ResourceReader)
             val pluralCategory = PluralCategory.fromString(
                 element.getAttribute("quantity"),
             ) ?: return@mapNotNull null
-            pluralCategory to element.textContent.orEmpty()
+            pluralCategory to handleSpecialCharacters(element.textContent.orEmpty())
         }
         pluralElement.getAttribute("name") to StringItem.Plurals(items.toMap())
     }


### PR DESCRIPTION
A follow-up PR for #4519, which handles special characters for quantity strings.