### PR TITLE
Remove redundant @OptIn of experimental annotations

### DIFF
--- a/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/RadioGroup.kt
+++ b/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/RadioGroup.kt
@@ -95,7 +95,6 @@ fun RadioGroup(
 @ExperimentalComposeWebApi
 class RadioGroupScope<T> internal constructor()
 
-@OptIn(ExperimentalComposeWebApi::class)
 private val radioGroupScopeImpl = RadioGroupScope<Any>()
 
 private var generatedRadioGroupNamesCounter = 0

--- a/html/core/src/jsTest/kotlin/elements/ElementsTests.kt
+++ b/html/core/src/jsTest/kotlin/elements/ElementsTests.kt
@@ -113,7 +113,6 @@ class ElementsTests {
     }
 
     @Test
-    @OptIn(ExperimentalComposeWebApi::class)
     fun rawCreation() = runTest {
         @Composable
         fun CustomElement(
@@ -155,7 +154,6 @@ class ElementsTests {
     }
 
     @Test
-    @OptIn(ExperimentalComposeWebApi::class)
     fun rawCreationAndTagChanges() = runTest {
         @Composable
         fun CustomElement(

--- a/html/core/src/jsTest/kotlin/elements/RadioGroupTests.kt
+++ b/html/core/src/jsTest/kotlin/elements/RadioGroupTests.kt
@@ -12,7 +12,6 @@ import org.w3c.dom.HTMLInputElement
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalComposeWebApi::class)
 class RadioGroupTests {
 
     @Test

--- a/html/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/tests/RadioGroupTestCases.kt
+++ b/html/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/tests/RadioGroupTestCases.kt
@@ -13,7 +13,6 @@ import org.jetbrains.compose.web.sample.tests.testCase
 
 class RadioGroupTestCases {
 
-    @OptIn(ExperimentalComposeWebApi::class)
     val radioGroupItemsCanBeChecked by testCase {
         var checked by remember { mutableStateOf("None") }
 
@@ -34,7 +33,6 @@ class RadioGroupTestCases {
         }
     }
 
-    @OptIn(ExperimentalComposeWebApi::class)
     val twoRadioGroupsChangedIndependently by testCase {
         var checked1 by remember { mutableStateOf("None") }
         var checked2 by remember { mutableStateOf("None") }


### PR DESCRIPTION
## Proposed Change

Remove the annotation usage of ExperimentalComposeWebAPI from html core and integeration-core modules as this is no longer required

## Issues Fixed

Fixes: #3364 
