### PR TITLE
Fix eager tryGetSkikoRuntimeIfNeeded

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/internal/configurePreview.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/internal/configurePreview.kt
@@ -34,7 +34,7 @@ private fun registerConfigurePreviewTask(
     ) { previewTask ->
         runtimeFiles.configureUsageBy(previewTask) { (runtimeJars, _) ->
             previewClasspath = runtimeJars
-            skikoRuntime = project.provider { tryGetSkikoRuntimeIfNeeded() }
+            skikoRuntime.set(project.provider { tryGetSkikoRuntimeIfNeeded() })
         }
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/internal/configurePreview.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/internal/configurePreview.kt
@@ -34,7 +34,7 @@ private fun registerConfigurePreviewTask(
     ) { previewTask ->
         runtimeFiles.configureUsageBy(previewTask) { (runtimeJars, _) ->
             previewClasspath = runtimeJars
-            skikoRuntime = tryGetSkikoRuntimeIfNeeded()
+            skikoRuntime = project.provider { tryGetSkikoRuntimeIfNeeded() }
         }
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
@@ -19,7 +19,7 @@ abstract class AbstractConfigureDesktopPreviewTask : AbstractComposeDesktopTask(
     internal lateinit var previewClasspath: FileCollection
 
     @get:InputFiles
-    internal lateinit var skikoRuntime: Provider<FileCollection>
+    internal abstract val skikoRuntime: Property<FileCollection>
 
     @get:Internal
     internal val javaHome: Property<String> = objects.notNullProperty<String>().apply {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
@@ -19,7 +19,7 @@ abstract class AbstractConfigureDesktopPreviewTask : AbstractComposeDesktopTask(
     internal lateinit var previewClasspath: FileCollection
 
     @get:InputFiles
-    internal lateinit var skikoRuntime: FileCollection
+    internal lateinit var skikoRuntime: Provider<FileCollection>
 
     @get:Internal
     internal val javaHome: Property<String> = objects.notNullProperty<String>().apply {
@@ -58,10 +58,12 @@ abstract class AbstractConfigureDesktopPreviewTask : AbstractComposeDesktopTask(
                 javaExecutable = javaExecutable(javaHome.get()),
                 hostClasspath = hostClasspath.files.asSequence().pathString()
             )
+
+        val skikoRuntimeFiles = skikoRuntime.get()
         val previewClasspathString =
             (previewClasspath.files.asSequence() +
                     uiTooling.files.asSequence() +
-                    skikoRuntime.files.asSequence()
+                    skikoRuntimeFiles.files.asSequence()
             ).pathString()
 
         val gradleLogger = logger


### PR DESCRIPTION
Fixes #4886

## Testing
- Built the gradle plugin to mavenLocal
- used it in the reproducer of #4886, - the issue is gonve


This should be tested by QA

## Release Notes

### Fixes - Gradle Plugin
- Make sure tryGetSkikoRuntimeIfNeeded is executed only during the task execution 

