### PR TITLE
Fix ImageViewer: Apply applyDefaultHierarchyTemplate

### DIFF
--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -28,6 +28,8 @@ kotlin {
         }
     }
 
+    applyDefaultHierarchyTemplate()
+
     sourceSets {
         all {
             languageSettings {


### PR DESCRIPTION
The intermediate `iosMain` source was previously removed here: https://github.com/JetBrains/compose-multiplatform/pull/3956 And it worked fine. 

According to the doc https://kotlinlang.org/docs/whatsnew1920.html#set-up-the-target-hierarchy :
> If you want to have additional source sets that the default hierarchy template doesn't provide, for example, one that shares code between a macOS and a JVM target, adjust the hierarchy by reapplying the template explicitly with applyDefaultHierarchyTemplate() and configuring additional source sets manually as usual with dependsOn()

Now we have an additional custom source set named 'jsWasmMain', therefore we need to have `applyDefaultHierarchyTemplate()`.