### PR TITLE
ImageViewer: workaround k/wasm configuration cache issue KT-68614

### DIFF
--- a/examples/imageviewer/webApp/build.gradle.kts
+++ b/examples/imageviewer/webApp/build.gradle.kts
@@ -26,16 +26,17 @@ kotlin {
     wasmJs {
         moduleName = "imageviewer"
         browser {
-            commonWebpackConfig {
-                devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
-                    static = (static ?: mutableListOf()).apply {
-                        // Serve sources to debug inside browser
-                        add(rootDirPath)
-                        add(rootDirPath + "/shared/")
-                        add(rootDirPath + "/webApp/")
-                    }
-                }
-            }
+             // TODO: uncomment when https://youtrack.jetbrains.com/issue/KT-68614 is fixed (it doesn't work with configuration cache)
+//            commonWebpackConfig {
+//                devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
+//                    static = (static ?: mutableListOf()).apply {
+//                        // Serve sources to debug inside browser
+//                        add(rootDirPath)
+//                        add(rootDirPath + "/shared/")
+//                        add(rootDirPath + "/webApp/")
+//                    }
+//                }
+//            }
         }
         binaries.executable()
     }


### PR DESCRIPTION
Added a workaround in ImageViewer for K/Wasm configuration cache issue https://youtrack.jetbrains.com/issue/KT-68614/Wasm.-KotlinWebpack-cannot-serialize-Gradle-script-object-references