### PR TITLE
Raise the minimal supported AGP to 8.1.0

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-14, windows-2022]
         gradle: [7.4, 8.7]
-        agp: [8.1.0, 8.3.1]
+        agp: [8.1.0, 8.4.0]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-14, windows-2022]
         gradle: [7.4, 8.7]
-        agp: [7.3.1, 8.3.1]
+        agp: [8.0.0, 8.3.1]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-14, windows-2022]
         gradle: [7.4, 8.7]
-        agp: [8.0.0, 8.3.1]
+        agp: [8.1.0, 8.3.1]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -20,7 +20,7 @@ compose.tests.js.compiler.compatible.kotlin.version=1.9.24
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config
 # minimal and current gradle version
 compose.tests.gradle.versions=7.4, 8.7
-compose.tests.agp.versions=8.1.0, 8.3.1
+compose.tests.agp.versions=8.1.0, 8.4.0
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -20,7 +20,7 @@ compose.tests.js.compiler.compatible.kotlin.version=1.9.24
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config
 # minimal and current gradle version
 compose.tests.gradle.versions=7.4, 8.7
-compose.tests.agp.versions=7.3.1, 8.3.1
+compose.tests.agp.versions=8.1.0, 8.3.1
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.


### PR DESCRIPTION
AGP 7 isn't supported by Jetpack Compose 1.7 (which we'll use in CMP 1.7) and by Lifecycle 2.8.

After this CI is merged, I will:
- revert the revert of [the skiko API fix](https://github.com/JetBrains/compose-multiplatform-core/pull/1328) in jb-main
- raise the AGP version on TeamCity

### Details

It was discovered after merging [the skiko API fix](https://github.com/JetBrains/compose-multiplatform-core/pull/1328). We had `D8: java.lang.NullPointerException` error on TeamCity. After investigating dependencies, it appears that previous the dependencies were incorrect:
```
org.jetbrains.compose.material:material -> androidx.compose.material:material:1.6.7 -> androidx.lifecycle:lifecycle-livedata-core:2.6.1
```
And the new are correct, but aren't supported by AGP 7:
```
org.jetbrains.compose.material:material -> org.jetbrains.compose.ui -> org.jetbrains.androidx.lifecycle:lifecycle-common -> androidx.lifecycle:lifecycle-common:2.8.0 -> androidx.lifecycle:lifecycle-livedata-core:2.8.0
```
The dependency chains was printed by this command on the `commonResources` test project:
```
./gradlew dependencyInsight --configuration demoDebugRuntimeClasspath --dependency androidx.lifecycle:lifecycle-livedata-core
```

## Testing

1. Create a pure Jetpack Compose project via Android Studio Hedgehog | 2023.1.1 Patch 2
2. Set Jetpack Compose  to 1.7.0-beta01
3. Downgrade AGP to 7.4.0
4. Run
5. See the error:
```
ERROR:C:\Users\igord\.gradle\caches\transforms-4\7fcc63c0892ce9266300d6463c3c751d\transformed\lifecycle-livedata-core-2.8.0-runtime.jar: D8: java.lang.NullPointerException: Cannot invoke "String.length()" because "<parameter1>" is null
Execution failed for task ':app:mergeExtDexDebug'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform lifecycle-livedata-core-2.8.0.aar (androidx.lifecycle:lifecycle-livedata-core:2.8.0) to match attributes {artifactType=android-dex, asm-transformed-variant=NONE, dexing-enable-desugaring=true, dexing-enable-jacoco-instrumentation=false, dexing-is-debuggable=true, dexing-min-sdk=24, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for DexingNoClasspathTransform: C:\Users\igord\.gradle\caches\transforms-3\4aae1223695d47acd0b149bb5811ca5f\transformed\lifecycle-livedata-core-2.8.0-runtime.jar.
         > Error while dexing.
```
6. Change AGP to 8.1.0
7. The run is successful.

## Release Notes
### Breaking changes - Android
- Minimal supported AGP raised to 8.1.0