### PR TITLE
ci: update Dockerfile used to run web tests

### DIFF
--- a/ci/docker/compose-web/Dockerfile-Basic
+++ b/ci/docker/compose-web/Dockerfile-Basic
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 SHELL ["/bin/bash", "-c"]
 
@@ -11,7 +11,8 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
     python3 \
     python-is-python3 \
     unzip \
-    wget
+    wget \
+    xvfb
 
 
 ARG CHROME_VERSION="google-chrome-stable"


### PR DESCRIPTION
update to the latest LTS and add Xvfb to run browser in non-headless mode