### PR TITLE
Fix `DesktopImageStorage` to store images by id, rather than by the `PictureData.Camera` itself

### DIFF
--- a/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/Dependencies.kt
+++ b/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/Dependencies.kt
@@ -39,6 +39,7 @@ abstract class Dependencies {
         }
 
         override fun saveImage(picture: PictureData.Camera, image: PlatformStorableImage) {
+            pictures.add(0, picture)
             imageStorage.saveImage(picture, image)
         }
 

--- a/examples/imageviewer/shared/src/desktopMain/kotlin/example/imageviewer/DesktopImageStorage.kt
+++ b/examples/imageviewer/shared/src/desktopMain/kotlin/example/imageviewer/DesktopImageStorage.kt
@@ -1,6 +1,5 @@
 package example.imageviewer
 
-import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toAwtImage
 import androidx.compose.ui.graphics.toComposeImageBitmap
@@ -13,25 +12,24 @@ private const val maxStorableImageSizePx = 2000
 private const val storableThumbnailSizePx = 200
 
 class DesktopImageStorage(
-    private val pictures: SnapshotStateList<PictureData>,
     private val ioScope: CoroutineScope
 ) : ImageStorage {
-    private val largeImages = mutableMapOf<PictureData.Camera, ImageBitmap>()
-    private val thumbnails = mutableMapOf<PictureData.Camera, ImageBitmap>()
+    private val largeImages = mutableMapOf<String, ImageBitmap>()
+    private val thumbnails = mutableMapOf<String, ImageBitmap>()
 
     override fun saveImage(picture: PictureData.Camera, image: PlatformStorableImage) {
         if (image.imageBitmap.width == 0 || image.imageBitmap.height == 0) {
             return
         }
         ioScope.launch {
-            largeImages[picture] = image.imageBitmap.fitInto(maxStorableImageSizePx)
-            thumbnails[picture] = image.imageBitmap.fitInto(storableThumbnailSizePx)
-            pictures.add(0, picture)
+            largeImages[picture.id] = image.imageBitmap.fitInto(maxStorableImageSizePx)
+            thumbnails[picture.id] = image.imageBitmap.fitInto(storableThumbnailSizePx)
         }
     }
 
     override fun delete(picture: PictureData.Camera) {
-        // For now, on Desktop pictures saving in memory. We don't need additional delete logic.
+        largeImages.remove(picture.id)
+        thumbnails.remove(picture.id)
     }
 
     override fun rewrite(picture: PictureData.Camera) {
@@ -39,11 +37,11 @@ class DesktopImageStorage(
     }
 
     override suspend fun getThumbnail(picture: PictureData.Camera): ImageBitmap {
-        return thumbnails[picture]!!
+        return thumbnails[picture.id]!!
     }
 
     override suspend fun getImage(picture: PictureData.Camera): ImageBitmap {
-        return largeImages[picture]!!
+        return largeImages[picture.id]!!
     }
 }
 

--- a/examples/imageviewer/shared/src/desktopMain/kotlin/example/imageviewer/view/ImageViewer.desktop.kt
+++ b/examples/imageviewer/shared/src/desktopMain/kotlin/example/imageviewer/view/ImageViewer.desktop.kt
@@ -104,7 +104,7 @@ private fun getDependencies(
                 toastState.value = ToastState.Shown(text)
             }
         }
-        override val imageStorage: DesktopImageStorage = DesktopImageStorage(pictures, ioScope)
+        override val imageStorage: DesktopImageStorage = DesktopImageStorage(ioScope)
         override val sharePicture: SharePicture = object : SharePicture {
             override fun share(context: PlatformContext, picture: PictureData) {
                 // On Desktop share feature not supported

--- a/examples/imageviewer/shared/src/iosMain/kotlin/example/imageviewer/storage/IosImageStorage.ios.kt
+++ b/examples/imageviewer/shared/src/iosMain/kotlin/example/imageviewer/storage/IosImageStorage.ios.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import platform.CoreGraphics.CGRectMake
@@ -36,7 +35,7 @@ private const val storableThumbnailSizePx = 180
 private const val jpegCompressionQuality = 60
 
 class IosImageStorage(
-    private val pictures: SnapshotStateList<PictureData>,
+    pictures: SnapshotStateList<PictureData>,
     private val ioScope: CoroutineScope
 ) : ImageStorage {
 
@@ -77,7 +76,6 @@ class IosImageStorage(
                 picture.jpgFile.writeJpeg(fitInto(maxStorableImageSizePx))
                 picture.thumbnailJpgFile.writeJpeg(fitInto(storableThumbnailSizePx))
             }
-            pictures.add(0, picture)
             picture.jsonFile.writeText(picture.toJson())
         }
     }


### PR DESCRIPTION
`DesktopImageStorage` was using the `PictureData.Camera` itself as the key to its images, which is wrong, because `PictureData.Camera` contains metadata that can change. This causes a crash when editing e.g. the description of an image.

Also moved responsibility for putting a new picture into `pictures` from `DesktopImageStorage` to `Dependencies`, as all the other management of pictures is there.

## Testing
- Tested manually.
