### PR TITLE
[Android] update Font with new resource value

### DIFF
--- a/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/FontResources.android.kt
+++ b/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/FontResources.android.kt
@@ -8,6 +8,6 @@ import androidx.compose.ui.text.font.*
 @Composable
 actual fun Font(resource: FontResource, weight: FontWeight, style: FontStyle): Font {
     val environment = LocalComposeEnvironment.current.rememberEnvironment()
-    val path = remember(environment) { resource.getResourceItemByEnvironment(environment).path }
+    val path = remember(environment, resource) { resource.getResourceItemByEnvironment(environment).path }
     return Font(path, LocalContext.current.assets, weight, style)
 }


### PR DESCRIPTION
Fixes #4863

Before this update, when a new `resource` value was passed to `org.jetbrains.compose.resources.Font` composable, it kept the original value.

Test sample code. `Res.font` here is autogenerated from `commonMain/composeResources/font/` folder content.
```kt
var flag by remember {
    mutableStateOf(false)
}
Column {
    Text(
        "hey",
        fontFamily = FontFamily(Font(if (flag) Res.font.HelveticaNeueMedium else Res.font.COMICSANS, FontWeight.Normal))
    )
    Switch(checked = flag, onCheckedChange = { flag = it })
}
```

## Release Notes
### Fixes - Resources
- Fix a cached font if the resource acessor was changed 
