### PR TITLE
Change dependency on the foundation to the ui and update coroutines version to avoid resolve issues.

### DIFF
--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -8,8 +8,8 @@ android.useAndroidX=true
 
 #Versions
 kotlin.version=1.9.23
-compose.version=1.6.10-dev1575
-agp.version=8.1.2
+compose.version=1.6.10-beta01
+agp.version=8.2.2
 
 #Compose
 org.jetbrains.compose.experimental.jscanvas.enabled=true

--- a/components/gradle/libs.versions.toml
+++ b/components/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlinx-coroutines = "1.7.3"
+kotlinx-coroutines = "1.8.0"
 androidx-appcompat = "1.6.1"
 androidx-activity-compose = "1.8.2"
 androidx-test = "1.5.0"

--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -68,7 +68,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(compose.runtime)
-                implementation(compose.foundation)
+                implementation(compose.ui)
                 implementation(libs.kotlinx.coroutines.core)
             }
         }


### PR DESCRIPTION
More info: https://jakewharton.com/nonsensical-maven-is-still-a-gradle-problem/