### PR TITLE
[resources] Update resource density-based lookup to be equal with the android logic

### DIFF
--- a/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.kt
+++ b/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.kt
@@ -60,6 +60,44 @@ class ComposeResourceTest {
     }
 
     @Test
+    fun testImageResourceDensity() = runComposeUiTest {
+        val testResourceReader = TestResourceReader()
+        val imgRes = DrawableResource(
+            "test_id", setOf(
+                ResourceItem(setOf(DensityQualifier.XXXHDPI), "2.png", -1, -1),
+                ResourceItem(setOf(DensityQualifier.MDPI), "1.png", -1, -1),
+            )
+        )
+        val mdpiEnvironment = object : ComposeEnvironment {
+            @Composable
+            override fun rememberEnvironment() = ResourceEnvironment(
+                language = LanguageQualifier("en"),
+                region = RegionQualifier("US"),
+                theme = ThemeQualifier.LIGHT,
+                density = DensityQualifier.MDPI
+            )
+        }
+
+        var environment by mutableStateOf(TestComposeEnvironment)
+        setContent {
+            CompositionLocalProvider(
+                LocalResourceReader provides testResourceReader,
+                LocalComposeEnvironment provides environment
+            ) {
+                Image(painterResource(imgRes), null)
+            }
+        }
+        waitForIdle()
+        environment = mdpiEnvironment
+        waitForIdle()
+
+        assertEquals(
+            expected = listOf("2.png", "1.png"), //XXXHDPI - fist, MDPI - next
+            actual = testResourceReader.readPaths
+        )
+    }
+
+    @Test
     fun testStringResourceCache() = runComposeUiTest {
         val testResourceReader = TestResourceReader()
         var res by mutableStateOf(TestStringResource("app_name"))


### PR DESCRIPTION
In general, Android prefers scaling down a larger original image to scaling up a smaller original image: https://developer.android.com/guide/topics/resources/providing-resources#BestMatch

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4368

## Release Notes
### Highlights - Resources
- If there is no resource with suitable density, use resource with the most suitable density, otherwise use default (similar to the Android logic)