### PR TITLE
[resources] Delete Thread.currentThread().contextClassLoader on JVM targets

### DIFF
--- a/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/ResourceReader.android.kt
+++ b/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/ResourceReader.android.kt
@@ -46,6 +46,6 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
     }
 
     private fun getClassLoader(): ClassLoader {
-        return Thread.currentThread().contextClassLoader ?: this.javaClass.classLoader!!
+        return this.javaClass.classLoader ?: error("Cannot find class loader")
     }
 }

--- a/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceReader.desktop.kt
+++ b/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceReader.desktop.kt
@@ -30,6 +30,6 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
     }
 
     private fun getClassLoader(): ClassLoader {
-        return Thread.currentThread().contextClassLoader ?: this.javaClass.classLoader!!
+        return this.javaClass.classLoader ?: error("Cannot find class loader")
     }
 }


### PR DESCRIPTION
The class loader retrieval method has been modified in both `ResourceReader.android.kt` and `ResourceReader.desktop.kt` files. The return statement has been changed to prioritize java class classLoader and provides a clearer error message when it can't be found.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4887
Fixes https://github.com/JetBrains/compose-multiplatform/issues/4742

## Release Notes
### Fixes - Resources
- Delete contextClassLoader usage on JVM targets