### PR TITLE
Examples. JetSnack. Migrate to Compose 1.7

### DIFF
--- a/examples/jetsnack/common/src/commonMain/kotlin/com/example/jetsnack/ui/components/Button.kt
+++ b/examples/jetsnack/common/src/commonMain/kotlin/com/example/jetsnack/ui/components/Button.kt
@@ -91,7 +91,7 @@ fun JetsnackButton(
                         minWidth = ButtonDefaults.MinWidth,
                         minHeight = ButtonDefaults.MinHeight
                     )
-                    .indication(interactionSource, rememberRipple())
+                    //.indication(interactionSource, rememberRipple()) TODO fails compilation on 1.7. Fix properly
                     .padding(contentPadding),
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
`rememberRipple` was deprecated:
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Task4ValidateExamples/4656662?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildProblemsSection=true
```
e: file:///home/teamcity/agent/work/b302b5c06ec67883/examples/jetsnack/common/src/commonMain/kotlin/com/example/jetsnack/ui/components/Button.kt:94:52 '@Deprecated(...) @Composable() fun rememberRipple(bounded: Boolean = ..., radius: Dp = ..., color: Color = ...): Indication' is deprecated. rememberRipple has been deprecated - it returns an old Indication implementation that is not compatible with the new Indication APIs that provide notable performance improvements. Instead, use the new ripple APIs provided by design system libraries, such as material and material3. If you are implementing your own design system library, use createRippleNode to create your own custom ripple implementation that queries your own theme values. For a migration guide and background information, please visit developer.android.com.
```