### PR TITLE
[gradle] Generate method to create drawable or font resource accessors by a file path.

### DIFF
--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonResClass/my/lib/res/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonResClass/my/lib/res/Res.kt
@@ -8,7 +8,9 @@ package my.lib.res
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
+import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
@@ -35,7 +37,22 @@ public object Res {
   @ExperimentalResourceApi
   public fun getUri(path: String): String = getResourceUri("" + path)
 
-  public object drawable
+  public object drawable {
+    /**
+     * Returns the resource accessor by the specified path.
+     *
+     * NOTE: if the file does not match the resource type, there will be a crash in runtime!
+     *
+     * @param path The path of the file in the compose resource's directory.
+     * @return The accessor to the specified file.
+     */
+    @ExperimentalResourceApi
+    public fun byPath(path: String): DrawableResource =
+      org.jetbrains.compose.resources.DrawableResource(
+        "drawable:" + path,
+        setOf(org.jetbrains.compose.resources.ResourceItem(setOf(), "" + path, -1, -1))
+      )
+  }
 
   public object string
 
@@ -43,5 +60,19 @@ public object Res {
 
   public object plurals
 
-  public object font
+  public object font {
+    /**
+     * Returns the resource accessor by the specified path.
+     *
+     * NOTE: if the file does not match the resource type, there will be a crash in runtime!
+     *
+     * @param path The path of the file in the compose resource's directory.
+     * @return The accessor to the specified file.
+     */
+    @ExperimentalResourceApi
+    public fun byPath(path: String): FontResource = org.jetbrains.compose.resources.FontResource(
+      "font:" + path,
+      setOf(org.jetbrains.compose.resources.ResourceItem(setOf(), "" + path, -1, -1))
+    )
+  }
 }

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/commonResClass/app/group/resources_test/generated/resources/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/commonResClass/app/group/resources_test/generated/resources/Res.kt
@@ -8,7 +8,9 @@ package app.group.resources_test.generated.resources
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
+import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
@@ -35,7 +37,22 @@ internal object Res {
   @ExperimentalResourceApi
   public fun getUri(path: String): String = getResourceUri("" + path)
 
-  public object drawable
+  public object drawable {
+    /**
+     * Returns the resource accessor by the specified path.
+     *
+     * NOTE: if the file does not match the resource type, there will be a crash in runtime!
+     *
+     * @param path The path of the file in the compose resource's directory.
+     * @return The accessor to the specified file.
+     */
+    @ExperimentalResourceApi
+    public fun byPath(path: String): DrawableResource =
+      org.jetbrains.compose.resources.DrawableResource(
+        "drawable:" + path,
+        setOf(org.jetbrains.compose.resources.ResourceItem(setOf(), "" + path, -1, -1))
+      )
+  }
 
   public object string
 
@@ -43,5 +60,19 @@ internal object Res {
 
   public object plurals
 
-  public object font
+  public object font {
+    /**
+     * Returns the resource accessor by the specified path.
+     *
+     * NOTE: if the file does not match the resource type, there will be a crash in runtime!
+     *
+     * @param path The path of the file in the compose resource's directory.
+     * @return The accessor to the specified file.
+     */
+    @ExperimentalResourceApi
+    public fun byPath(path: String): FontResource = org.jetbrains.compose.resources.FontResource(
+      "font:" + path,
+      setOf(org.jetbrains.compose.resources.ResourceItem(setOf(), "" + path, -1, -1))
+    )
+  }
 }

--- a/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/Res.kt
@@ -8,7 +8,9 @@ package app.group.empty_res.generated.resources
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
+import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
@@ -35,7 +37,22 @@ internal object Res {
     @ExperimentalResourceApi
     public fun getUri(path: String): String = getResourceUri("" + path)
 
-    public object drawable
+    public object drawable {
+        /**
+         * Returns the resource accessor by the specified path.
+         *
+         * NOTE: if the file does not match the resource type, there will be a crash in runtime!
+         *
+         * @param path The path of the file in the compose resource's directory.
+         * @return The accessor to the specified file.
+         */
+        @ExperimentalResourceApi
+        public fun byPath(path: String): DrawableResource =
+            org.jetbrains.compose.resources.DrawableResource(
+                "drawable:" + path,
+                setOf(org.jetbrains.compose.resources.ResourceItem(setOf(), "" + path, -1, -1))
+            )
+    }
 
     public object string
 
@@ -43,5 +60,19 @@ internal object Res {
 
     public object plurals
 
-    public object font
+    public object font {
+        /**
+         * Returns the resource accessor by the specified path.
+         *
+         * NOTE: if the file does not match the resource type, there will be a crash in runtime!
+         *
+         * @param path The path of the file in the compose resource's directory.
+         * @return The accessor to the specified file.
+         */
+        @ExperimentalResourceApi
+        public fun byPath(path: String): FontResource = org.jetbrains.compose.resources.FontResource(
+            "font:" + path,
+            setOf(org.jetbrains.compose.resources.ResourceItem(setOf(), "" + path, -1, -1))
+        )
+    }
 }

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/commonResClass/me/app/jvmonlyresources/generated/resources/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/commonResClass/me/app/jvmonlyresources/generated/resources/Res.kt
@@ -8,7 +8,9 @@ package me.app.jvmonlyresources.generated.resources
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
+import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
@@ -35,7 +37,22 @@ internal object Res {
     @ExperimentalResourceApi
     public fun getUri(path: String): String = getResourceUri("" + path)
 
-    public object drawable
+    public object drawable {
+        /**
+         * Returns the resource accessor by the specified path.
+         *
+         * NOTE: if the file does not match the resource type, there will be a crash in runtime!
+         *
+         * @param path The path of the file in the compose resource's directory.
+         * @return The accessor to the specified file.
+         */
+        @ExperimentalResourceApi
+        public fun byPath(path: String): DrawableResource =
+            org.jetbrains.compose.resources.DrawableResource(
+                "drawable:" + path,
+                setOf(org.jetbrains.compose.resources.ResourceItem(setOf(), "" + path, -1, -1))
+            )
+    }
 
     public object string
 
@@ -43,5 +60,19 @@ internal object Res {
 
     public object plurals
 
-    public object font
+    public object font {
+        /**
+         * Returns the resource accessor by the specified path.
+         *
+         * NOTE: if the file does not match the resource type, there will be a crash in runtime!
+         *
+         * @param path The path of the file in the compose resource's directory.
+         * @return The accessor to the specified file.
+         */
+        @ExperimentalResourceApi
+        public fun byPath(path: String): FontResource = org.jetbrains.compose.resources.FontResource(
+            "font:" + path,
+            setOf(org.jetbrains.compose.resources.ResourceItem(setOf(), "" + path, -1, -1))
+        )
+    }
 }


### PR DESCRIPTION
Now we can get resource accessors by the path.

```kotlin
Icon(
  painterResource(Res.drawable.byPath("drawable/my_icon.xml")),
  contentDescription = null
)
```

The new API doesn't work with qualifiers and environment. It associates a concrete file with a new resource instance.
If there are two icons: `drawable-night/my_icon.xml` and `drawable-light/my_icon.xml`, users are supposed to select a right icon by their own.

It doesn't work for strings resources. There is no a such thing as a full qualified key for the string in a text representation. (as path for other resource types) We need to combine an xml file path + key inside. It is not what we want.

I understand that someone would like to have something like a runtime search in their string resources based on a string key and a current environment but it is a huge performance problem. That's why we converted XML files to the internal format and use generated classes instead. To iterate by files in the runtime is not possible.

Note: there is a way to generate a special map: `key -> value` and use for the search but it requires more resources to maintain it then brings a profit.

So, for the case it's possible to save strings to the regular txt file and read it as string on app's side.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4880

## Release Notes
### Features - Resources
- Generate method to create drawable or font resource accessors by a file path.