### PR TITLE
[gradle] Add validation checks on invalid xml or item type.

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2022]
+        os: [ubuntu-20.04, macos-14, windows-2022]
         gradle: [7.4, 8.7]
         agp: [7.3.1, 8.3.1]
     runs-on: ${{ matrix.os }}

--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 
 #Versions
 kotlin.version=1.9.23
-compose.version=1.6.10-dev1596
+compose.version=1.6.10-beta02
 agp.version=8.2.2
 
 #Compose

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResourcesGeneration.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResourcesGeneration.kt
@@ -68,7 +68,7 @@ internal fun Project.configureComposeResourcesGeneration(
     //setup task execution during IDE import
     tasks.configureEach { importTask ->
         if (importTask.name == "prepareKotlinIdeaImport") {
-            importTask.dependsOn(tasks.withType(CodeGenerationTask::class.java))
+            importTask.dependsOn(tasks.withType(IdeaImportTask::class.java))
         }
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
@@ -15,7 +15,7 @@ import java.io.File
  */
 internal abstract class IdeaImportTask : DefaultTask() {
     @get:Input
-    val isIdeaSync: Provider<Boolean> = project.provider {
+    val ideaIsInSync: Provider<Boolean> = project.provider {
         System.getProperty("idea.sync.active", "false").toBoolean()
     }
 
@@ -26,7 +26,7 @@ internal abstract class IdeaImportTask : DefaultTask() {
         } catch (e: Exception) {
             //message must contain two ':' symbols to be parsed by IDE UI!
             logger.error("e: $name task was failed:", e)
-            if (!isIdeaSync.get()) throw e
+            if (!ideaIsInSync.get()) throw e
         }
     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
@@ -2,18 +2,38 @@ package org.jetbrains.compose.resources
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 /**
  * This task should be FAST and SAFE! Because it is being run during IDE import.
  */
-internal abstract class CodeGenerationTask : DefaultTask()
+internal abstract class IdeaImportTask : DefaultTask() {
+    @get:Input
+    val isIdeaSync: Provider<Boolean> = project.provider {
+        System.getProperty("idea.sync.active", "false").toBoolean()
+    }
 
-internal abstract class GenerateResClassTask : CodeGenerationTask() {
+    @TaskAction
+    fun run() {
+        try {
+            safeAction()
+        } catch (e: Exception) {
+            //message must contain two ':' symbols to be parsed by IDE UI!
+            logger.error("e: $name task was failed:", e)
+            if (!isIdeaSync.get()) throw e
+        }
+    }
+
+    abstract fun safeAction()
+}
+
+internal abstract class GenerateResClassTask : IdeaImportTask() {
     companion object {
         private const val RES_FILE_NAME = "Res"
     }
@@ -34,26 +54,20 @@ internal abstract class GenerateResClassTask : CodeGenerationTask() {
     @get:OutputDirectory
     abstract val codeDir: DirectoryProperty
 
-    @TaskAction
-    fun generate() {
-        try {
-            val dir = codeDir.get().asFile
-            dir.deleteRecursively()
-            dir.mkdirs()
+    override fun safeAction() {
+        val dir = codeDir.get().asFile
+        dir.deleteRecursively()
+        dir.mkdirs()
 
-            if (shouldGenerateCode.get()) {
-                logger.info("Generate $RES_FILE_NAME.kt")
+        if (shouldGenerateCode.get()) {
+            logger.info("Generate $RES_FILE_NAME.kt")
 
-                val pkgName = packageName.get()
-                val moduleDirectory = packagingDir.getOrNull()?.let { it.invariantSeparatorsPath + "/" } ?: ""
-                val isPublic = makeAccessorsPublic.get()
-                getResFileSpec(pkgName, RES_FILE_NAME, moduleDirectory, isPublic).writeTo(dir)
-            } else {
-                logger.info("Generation Res class is disabled")
-            }
-        } catch (e: Exception) {
-            //message must contain two ':' symbols to be parsed by IDE UI!
-            logger.error("e: $name task was failed:", e)
+            val pkgName = packageName.get()
+            val moduleDirectory = packagingDir.getOrNull()?.let { it.invariantSeparatorsPath + "/" } ?: ""
+            val isPublic = makeAccessorsPublic.get()
+            getResFileSpec(pkgName, RES_FILE_NAME, moduleDirectory, isPublic).writeTo(dir)
+        } else {
+            logger.info("Generation Res class is disabled")
         }
     }
 }


### PR DESCRIPTION
If a project has invalid value xml files (empty/broken content or duplicated keys) then gradle will show an error.

fixes https://github.com/JetBrains/compose-multiplatform/issues/4663