### PR TITLE
[gradle] Use `addStaticSourceDirectory` in AGP to fix AS previews with compose resources.

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResources.kt
@@ -40,7 +40,13 @@ private fun Project.onKgpApplied(config: Provider<ResourcesExtension>, kgp: Kotl
     if (kmpResourcesAreAvailable) {
         configureKmpResources(kotlinExtension, extraProperties.get(KMP_RES_EXT)!!, config)
         onAgpApplied {
-            configureAndroidAssetsForPreview()
+            //workaround to fix AndroidStudio preview works with compose resources:
+            //it copies android assets and mark it as a static assets dir
+            //yes, the same resources will be registered in AGP twice: from KGP and here as static dirs
+            //but it works fine and there are no problems during merge android assets
+            configureAndroidComposeResources { variant ->
+                getKgpAndroidVariantComposeResources(variant)
+            }
             fixAndroidLintTaskDependencies()
         }
     } else {
@@ -63,7 +69,9 @@ private fun Project.onKgpApplied(config: Provider<ResourcesExtension>, kgp: Kotl
         configureComposeResources(kotlinExtension, commonMain, config)
 
         onAgpApplied {
-            configureAndroidComposeResources(kotlinExtension)
+            configureAndroidComposeResources { variant ->
+                getAndroidVariantComposeResources(kotlinExtension, variant)
+            }
             fixAndroidLintTaskDependencies()
         }
     }


### PR DESCRIPTION
More info: https://issuetracker.google.com/348208777

Fixes https://github.com/JetBrains/compose-multiplatform/issues/5053

## Release Notes
### Fixes - Resources
- _(prerelease fix)_ Fix an android app compose resources packaging broken after introduction AS previews
