### PR TITLE
[resources] Check cached deferreds and drop them if they are cancelled.

### DIFF
--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/AsyncCache.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/AsyncCache.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.compose.resources
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class AsyncCache<K, V> {
+    private val mutex = Mutex()
+    private val cache = mutableMapOf<K, Deferred<V>>()
+
+    suspend fun getOrLoad(key: K, load: suspend () -> V): V = coroutineScope {
+        val deferred = mutex.withLock {
+            var cached = cache[key]
+            if (cached == null || cached.isCancelled) {
+                //LAZY - to free the mutex lock as fast as possible
+                cached = async(start = CoroutineStart.LAZY) { load() }
+                cache[key] = cached
+            }
+            cached
+        }
+        deferred.await()
+    }
+
+    //@TestOnly
+    fun clear() {
+        cache.clear()
+    }
+}


### PR DESCRIPTION
Before the fix we could cancel a coroutine and the cancelled deferred was saved in cache.

## Release Notes
### Fixes - Resources
- _(prerelease fix)_ Fix a cached empty resource on a Compose for Web if the resource loading was canceled during progress