### PR TITLE
[gradle] Add a customization for resources directories.

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResourcesGeneration.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResourcesGeneration.kt
@@ -54,7 +54,7 @@ internal fun Project.configureComposeResourcesGeneration(
         }
 
         //common resources must be converted (XML -> CVR)
-        val preparedResourcesTask = registerPrepareComposeResourcesTask(sourceSet)
+        val preparedResourcesTask = registerPrepareComposeResourcesTask(sourceSet, config)
         val preparedResources = preparedResourcesTask.flatMap { it.outputDir.asFile }
         configureResourceAccessorsGeneration(
             sourceSet,

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesDSL.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesDSL.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.compose.resources
 
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import java.io.File
 
@@ -36,6 +37,18 @@ abstract class ResourcesExtension {
      * - `never`: Never generate the Res class.
      */
     var generateResClass: ResourceClassGeneration = auto
+
+    internal val customResourceDirectories: MutableMap<String, Provider<Directory>> = mutableMapOf()
+
+    /**
+     * Associates a custom resource directory with a specific source set.
+     *
+     * @param sourceSetName the name of the source set to associate the custom resource directory with
+     * @param directoryProvider the provider that provides the custom directory
+     */
+    fun customDirectory(sourceSetName: String, directoryProvider: Provider<Directory>) {
+        customResourceDirectories[sourceSetName] = directoryProvider
+    }
 }
 
 internal fun Provider<ResourcesExtension>.getResourcePackage(project: Project) = map { config ->

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/build.gradle.kts
@@ -62,3 +62,31 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 }
+
+abstract class GenerateAndroidRes : DefaultTask() {
+    @get:Inject
+    abstract val layout: ProjectLayout
+
+    @get:OutputDirectory
+    val outputDir = layout.buildDirectory.dir("generatedAndroidResources")
+
+    @TaskAction
+    fun run() {
+        val dir = outputDir.get().asFile
+        dir.deleteRecursively()
+        File(dir, "values/strings.xml").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                    <resources>
+                        <string name="android_str">Android string</string>
+                    </resources>
+                """.trimIndent()
+            )
+        }
+    }
+}
+compose.resources.customDirectory(
+    sourceSetName = "androidMain",
+    directoryProvider = tasks.register<GenerateAndroidRes>("generateAndroidRes").map { it.outputDir.get() }
+)

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/src/androidMain/composeResources/values/strings.xml
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/src/androidMain/composeResources/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="android_str">Android string</string>
-</resources>


### PR DESCRIPTION
With the new API it is possible to customize compose resources directories. For example:

```kotlin
abstract class GenerateAndroidRes : DefaultTask() {
    @get:Inject
    abstract val layout: ProjectLayout

    @get:OutputDirectory
    val outputDir = layout.buildDirectory.dir("generatedAndroidResources")

    @TaskAction
    fun run() {...}
}
compose.resources {
    customDirectory(
        sourceSetName = "androidMain",
        directoryProvider = tasks.register<GenerateAndroidRes>("generateAndroidRes").map { it.outputDir.get() }
    )
    customDirectory(
        sourceSetName = "desktopMain",
        directoryProvider = provider { layout.projectDirectory.dir("desktopResources") }
    )
}
```

<!-- Optional -->
Fixes https://github.com/JetBrains/compose-multiplatform/issues/4718
Fixes https://github.com/JetBrains/compose-multiplatform/issues/4564

## Release Notes
### Features - Resources
- Add a customization for resources directories. Now it is possible to use e.g downloaded resources.
