### PR TITLE
Refresh desktop preview (#2921)

### DIFF
--- a/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/PreviewActions.kt
+++ b/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/PreviewActions.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.compose.desktop.ide.preview
 
 import com.intellij.execution.executors.DefaultRunExecutor
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -27,6 +28,14 @@ class RunPreviewAction(
 ) : AnAction({ "Show non-interactive preview" }, PreviewIcons.RUN_PREVIEW) {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
+        buildPreviewViaGradle(project, previewLocation)
+    }
+}
+
+class RefreshShownPreviewAction : AnAction({ "Refresh last preview" }, AllIcons.Actions.Refresh) {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val previewLocation = project.service<PreviewStateService>().lastPreviewLocation ?: return
         buildPreviewViaGradle(project, previewLocation)
     }
 }
@@ -79,10 +88,10 @@ private fun buildPreviewViaGradle(project: Project, previewLocation: PreviewLoca
         GradleConstants.SYSTEM_ID,
         object : TaskCallback {
             override fun onSuccess() {
-                previewService.buildFinished(success = true)
+                previewService.buildFinished(previewLocation, success = true)
             }
             override fun onFailure() {
-                previewService.buildFinished(success = false)
+                previewService.buildFinished(previewLocation, success = false)
             }
         },
         ProgressExecutionMode.IN_BACKGROUND_ASYNC,

--- a/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/PreviewStateService.kt
+++ b/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/PreviewStateService.kt
@@ -32,6 +32,9 @@ class PreviewStateService(private val myProject: Project) : Disposable {
     private val configurePreviewTaskNameCache =
         ConfigurePreviewTaskNameCache(ConfigurePreviewTaskNameProviderImpl())
 
+    var lastPreviewLocation: PreviewLocation? = null
+        private set
+
     init {
         val projectRefreshListener = ConfigurePreviewTaskNameCacheInvalidator(configurePreviewTaskNameCache)
         ExternalSystemProgressNotificationManager.getInstance()
@@ -63,7 +66,8 @@ class PreviewStateService(private val myProject: Project) : Disposable {
         previewListener.onNewBuildRequest()
     }
 
-    internal fun buildFinished(success: Boolean) {
+    internal fun buildFinished(previewLocation: PreviewLocation, success: Boolean) {
+        lastPreviewLocation = previewLocation
         previewListener.onFinishedBuild(success)
     }
 }

--- a/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/PreviewToolWindow.kt
+++ b/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/PreviewToolWindow.kt
@@ -25,6 +25,7 @@ class PreviewToolWindow : ToolWindowFactory, DumbAware {
     }
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        toolWindow.setTitleActions(listOf(RefreshShownPreviewAction()))
         toolWindow.contentManager.let { content ->
             val panel = PreviewPanel(project)
             val loadingPanel = JBLoadingPanel(BorderLayout(), project)

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -48,6 +48,9 @@
     </extensions>
 
     <actions>
+        <group id="Compose.Desktop.Preview">
+            <action class="org.jetbrains.compose.desktop.ide.preview.RefreshShownPreviewAction"/>
+        </group>
         <group id="Compose.Desktop.Preview.Editor.Toolbar">
             <action class="org.jetbrains.compose.desktop.ide.preview.RefreshOrRunPreviewAction"/>
         </group>


### PR DESCRIPTION
Add refresh action to desktop preview window
Add global action for refreshing desktop preview (keymap can be assigned) 
Partially addresses #2921 by allowing user to refresh already shown preview more easily after changing the previewed UI code