### PR TITLE
overridable resource locale

### DIFF
--- a/components/resources/demo/shared/src/commonMain/composeResources/values-np/strings.xml
+++ b/components/resources/demo/shared/src/commonMain/composeResources/values-np/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="hello">😊 नमस्कार संसार!</string>
+</resources>

--- a/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/StringRes.kt
+++ b/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/StringRes.kt
@@ -9,10 +9,12 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
 import components.resources.demo.shared.generated.resources.*
 import org.jetbrains.compose.resources.*
 
+@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun StringRes(paddingValues: PaddingValues) {
     Column(
@@ -42,6 +44,41 @@ fun StringRes(paddingValues: PaddingValues) {
                 disabledLabelColor = MaterialTheme.colorScheme.onSurface,
             )
         )
+        OutlinedCard(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            shape = RoundedCornerShape(4.dp)
+        ) {
+            CompositionLocalProvider(
+                LocalResourceLocale provides Locale("np")
+            ) {
+                OutlinedTextField(
+                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                    value = stringResource(Res.string.hello),
+                    onValueChange = {},
+                    label = {
+                        Text("Text(stringResource(Res.string.hello))")
+                    },
+                    enabled = false,
+                    colors = TextFieldDefaults.colors(
+                        disabledTextColor = MaterialTheme.colorScheme.onSurface,
+                        disabledContainerColor = MaterialTheme.colorScheme.surface,
+                        disabledLabelColor = MaterialTheme.colorScheme.onSurface,
+                    )
+                )
+                Text(
+                    modifier = Modifier.padding(16.dp),
+                    text = """
+                        CompositionLocalProvider(
+                            LocalResourceLocale provides Locale("np")
+                        ) {
+                            Text(stringResource(Res.string.hello))
+                        }
+                    """.trimIndent(),
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    softWrap = false
+                )
+            }
+        }
         OutlinedTextField(
             modifier = Modifier.padding(16.dp).fillMaxWidth(),
             value = stringResource(Res.string.multi_line),

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.kt
@@ -43,7 +43,7 @@ internal interface ComposeEnvironment {
 internal val DefaultComposeEnvironment = object : ComposeEnvironment {
     @Composable
     override fun rememberEnvironment(): ResourceEnvironment {
-        val composeLocale = Locale.current
+        val composeLocale = LocalResourceLocale.current
         val composeTheme = isSystemInDarkTheme()
         val composeDensity = LocalDensity.current
 
@@ -154,3 +154,7 @@ private fun List<ResourceItem>.filterByLocale(language: LanguageQualifier, regio
         item.qualifiers.none { it is LanguageQualifier || it is RegionQualifier }
     }
 }
+
+// Locale used for Resource that can be override by user
+@ExperimentalResourceApi
+val LocalResourceLocale = compositionLocalOf { Locale.current }

--- a/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.kt
+++ b/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.intl.Locale
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
@@ -327,5 +328,38 @@ class ComposeResourceTest {
 
         val systemEnvironment = getSystemResourceEnvironment()
         assertEquals(systemEnvironment, environment)
+    }
+
+    @Test
+    fun testDefaultResourceLocaleOnResourceEnvironment() = runComposeUiTest {
+        var resourceEnvironment: ResourceEnvironment? = null
+        var expectedLocale: Locale? = null
+
+        setContent {
+            expectedLocale = Locale.current
+            resourceEnvironment = rememberResourceEnvironment()
+        }
+
+        waitForIdle()
+
+        assertEquals(resourceEnvironment?.language?.language, expectedLocale?.language)
+        assertEquals(resourceEnvironment?.region?.region, expectedLocale?.region)
+    }
+
+    @Test
+    fun testProvidedResourceLocaleOnResourceEnvironment() = runComposeUiTest {
+        var resourceEnvironment: ResourceEnvironment? = null
+        val expectedLocale = Locale("np")
+
+        setContent {
+            CompositionLocalProvider(LocalResourceLocale provides expectedLocale) {
+                resourceEnvironment = rememberResourceEnvironment()
+            }
+        }
+
+        waitForIdle()
+
+        assertEquals(resourceEnvironment?.language?.language, expectedLocale.language)
+        assertEquals(resourceEnvironment?.region?.region, expectedLocale.region)
     }
 }


### PR DESCRIPTION
Add a way to override local for the resources (partially address #4197).

Similar to how we override the density with the LocalDensity composition provider it adds LocalResourceLocale to override Locale for Resource. 

**Usage**

```kotlin
 CompositionLocalProvider(LocalResourceLocale provides Locale("np")) {
  Text(stringResource(Res.string.hello))
}
```
