### PR TITLE
[gradle] Don't create Kotlin binary's linkTask eagerly

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResources.kt
@@ -73,7 +73,7 @@ internal fun Project.configureSyncIosComposeResources(
                     })
                     into(testExec.outputDirectory.resolve(IOS_COMPOSE_RESOURCES_ROOT_DIR))
                 }
-                testExec.linkTask.dependsOn(copyTestResourcesTask)
+                testExec.linkTaskProvider.dependsOn(copyTestResourcesTask)
             }
         }
     }

--- a/gradle-plugins/compose/src/test/test-projects/misc/iosResources/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/iosResources/build.gradle.kts
@@ -5,19 +5,20 @@ plugins {
 }
 
 kotlin {
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-
     cocoapods {
         version = "1.0"
         summary = "Some description for a Kotlin/Native module"
         homepage = "Link to a Kotlin/Native module homepage"
+        pod("Base64", "1.1.2")
         framework {
             baseName = "shared"
             isStatic = true
         }
     }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
It's better for the build performance, and it avoids uncovering the hidden CocoaPods plugin bug ([KT-67666](https://youtrack.jetbrains.com/issue/KT-67666))

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4632