### PR TITLE
Add our space dev maven repository to JetSnack example

### DIFF
--- a/examples/jetsnack/build.gradle.kts
+++ b/examples/jetsnack/build.gradle.kts
@@ -7,6 +7,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }
 

--- a/examples/jetsnack/settings.gradle.kts
+++ b/examples/jetsnack/settings.gradle.kts
@@ -3,6 +3,7 @@ pluginManagement {
         google()
         gradlePluginPortal()
         mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 
     plugins {


### PR DESCRIPTION
This should fix our CI examples verification which relies on the availability of dev versions. 