### PR TITLE
Move Proguard version from ProguardSettings.kt To Gradle version catalog

### DIFF
--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -30,6 +30,7 @@ val buildConfig = tasks.register("buildConfig", GenerateBuildConfig::class.java)
     generatedOutputDir.set(buildConfigDir)
     fieldsToGenerate.put("composeVersion", BuildProperties.composeVersion(project))
     fieldsToGenerate.put("composeGradlePluginVersion", BuildProperties.deployVersion(project))
+    fieldsToGenerate.put("DEFAULT_PROGUARD_VERSION", libs.versions.default.proguard.get())
 }
 tasks.named("compileKotlin", KotlinCompilationTask::class) {
     dependsOn(buildConfig)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
@@ -8,11 +8,12 @@ package org.jetbrains.compose.desktop.application.dsl
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.jetbrains.compose.ComposeBuildConfig
 import org.jetbrains.compose.internal.utils.notNullProperty
 import org.jetbrains.compose.internal.utils.nullableProperty
 import javax.inject.Inject
 
-private const val DEFAULT_PROGUARD_VERSION = "7.2.2"
+private const val DEFAULT_PROGUARD_VERSION = ComposeBuildConfig.DEFAULT_PROGUARD_VERSION
 
 abstract class ProguardSettings @Inject constructor(
     objects: ObjectFactory,

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -5,6 +5,9 @@ kotlin-poet = "1.16.0"
 plugin-android = "7.3.0"
 shadow-jar = "8.1.1"
 publish-plugin = "1.2.1"
+# The default version of Proguard that will be used in Compose Desktop Gradle plugin
+# to shrink and minimize the application in the Release build, the version can be overriden.
+default-proguard = "7.2.2"
 
 [libraries]
 download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }


### PR DESCRIPTION
This change is specific to **Compose Desktop**, when using Compose Desktop Gradle plugin to build the release version of the application

Move the Proguard version from `ProguardSettings.kt` to `gradle/libs.versions.toml` without any breaking change, this PR shouldn't affect the functionality, tests, or anything in any way

## Testing
Describe how you tested your changes. If possible and needed:
- Test it on a sample project: The examples use the libraries and plugins of Compose Desktop from Maven Central, I couldn't test this change on the new blank project as the Gradel build took longer than usual (about 1H), `gradlew build -x test` didn't skip the tests, in general, this PR should not introduce any new bugs, the property `DEFAULT_PROGUARD_VERSION` was is private in `ProguardSettings.kt`
- Write unit tests: I couldn't find `ComposeBuildConfigTest` or anything that tests the generated file, `DEFAULT_PROGUARD_VERSION`, or anything that's related to adding new tests.
- Provide a code snippet: This doesn't change how the developers will use the project, the goal is to help maintain the repository, Some versions are in `gradle.properties` others are in `gradle/libs.versions.toml`, I wasn't certain when should I use the Gradel version catalog or `gradle.properties` in this project

Let me know if any additional changes are required or if I should move the Proguard version to `gradle.properties`, rename the `default-proguard`