### PR TITLE
Get resource files as URI

### DIFF
--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceReader.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceReader.kt
@@ -14,9 +14,19 @@ class MissingResourceException(path: String) : Exception("Missing resource with 
 @InternalResourceApi
 suspend fun readResourceBytes(path: String): ByteArray = DefaultResourceReader.read(path)
 
+/**
+ * Provides the platform dependent URI for a given resource path.
+ *
+ * @param path The path to the file in the resource's directory.
+ * @return The URI string of the specified resource.
+ */
+@InternalResourceApi
+fun getResourceUri(path: String): String = DefaultResourceReader.getUri(path)
+
 internal interface ResourceReader {
     suspend fun read(path: String): ByteArray
     suspend fun readPart(path: String, offset: Long, size: Long): ByteArray
+    fun getUri(path: String): String
 }
 
 internal expect fun getPlatformResourceReader(): ResourceReader

--- a/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/TestResourceReader.kt
+++ b/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/TestResourceReader.kt
@@ -13,4 +13,8 @@ internal class TestResourceReader : ResourceReader {
         readPathsList.add("$path/$offset-$size")
         return DefaultResourceReader.readPart(path, offset, size)
     }
+
+    override fun getUri(path: String): String {
+        return DefaultResourceReader.getUri(path)
+    }
 }

--- a/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceReader.desktop.kt
+++ b/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceReader.desktop.kt
@@ -19,8 +19,19 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
     }
 
     @OptIn(ExperimentalResourceApi::class)
+    override fun getUri(path: String): String {
+        val classLoader = getClassLoader()
+        val resource = classLoader.getResource(path) ?: throw MissingResourceException(path)
+        return resource.toURI().toString()
+    }
+
+    @OptIn(ExperimentalResourceApi::class)
     private fun getResourceAsStream(path: String): InputStream {
-        val classLoader = Thread.currentThread().contextClassLoader ?: this.javaClass.classLoader
+        val classLoader = getClassLoader()
         return classLoader.getResourceAsStream(path) ?: throw MissingResourceException(path)
+    }
+
+    private fun getClassLoader(): ClassLoader {
+        return Thread.currentThread().contextClassLoader ?: this.javaClass.classLoader!!
     }
 }

--- a/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceReader.ios.kt
+++ b/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceReader.ios.kt
@@ -21,6 +21,10 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
         }
     }
 
+    override fun getUri(path: String): String {
+        return NSURL.fileURLWithPath(getPathInBundle(path)).toString()
+    }
+
     private fun readData(path: String): NSData {
         return NSFileManager.defaultManager().contentsAtPath(path) ?: throw MissingResourceException(path)
     }

--- a/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.js.kt
+++ b/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.js.kt
@@ -18,6 +18,11 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
         return part.asByteArray()
     }
 
+    override fun getUri(path: String): String {
+        val location = window.location
+        return getResourceUrl(location.origin, location.pathname, path)
+    }
+
     private suspend fun readAsBlob(path: String): Blob {
         val resPath = WebResourcesConfiguration.getResourcePath(path)
         val response = window.fetch(resPath).await()

--- a/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/ResourceReader.macos.kt
+++ b/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/ResourceReader.macos.kt
@@ -21,6 +21,10 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
         }
     }
 
+    override fun getUri(path: String): String {
+        return NSURL.fileURLWithPath(getPathOnDisk(path)).toString()
+    }
+
     private fun readData(path: String): NSData {
         return NSFileManager.defaultManager().contentsAtPath(path) ?: throw MissingResourceException(path)
     }

--- a/components/resources/library/src/wasmJsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.wasmJs.kt
+++ b/components/resources/library/src/wasmJsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.wasmJs.kt
@@ -33,6 +33,11 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
         return part.asByteArray()
     }
 
+    override fun getUri(path: String): String {
+        val location = window.location
+        return getResourceUrl(location.origin, location.pathname, path)
+    }
+
     private suspend fun readAsBlob(path: String): Blob {
         val resPath = WebResourcesConfiguration.getResourcePath(path)
         val response = window.fetch(resPath).await<Response>()

--- a/components/resources/library/src/webMain/kotlin/org/jetbrains/compose/resources/Resource.web.kt
+++ b/components/resources/library/src/webMain/kotlin/org/jetbrains/compose/resources/Resource.web.kt
@@ -45,3 +45,13 @@ object WebResourcesConfiguration {
 fun configureWebResources(configure: WebResourcesConfiguration.() -> Unit) {
     WebResourcesConfiguration.configure()
 }
+
+@OptIn(ExperimentalResourceApi::class)
+internal fun getResourceUrl(windowOrigin: String, windowPathname: String, resourcePath: String): String {
+    val path = WebResourcesConfiguration.getResourcePath(resourcePath)
+    return when {
+        path.startsWith("/") -> windowOrigin + path
+        path.startsWith("http://") || path.startsWith("https://") -> path
+        else -> windowOrigin + windowPathname + path
+    }
+}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GeneratedResClassSpec.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GeneratedResClassSpec.kt
@@ -160,6 +160,27 @@ internal fun getResFileSpecs(
                     .addStatement("""return %M("$moduleDir" + path)""", readResourceBytes)
                     .build()
             )
+
+            //getUri
+            val getResourceUri = MemberName("org.jetbrains.compose.resources", "getResourceUri")
+            resObject.addFunction(
+                FunSpec.builder("getUri")
+                    .addKdoc(
+                        """
+                    Returns the URI string of the resource file at the specified path.
+                    
+                    Example: `val uri = Res.getUri("files/key.bin")`
+                    
+                    @param path The path of the file in the compose resource's directory.
+                    @return The URI string of the file.
+                """.trimIndent()
+                    )
+                    .addParameter("path", String::class)
+                    .returns(String::class)
+                    .addStatement("""return %M("$moduleDir" + path)""", getResourceUri)
+                    .build()
+            )
+
             ResourceType.values().forEach { type ->
                 resObject.addType(TypeSpec.objectBuilder(type.accessorName).build())
             }

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/Res.kt
@@ -9,6 +9,7 @@ import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
 @ExperimentalResourceApi
@@ -22,6 +23,16 @@ public object Res {
    * @return The content of the file as a byte array.
    */
   public suspend fun readBytes(path: String): ByteArray = readResourceBytes("" + path)
+
+  /**
+   * Returns the URI string of the resource file at the specified path.
+   *
+   * Example: `val uri = Res.getUri("files/key.bin")`
+   *
+   * @param path The path of the file in the compose resource's directory.
+   * @return The URI string of the file.
+   */
+  public fun getUri(path: String): String = getResourceUri("" + path)
 
   public object drawable
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/Res.kt
@@ -9,6 +9,7 @@ import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
 @ExperimentalResourceApi
@@ -22,6 +23,16 @@ internal object Res {
    * @return The content of the file as a byte array.
    */
   public suspend fun readBytes(path: String): ByteArray = readResourceBytes("" + path)
+
+  /**
+   * Returns the URI string of the resource file at the specified path.
+   *
+   * Example: `val uri = Res.getUri("files/key.bin")`
+   *
+   * @param path The path of the file in the compose resource's directory.
+   * @return The URI string of the file.
+   */
+  public fun getUri(path: String): String = getResourceUri("" + path)
 
   public object drawable
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/Res.kt
@@ -3,12 +3,13 @@
     org.jetbrains.compose.resources.ExperimentalResourceApi::class,
 )
 
-package app.group.empty_res.generated.resources
+package app.group.resources_test.generated.resources
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
 @ExperimentalResourceApi
@@ -22,6 +23,16 @@ internal object Res {
      * @return The content of the file as a byte array.
      */
     public suspend fun readBytes(path: String): ByteArray = readResourceBytes("" + path)
+
+    /**
+     * Returns the URI string of the resource file at the specified path.
+     *
+     * Example: `val uri = Res.getUri("files/key.bin")`
+     *
+     * @param path The path of the file in the compose resource's directory.
+     * @return The URI string of the file.
+     */
+    public fun getUri(path: String): String = getResourceUri("" + path)
 
     public object drawable
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/Res.kt
@@ -3,12 +3,13 @@
     org.jetbrains.compose.resources.ExperimentalResourceApi::class,
 )
 
-package me.app.jvmonlyresources.generated.resources
+package app.group.resources_test.generated.resources
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
 @ExperimentalResourceApi
@@ -22,6 +23,16 @@ internal object Res {
      * @return The content of the file as a byte array.
      */
     public suspend fun readBytes(path: String): ByteArray = readResourceBytes("" + path)
+
+    /**
+     * Returns the URI string of the resource file at the specified path.
+     *
+     * Example: `val uri = Res.getUri("files/key.bin")`
+     *
+     * @param path The path of the file in the compose resource's directory.
+     * @return The URI string of the file.
+     */
+    public fun getUri(path: String): String = getResourceUri("" + path)
 
     public object drawable
 


### PR DESCRIPTION
Adds a public `Res.getUri(path: String): String` function.
It lets external libraries a way to read resource files by a platform dependent Uri.
E.g.: video players, image loaders or embedded web browsers.

```kotlin
val uri = Res.getUri("files/my_video.mp4")
```

fixes https://github.com/JetBrains/compose-multiplatform/issues/4360