### PR TITLE
[gradle] Hide multimodule resources under a flag.

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
@@ -22,7 +22,7 @@ internal object ComposeProperties {
     internal const val MAC_NOTARIZATION_PASSWORD = "compose.desktop.mac.notarization.password"
     internal const val MAC_NOTARIZATION_TEAM_ID_PROVIDER = "compose.desktop.mac.notarization.teamID"
     internal const val CHECK_JDK_VENDOR = "compose.desktop.packaging.checkJdkVendor"
-    internal const val ALWAYS_GENERATE_RESOURCE_ACCESSORS = "compose.resources.always.generate.accessors"
+    internal const val ENABLE_MULTIMODULE_RESOURCES = "compose.resources.multimodule.enable"
     internal const val SYNC_RESOURCES_PROPERTY = "compose.ios.resources.sync"
 
     fun isVerbose(providers: ProviderFactory): Provider<Boolean> =
@@ -54,6 +54,9 @@ internal object ComposeProperties {
 
     fun checkJdkVendor(providers: ProviderFactory): Provider<Boolean> =
         providers.valueOrNull(CHECK_JDK_VENDOR).toBooleanProvider(true)
+
+    fun enableMultimoduleResources(providers: ProviderFactory): Provider<Boolean> =
+        providers.valueOrNull(ENABLE_MULTIMODULE_RESOURCES).toBooleanProvider(false)
 
     //providers.valueOrNull works only with root gradle.properties
     fun dontSyncResources(project: Project): Provider<Boolean> = project.provider {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -158,42 +158,50 @@ class ResourcesTest : GradlePluginTestBase() {
             check.logContains("${testXml.name} is not valid. Check the file content.")
         }
 
-        testXml.writeText("""
+        testXml.writeText(
+            """
             <resources>
                 <aaa name="v">aaa</aaa>
             </resources>
-        """.trimIndent())
+        """.trimIndent()
+        )
         gradleFailure("prepareKotlinIdeaImport").checks {
             check.logContains("${testXml.name} is not valid. Unknown resource type: 'aaa'.")
         }
 
-        testXml.writeText("""
+        testXml.writeText(
+            """
             <resources>
                 <drawable name="v">aaa</drawable>
             </resources>
-        """.trimIndent())
+        """.trimIndent()
+        )
         gradleFailure("prepareKotlinIdeaImport").checks {
             check.logContains("${testXml.name} is not valid. Unknown string resource type: 'drawable'.")
         }
 
-        testXml.writeText("""
+        testXml.writeText(
+            """
             <resources>
                 <string name="v1">aaa</string>
                 <string name="v2">aaa</string>
                 <string name="v3">aaa</string>
                 <string name="v1">aaa</string>
             </resources>
-        """.trimIndent())
+        """.trimIndent()
+        )
         gradleFailure("prepareKotlinIdeaImport").checks {
             check.logContains("${testXml.name} is not valid. Duplicated key 'v1'.")
         }
 
-        testXml.writeText("""
+        testXml.writeText(
+            """
             <resources>
                 <string name="v1">aaa</string>
                 <string foo="v2">aaa</string>
             </resources>
-        """.trimIndent())
+        """.trimIndent()
+        )
         gradleFailure("prepareKotlinIdeaImport").checks {
             check.logContains("${testXml.name} is not valid. Attribute 'name' not found.")
         }
@@ -219,7 +227,7 @@ class ResourcesTest : GradlePluginTestBase() {
     @Test
     fun testMultiModuleResources() {
         val environment = defaultTestEnvironment.copy(
-            kotlinVersion = "2.0.0-Beta5"
+            kotlinVersion = "2.0.0-RC2"
         )
         with(
             testProject("misc/kmpResourcePublication", environment)
@@ -313,6 +321,25 @@ class ResourcesTest : GradlePluginTestBase() {
             gradleFailure(":appModule:jvmTest").checks {
                 check.logContains("java.lang.AssertionError: Failed to assert the following: (Text + EditableText = [test text: Feature text str_1])")
                 check.logContains("Text = '[Feature text str_1]'")
+            }
+        }
+    }
+
+    @Test
+    fun testOldResourcesWithNewKotlin() {
+        val environment = defaultTestEnvironment.copy(
+            kotlinVersion = "2.0.0-RC2"
+        )
+        with(
+            testProject("misc/kmpResourcePublication", environment)
+        ) {
+            file("gradle.properties").modify { content ->
+                content.replace("compose.resources.multimodule.enable=true", "")
+            }
+
+            gradle(":cmplib:build").checks {
+                check.logContains("Multimodule Compose Resources are disabled by default.")
+                check.logContains("To enable it add 'compose.resources.multimodule.enable=true' int the root gradle.properties file.")
             }
         }
     }

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/appModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/appModule/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.compose.ExperimentalComposeLibrary
 plugins {
     id("org.jetbrains.compose")
     kotlin("multiplatform")
+    kotlin("plugin.compose")
     id("com.android.application")
 }
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("org.jetbrains.compose").apply(false)
     kotlin("multiplatform").apply(false)
+    kotlin("plugin.compose").apply(false)
     id("com.android.library").apply(false)
     id("com.android.application").apply(false)
 }

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/cmplib/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/cmplib/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("org.jetbrains.compose")
     kotlin("multiplatform")
+    kotlin("plugin.compose")
     id("maven-publish")
     id("com.android.library")
 }

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/featureModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/featureModule/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("org.jetbrains.compose")
     kotlin("multiplatform")
+    kotlin("plugin.compose")
     id("com.android.library")
 }
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/gradle.properties
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/gradle.properties
@@ -5,3 +5,4 @@ android.useAndroidX=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.wasm.enabled=true
+compose.resources.multimodule.enable=true

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/settings.gradle.kts
@@ -15,6 +15,7 @@ pluginManagement {
     }
     plugins {
         id("org.jetbrains.kotlin.multiplatform").version("KOTLIN_VERSION_PLACEHOLDER")
+        id("org.jetbrains.kotlin.plugin.compose").version("KOTLIN_VERSION_PLACEHOLDER")
         id("org.jetbrains.compose").version("COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER")
         id("com.android.library").version("AGP_VERSION_PLACEHOLDER")
         id("com.android.application").version("AGP_VERSION_PLACEHOLDER")


### PR DESCRIPTION
After some discussions with Kotlin team we decided to hide the multi module support for resources under a gradle property: `compose.resources.multimodule.enable=true`.
It gives users a way to migrate on the new Kotlin without unexpected problems and enable the new resource's behavior smoothly.

By default the new behavior is disabled. But I guess it should be enabled in the official wizard though. 

## Testing
Projects with CMP 1.6.2 should work as before after update to Kotlin 2.0.0 and CMP 1.6.10
Gradle output should contain a message:
```
Multimodule Compose Resources are disabled by default.
To enable it add 'compose.resources.multimodule.enable=true' int the root gradle.properties file.
```

If the new feature is enebled then the publication and the multimodule support will work. 

## Release Notes
To enable the Compose Resources publication and the multimodule support add `compose.resources.multimodule.enable=true` to the root `gradle.properties`.


Sections:
- Breaking changes

Subsections:
- Resources
- Gradle Plugin
