### PR TITLE
Update compose compiler version for kotlin 1.9.24

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatibility.kt
@@ -24,7 +24,7 @@ internal object ComposeCompilerCompatibility {
         "1.9.21" to "1.5.4",
         "1.9.22" to "1.5.8.1",
         "1.9.23" to "1.5.13.5",
-        "1.9.24" to "1.5.14",
+        "1.9.24" to "1.5.14.1-beta02",
         "2.0.0-Beta1" to "1.5.4-dev1-kt2.0.0-Beta1",
         "2.0.0-Beta4" to "1.5.9-kt-2.0.0-Beta4",
         "2.0.0-Beta5" to "1.5.11-kt-2.0.0-Beta5",

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -8,7 +8,7 @@ kotlin.code.style=official
 dev.junit.parallel=false
 
 # Default version of Compose Libraries used by Gradle plugin
-compose.version=1.6.10
+compose.version=1.7.0-alpha01
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
 compose.tests.kotlin.version=2.0.0
 # __SUPPORTED_GRADLE_VERSIONS__


### PR DESCRIPTION
This fixes https://youtrack.jetbrains.com/issue/CMP-1612 and https://youtrack.jetbrains.com/issue/CMP-1602/Html-js-error-content-is-not-a-function