### PR TITLE
CfW: Prevent UnpackSkikoWasmRuntime task execution when it's not needed

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -31,6 +31,7 @@ internal fun Project.configureWeb(
 internal fun Collection<KotlinJsIrTarget>.configureWebApplication(
     project: Project
 ) {
+    if (project.properties["org.jetbrains.compose.web.skipUnpackSkiko"] == "true") return
     val skikoJsWasmRuntimeConfiguration = project.configurations.create("COMPOSE_SKIKO_JS_WASM_RUNTIME")
     val skikoJsWasmRuntimeDependency = skikoVersionProvider(project).map { skikoVersion ->
         project.dependencies.create("org.jetbrains.skiko:skiko-js-wasm-runtime:$skikoVersion")

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -28,14 +28,14 @@ internal fun Project.configureWeb(
     // If there is compose.ui, then skiko is required!
     val shouldRunUnpackSkiko = project.provider {
         var dependsOnComposeUi = false
-        project.configurations.matching {
-            val isWasmOrJs = it.name.contains("js", true) ||
-                    it.name.contains("wasm", true)
+        project.configurations.matching { configuration ->
+            val isWasmOrJs = configuration.name.contains("js", true) ||
+                    configuration.name.contains("wasm", true)
 
-            it.isCanBeResolved && isWasmOrJs
-        }.all {
-            val match = it.incoming.artifacts.resolvedArtifacts.get().any {
-                it.id.componentIdentifier.toString().contains("org.jetbrains.compose.ui")
+            configuration.isCanBeResolved && isWasmOrJs
+        }.all { configuration ->
+            val match = configuration.incoming.artifacts.resolvedArtifacts.get().any { artifact ->
+                artifact.id.componentIdentifier.toString().contains("org.jetbrains.compose.ui")
             }
 
             dependsOnComposeUi = dependsOnComposeUi || match

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -35,7 +35,7 @@ internal fun Project.configureWeb(
             configuration.isCanBeResolved && isWasmOrJs
         }.all { configuration ->
             val match = configuration.incoming.artifacts.resolvedArtifacts.get().any { artifact ->
-                artifact.id.componentIdentifier.toString().contains("org.jetbrains.compose.ui")
+                artifact.id.componentIdentifier.toString().contains("org.jetbrains.compose.ui:ui:")
             }
 
             dependsOnComposeUi = dependsOnComposeUi || match


### PR DESCRIPTION
Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4823

In https://github.com/JetBrains/compose-multiplatform/pull/4796 we intentionally started to configure the web app for all k/js and k/wasm targets.  The configuration involves adding a dependency on skiko-wasm runtime and unpacking it. 
Some projects don't need skiko-wasm-runtime (like those based on compose.html or just compose.runtime). 

**Solution:**
We check if there is a dependency on org.jetbrains.compose.ui libraries (including transitive dependencies). If we find it, then we enable skikoUnpack task. Otherwise it's disabled.

## Testing
- Build the gradle plugin locally (with this change)
- Used it in our html landing example: https://github.com/JetBrains/compose-multiplatform/blob/master/examples/html/landing
- Run `./gradlew jsBrowserDistribution`, check `.../compose-multiplatform/examples/html/landing/build/dist/js/productionExecutable` and see NO skiko.* files added there
- Then add `implementation(compose.foundation)` dependency in build.gradle.jts and run `./gradlew clean jsBrowserDistribution` again - the build/dist contains skiko.* now
