### PR TITLE
[gradle] Configure Compose Compiler if kotlin-android or kotlin-js plugins are applied.

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -8,6 +8,8 @@ package org.jetbrains.compose
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.compose.internal.ComposeCompilerArtifactProvider
+import org.jetbrains.compose.internal.KOTLIN_ANDROID_PLUGIN_ID
+import org.jetbrains.compose.internal.KOTLIN_JS_PLUGIN_ID
 import org.jetbrains.compose.internal.KOTLIN_JVM_PLUGIN_ID
 import org.jetbrains.compose.internal.KOTLIN_MPP_PLUGIN_ID
 import org.jetbrains.compose.internal.Version
@@ -27,11 +29,16 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal fun Project.configureComposeCompilerPlugin() {
-    plugins.withId(KOTLIN_MPP_PLUGIN_ID) { plugin ->
-        configureComposeCompilerPlugin(plugin as KotlinBasePlugin)
-    }
-    plugins.withId(KOTLIN_JVM_PLUGIN_ID) { plugin ->
-        configureComposeCompilerPlugin(plugin as KotlinBasePlugin)
+    //only one of them can be applied to the project
+    listOf(
+        KOTLIN_MPP_PLUGIN_ID,
+        KOTLIN_JVM_PLUGIN_ID,
+        KOTLIN_ANDROID_PLUGIN_ID,
+        KOTLIN_JS_PLUGIN_ID
+    ).forEach { pluginId ->
+        plugins.withId(pluginId) { plugin ->
+            configureComposeCompilerPlugin(plugin as KotlinBasePlugin)
+        }
     }
 }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/constants.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/constants.kt
@@ -7,6 +7,7 @@ package org.jetbrains.compose.internal
 
 internal const val KOTLIN_MPP_PLUGIN_ID = "org.jetbrains.kotlin.multiplatform"
 internal const val KOTLIN_JVM_PLUGIN_ID = "org.jetbrains.kotlin.jvm"
+internal const val KOTLIN_ANDROID_PLUGIN_ID = "org.jetbrains.kotlin.android"
 internal const val KOTLIN_JS_PLUGIN_ID = "org.jetbrains.kotlin.js"
 internal const val COMPOSE_PLUGIN_ID = "org.jetbrains.compose"
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/KotlinCompatibilityTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/KotlinCompatibilityTest.kt
@@ -51,11 +51,9 @@ class KotlinCompatibilityTest : GradlePluginTestBase() {
 
     @Test
     fun testNewCompilerPluginError() {
-        // TODO replace by this after Kotlin 2.0 release
-        // testEnvironment = defaultTestEnvironment.copy(kotlinVersion = "2.0")
         val testProject = testProject(
             TestProjects.mpp,
-            testEnvironment = defaultTestEnvironment.copy(kotlinVersion = newCompilerIsAvailableVersion)
+            testEnvironment = defaultTestEnvironment.copy(kotlinVersion = "2.0.0")
         )
         testProject.gradleFailure("tasks").checks {
             check.logContains(newComposeCompilerError)


### PR DESCRIPTION
Fix Compose Compiler configuration for Kotlin < 2.0 when kotlin-android or kotlin-js gradle plugins are applied.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4831

## Release Notes
### Fixes - Gradle Plugin
- Fix Compose Compiler configuration for Kotlin < 2.0 when kotlin-android or kotlin-js gradle plugins are applied.
