### PR TITLE
Pack all resources to assets on the android target.

### DIFF
--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -187,6 +187,7 @@ android {
             assets.srcDir("src/androidInstrumentedTest/assets")
         }
         named("test") { resources.srcDir(commonTestResources) }
+        named("main") { manifest.srcFile("src/androidMain/AndroidManifest.xml") }
     }
 }
 

--- a/components/resources/library/src/androidMain/AndroidManifest.xml
+++ b/components/resources/library/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <provider
+                android:authorities="org.jetbrains.compose.resources.AndroidContextProvider"
+                android:name="org.jetbrains.compose.resources.AndroidContextProvider"
+                android:exported="false"
+                android:enabled="true">
+        </provider>
+    </application>
+
+</manifest>

--- a/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/AndroidContextProvider.kt
+++ b/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/AndroidContextProvider.kt
@@ -1,0 +1,41 @@
+package org.jetbrains.compose.resources
+
+import android.annotation.SuppressLint
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+
+internal val androidContext get() = AndroidContextProvider.ANDROID_CONTEXT
+
+//https://andretietz.com/2017/09/06/autoinitialise-android-library/
+internal class AndroidContextProvider : ContentProvider() {
+    companion object {
+        @SuppressLint("StaticFieldLeak")
+        lateinit var ANDROID_CONTEXT: Context
+            private set
+    }
+
+    override fun onCreate(): Boolean {
+        ANDROID_CONTEXT = context ?: error("AndroidContextProvider context is null")
+        return true
+    }
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?
+    ): Cursor? = null
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int = 0
+}

--- a/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/FontResources.android.kt
+++ b/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/FontResources.android.kt
@@ -9,5 +9,5 @@ import androidx.compose.ui.text.font.*
 actual fun Font(resource: FontResource, weight: FontWeight, style: FontStyle): Font {
     val environment = LocalComposeEnvironment.current.rememberEnvironment()
     val path = remember(environment, resource) { resource.getResourceItemByEnvironment(environment).path }
-    return Font(path, LocalContext.current.assets, weight, style)
+    return Font(path, androidContext.assets, weight, style)
 }

--- a/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/ResourceReader.android.kt
+++ b/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/ResourceReader.android.kt
@@ -1,9 +1,13 @@
 package org.jetbrains.compose.resources
 
-import java.io.File
+import android.content.res.AssetManager
+import android.net.Uri
+import java.io.IOException
 import java.io.InputStream
 
 internal actual fun getPlatformResourceReader(): ResourceReader = object : ResourceReader {
+    private val assets: AssetManager = androidContext.assets
+
     override suspend fun read(path: String): ByteArray {
         val resource = getResourceAsStream(path)
         return resource.readBytes()
@@ -40,32 +44,39 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
     }
 
     override fun getUri(path: String): String {
-        val classLoader = getClassLoader()
-        val resource = classLoader.getResource(path) ?: run {
-            //try to find a font in the android assets
-            if (File(path).isFontResource()) {
-                classLoader.getResource("assets/$path")
-            } else null
-        } ?: throw MissingResourceException(path)
-        return resource.toURI().toString()
+        val uri = if (assets.hasFile(path)) {
+            Uri.parse("file:///android_asset/$path")
+        } else {
+            val classLoader = getClassLoader()
+            val resource = classLoader.getResource(path) ?: throw MissingResourceException(path)
+            resource.toURI()
+        }
+        return uri.toString()
     }
 
     private fun getResourceAsStream(path: String): InputStream {
-        val classLoader = getClassLoader()
-        val resource = classLoader.getResourceAsStream(path) ?: run {
-            //try to find a font in the android assets
-            if (File(path).isFontResource()) {
-                classLoader.getResourceAsStream("assets/$path")
-            } else null
-        } ?: throw MissingResourceException(path)
-        return resource
-    }
-
-    private fun File.isFontResource(): Boolean {
-        return this.parentFile?.name.orEmpty().startsWith("font")
+        return try {
+            assets.open(path)
+        } catch (e: IOException) {
+            val classLoader = getClassLoader()
+            classLoader.getResourceAsStream(path) ?: throw MissingResourceException(path)
+        }
     }
 
     private fun getClassLoader(): ClassLoader {
         return this.javaClass.classLoader ?: error("Cannot find class loader")
+    }
+
+    private fun AssetManager.hasFile(path: String): Boolean {
+        var inputStream: InputStream? = null
+        val result = try {
+            inputStream = open(path)
+            true
+        } catch (e: IOException) {
+            false
+        } finally {
+            inputStream?.close()
+        }
+        return result
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
@@ -39,8 +39,6 @@ internal fun Project.configureAndroidComposeResources(
                     .all { androidSourceSet ->
                         (compilation.allKotlinSourceSets as? ObservableSet<KotlinSourceSet>)?.forAll { kotlinSourceSet ->
                             val preparedComposeResources = getPreparedComposeResourcesDir(kotlinSourceSet)
-                            androidSourceSet.resources.srcDirs(preparedComposeResources)
-
                             //fix for AGP < 8.0
                             //usually 'androidSourceSet.resources.srcDir(preparedCommonResources)' should be enough
                             compilation.androidVariant.processJavaResourcesProvider.configure {
@@ -69,22 +67,20 @@ internal fun Project.configureAndroidComposeResources(
             }
         }
 
-        val copyFonts = registerTask<CopyAndroidFontsToAssetsTask>(
-            "copy${variant.name.uppercaseFirstChar()}FontsToAndroidAssets"
+        val copyResources = registerTask<CopyResourcesToAndroidAssetsTask>(
+            "copy${variant.name.uppercaseFirstChar()}ResourcesToAndroidAssets"
         ) {
             from.set(variantResources)
         }
         variant.sources?.assets?.addGeneratedSourceDirectory(
-            taskProvider = copyFonts,
-            wiredWith = CopyAndroidFontsToAssetsTask::outputDirectory
+            taskProvider = copyResources,
+            wiredWith = CopyResourcesToAndroidAssetsTask::outputDirectory
         )
-        //exclude a duplication of fonts in apks
-        variant.packaging.resources.excludes.add("**/font*/*")
     }
 }
 
 //Copy task doesn't work with 'variant.sources?.assets?.addGeneratedSourceDirectory' API
-internal abstract class CopyAndroidFontsToAssetsTask : DefaultTask() {
+internal abstract class CopyResourcesToAndroidAssetsTask : DefaultTask() {
     @get:Inject
     abstract val fileSystem: FileSystemOperations
 
@@ -100,7 +96,6 @@ internal abstract class CopyAndroidFontsToAssetsTask : DefaultTask() {
         fileSystem.copy {
             it.includeEmptyDirs = false
             it.from(from)
-            it.include("**/font*/*")
             it.into(outputDirectory)
         }
     }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/KmpResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/KmpResources.kt
@@ -32,28 +32,26 @@ internal fun Project.configureKmpResources(
             logger.info("Configure resources publication for '${target.targetName}' target")
             val packedResourceDir = config.getModuleResourcesDir(project)
 
-            kmpResources.publishResourcesAsKotlinComponent(
-                target,
-                { sourceSet ->
-                    KotlinTargetResourcesPublication.ResourceRoot(
-                        getPreparedComposeResourcesDir(sourceSet),
-                        emptyList(),
-                        //for android target exclude fonts
-                        if (target is KotlinAndroidTarget) listOf("**/font*/*") else emptyList()
-                    )
-                },
-                packedResourceDir
-            )
-
-            if (target is KotlinAndroidTarget) {
-                //for android target publish fonts in assets
-                logger.info("Configure fonts relocation for '${target.targetName}' target")
+            if (target !is KotlinAndroidTarget) {
+                kmpResources.publishResourcesAsKotlinComponent(
+                    target,
+                    { sourceSet ->
+                        KotlinTargetResourcesPublication.ResourceRoot(
+                            getPreparedComposeResourcesDir(sourceSet),
+                            emptyList(),
+                            emptyList()
+                        )
+                    },
+                    packedResourceDir
+                )
+            } else {
+                //for android target publish resources in assets
                 kmpResources.publishInAndroidAssets(
                     target,
                     { sourceSet ->
                         KotlinTargetResourcesPublication.ResourceRoot(
                             getPreparedComposeResourcesDir(sourceSet),
-                            listOf("**/font*/*"),
+                            emptyList(),
                             emptyList()
                         )
                     },


### PR DESCRIPTION
The PR changes the android resources packaging. Now all resources are packed to the android assets (not only fonts). It unblocks usage android URIs to the resources in a WebView or other external resource consumers.

For a backward compatibility the resources library tries to read resources in java resources if assets were not found.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4877
Fixes https://github.com/JetBrains/compose-multiplatform/issues/4503

## Release Notes

### Features - Resources
- Describe another change if needed
