### PR TITLE
Update MacOS CFBundleVersion validation

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/validatePackageVersions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/validatePackageVersions.kt
@@ -169,7 +169,7 @@ private object WindowsVersionChecker : VersionChecker {
 
 private object MacVersionChecker : VersionChecker {
     override val correctFormat = """|'MAJOR[.MINOR][.PATCH]', where:
-        |    * MAJOR is an integer > 0;
+        |    * MAJOR is a non-negative integer;
         |    * MINOR is an optional non-negative integer;
         |    * PATCH is an optional non-negative integer;
     """.trimMargin()
@@ -180,6 +180,5 @@ private object MacVersionChecker : VersionChecker {
         return parts.isNotEmpty()
                 && parts.size <= 3
                 && parts.all { it != null && it >= 0 }
-                && (parts.first() ?: 0) > 0
     }
 }

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -191,7 +191,7 @@ compose.desktop {
 Versions must follow the rules:
   * For `dmg` and `pkg`: 
     * The format is `MAJOR[.MINOR][.PATCH]`, where:
-      * `MAJOR` is an integer > 0;
+      * `MAJOR` is a non-negative integer;
       * `MINOR` is an optional non-negative integer;
       * `PATCH` is an optional non-negative integer;
   * For `msi` and `exe`: 


### PR DESCRIPTION
MacOS .dmg and .pkg files used to require that major versions of CFBundleVersion were greater than 0. See [here](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364).

This is no longer the case. See [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion)

Fixes what's mentioned in #2360

## Release Notes
### Fixes - Gradle Plugin
- Corrected version validation for MacOS CFBundleVersion. The major version may now be 0.