### PR TITLE
[gradle] Fix task configuration (use configureEach instead all).

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
@@ -122,7 +122,7 @@ internal fun Project.configureAndroidAssetsForPreview() {
 
             if (androidComponents.pluginVersion >= agp_8_1_0) {
                 // addGeneratedSourceDirectory doesn't mark the output directory as assets hence AS Compose Preview doesn't work
-                tasks.all { task ->
+                tasks.configureEach { task ->
                     if (task.name == kgpCopyAssetsTaskName) {
                         task.outputs.files.forEach { file ->
                             addStaticSourceDirectory(file.path)


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/5061

## Release Notes
### Fixes - Gradle Plugin
- _(prerelease fix)_ Fix "InvalidUserDataException: Cannot change hierarchy of dependency configuration" on Gradle sync