### PR TITLE
Show desktop preview tool for common preview (#4839)

### DIFF
--- a/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/PreviewEntryPoint.kt
+++ b/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/PreviewEntryPoint.kt
@@ -37,7 +37,8 @@ class PreviewEntryPoint : EntryPoint() {
     override fun isEntryPoint(refElement: RefElement, psiElement: PsiElement): Boolean = isEntryPoint(psiElement)
 
     override fun isEntryPoint(psiElement: PsiElement): Boolean =
-        psiElement is PsiMethod && psiElement.hasAnnotation(DESKTOP_PREVIEW_ANNOTATION_FQN)
+        psiElement is PsiMethod && (psiElement.hasAnnotation(DESKTOP_PREVIEW_ANNOTATION_FQN) ||
+                psiElement.hasAnnotation(COMMON_PREVIEW_ANNOTATION_FQN))
 
     override fun readExternal(element: Element) = element.deserializeInto(this)
 

--- a/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/locationUtils.kt
+++ b/idea-plugin/src/main/kotlin/org/jetbrains/compose/desktop/ide/preview/locationUtils.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 
 internal const val DESKTOP_PREVIEW_ANNOTATION_FQN = "androidx.compose.desktop.ui.tooling.preview.Preview"
+internal const val COMMON_PREVIEW_ANNOTATION_FQN = "org.jetbrains.compose.ui.tooling.preview.Preview"
 internal const val COMPOSABLE_FQ_NAME = "androidx.compose.runtime.Composable"
 
 /**
@@ -120,7 +121,9 @@ internal fun KtNamedFunction.isValidComposablePreviewFunction(): Boolean {
         while (annotationIt.hasNext() && !(hasComposableAnnotation && hasPreviewAnnotation)) {
             val annotation = annotationIt.next()
             hasComposableAnnotation = hasComposableAnnotation || annotation.fqNameMatches(COMPOSABLE_FQ_NAME)
-            hasPreviewAnnotation = hasPreviewAnnotation || annotation.fqNameMatches(DESKTOP_PREVIEW_ANNOTATION_FQN)
+            hasPreviewAnnotation = hasPreviewAnnotation ||
+                    annotation.fqNameMatches(DESKTOP_PREVIEW_ANNOTATION_FQN) ||
+                    annotation.fqNameMatches(COMMON_PREVIEW_ANNOTATION_FQN)
         }
 
         return hasComposableAnnotation && hasPreviewAnnotation


### PR DESCRIPTION
Allows desktop preview to work with org.jetbrains.compose.ui.tooling.preview.Preview annotation in addition to desktop preview annotation. That allows using preview in common code (#2045), though only with desktop target enabled

Fixes #4839, #2045
