### PR TITLE
Fix resources with cocoapods integration

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -706,8 +706,8 @@ class ResourcesTest : GradlePluginTestBase() {
                 check.taskNoSource(":prepareComposeResourcesTaskForIosX64Main")
                 check.taskSkipped(":generateResourceAccessorsForIosX64Main")
 
-                file("build/compose/ios/shared/compose-resources/drawable/compose-multiplatform.xml").checkExists()
-                file("build/compose/ios/shared/compose-resources/drawable/icon.xml").checkExists()
+                file("build/compose/cocoapods/compose-resources/drawable/compose-multiplatform.xml").checkExists()
+                file("build/compose/cocoapods/compose-resources/drawable/icon.xml").checkExists()
             }
 
             gradle(":podspec", "-Pkotlin.native.cocoapods.generate.wrapper=true").checks {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -709,6 +709,13 @@ class ResourcesTest : GradlePluginTestBase() {
                 file("build/compose/ios/shared/compose-resources/drawable/compose-multiplatform.xml").checkExists()
                 file("build/compose/ios/shared/compose-resources/drawable/icon.xml").checkExists()
             }
+
+            gradle(":podspec", "-Pkotlin.native.cocoapods.generate.wrapper=true").checks {
+                assertEqualTextFiles(
+                    file("iosResources.podspec"),
+                    file("expected/iosResources.podspec")
+                )
+            }
         }
     }
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/iosResources/expected/iosResources.podspec
+++ b/gradle-plugins/compose/src/test/test-projects/misc/iosResources/expected/iosResources.podspec
@@ -46,5 +46,5 @@ Pod::Spec.new do |spec|
             SCRIPT
         }
     ]
-    spec.resources = ['build/compose/ios/shared/compose-resources']
+    spec.resources = ['build/compose/cocoapods/compose-resources']
 end

--- a/gradle-plugins/compose/src/test/test-projects/misc/iosResources/expected/iosResources.podspec
+++ b/gradle-plugins/compose/src/test/test-projects/misc/iosResources/expected/iosResources.podspec
@@ -1,0 +1,50 @@
+Pod::Spec.new do |spec|
+    spec.name                     = 'iosResources'
+    spec.version                  = '1.0'
+    spec.homepage                 = 'Link to a Kotlin/Native module homepage'
+    spec.source                   = { :http=> ''}
+    spec.authors                  = ''
+    spec.license                  = ''
+    spec.summary                  = 'Some description for a Kotlin/Native module'
+    spec.vendored_frameworks      = 'build/cocoapods/framework/shared.framework'
+    spec.libraries                = 'c++'
+
+    spec.dependency 'Base64', '1.1.2'
+
+    if !Dir.exist?('build/cocoapods/framework/shared.framework') || Dir.empty?('build/cocoapods/framework/shared.framework')
+        raise "
+
+        Kotlin framework 'shared' doesn't exist yet, so a proper Xcode project can't be generated.
+        'pod install' should be executed after running ':generateDummyFramework' Gradle task:
+
+            ./gradlew :generateDummyFramework
+
+        Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
+    end
+
+    spec.pod_target_xcconfig = {
+        'KOTLIN_PROJECT_PATH' => '',
+        'PRODUCT_MODULE_NAME' => 'shared',
+    }
+
+    spec.script_phases = [
+        {
+            :name => 'Build iosResources',
+            :execution_position => :before_compile,
+            :shell_path => '/bin/sh',
+            :script => <<-SCRIPT
+                if [ "YES" = "$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED" ]; then
+                  echo "Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \"YES\""
+                  exit 0
+                fi
+                set -ev
+                REPO_ROOT="$PODS_TARGET_SRCROOT"
+                "$REPO_ROOT/gradlew" -p "$REPO_ROOT" $KOTLIN_PROJECT_PATH:syncFramework \
+                    -Pkotlin.native.cocoapods.platform=$PLATFORM_NAME \
+                    -Pkotlin.native.cocoapods.archs="$ARCHS" \
+                    -Pkotlin.native.cocoapods.configuration="$CONFIGURATION"
+            SCRIPT
+        }
+    ]
+    spec.resources = ['build/compose/ios/shared/compose-resources']
+end


### PR DESCRIPTION
The PR sets a static path to the compose resources for the cocoapods integration because there maybe only one integration framework for a gradle module.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4720

## Release Notes
### Fixes - Resources
- _(prerelease fix)_ Fix resources with cocoapods integration

