### PR TITLE
Update compose compiler version to 1.5.10.2

### DIFF
--- a/compose/integrations/composable-test-cases/gradle.properties
+++ b/compose/integrations/composable-test-cases/gradle.properties
@@ -1,11 +1,11 @@
 org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=512m
 kotlin.code.style=official
 android.useAndroidX=true
-kotlin.version=1.9.22
+kotlin.version=1.9.23
 agp.version=7.3.0
 
 # a version of compose libraries. In this project the only dependency is compose-runtime.
-compose.version=1.6.0-rc03
+compose.version=1.6.1
 # a group id for compose-runtime. Keep it as a parameter to easily change it on CI.
 compose.runtime.groupId=org.jetbrains.compose.runtime
 
@@ -13,7 +13,7 @@ kotlinx.coroutines.version=1.8.0
 
 #empty by default - a default version will be used
 #compose.kotlinCompilerPluginVersion=23.12.18
-compose.kotlinCompilerPluginVersion=1.5.10.1
+compose.kotlinCompilerPluginVersion=1.5.10.2
 
 # default|failingJs - see enum class CasesToRun
 tests.casesToRun=default

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
@@ -23,7 +23,7 @@ internal object ComposeCompilerCompatibility {
         "1.9.20" to "1.5.3",
         "1.9.21" to "1.5.4",
         "1.9.22" to "1.5.8.1",
-        "1.9.23" to "1.5.10.1",
+        "1.9.23" to "1.5.10.2",
         "2.0.0-Beta1" to "1.5.4-dev1-kt2.0.0-Beta1",
         "2.0.0-Beta4" to "1.5.9-kt-2.0.0-Beta4",
         "2.0.0-Beta5" to "1.5.11-kt-2.0.0-Beta5",

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -10,7 +10,7 @@ dev.junit.parallel=false
 # Default version of Compose Libraries used by Gradle plugin
 compose.version=1.6.10-dev1590
 # The latest version of Compose Compiler used by Gradle plugin. Used only in tests/CI.
-compose.tests.compiler.version=1.5.10.1
+compose.tests.compiler.version=1.5.10.2
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
 compose.tests.compiler.compatible.kotlin.version=1.9.23
 # The latest version of Kotlin compatible with compose.tests.compiler.version for JS target. Used only on CI.


### PR DESCRIPTION
version bump & test added for reified generic in composable functions

Fixes #3147