### PR TITLE
fix(Resources): Use readNBytes() to read a chunk of resources  #4938

### DIFF
--- a/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceReader.desktop.kt
+++ b/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceReader.desktop.kt
@@ -10,12 +10,10 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
 
     override suspend fun readPart(path: String, offset: Long, size: Long): ByteArray {
         val resource = getResourceAsStream(path)
-        val result = ByteArray(size.toInt())
-        resource.use { input ->
-            input.skip(offset)
-            input.read(result, 0, size.toInt())
+        return resource.use { input ->
+            input.skipNBytes(offset)
+            input.readNBytes(size.toInt())
         }
-        return result
     }
 
     override fun getUri(path: String): String {


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/4938 The idea is that both `.skip()` and `.read()` may skip and read less bytes that requested.

Sections:
- Fixes

Subsections:
- Desktop
- Resources