### PR TITLE
[gradle] Disable code generation tasks if they are not needed.

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResourcesGeneration.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResourcesGeneration.kt
@@ -98,17 +98,21 @@ private fun Project.configureResClassGeneration(
         GenerateResClassTask::class.java
     ) { task ->
         task.packageName.set(packageName)
-        task.shouldGenerateCode.set(shouldGenerateCode)
         task.makeAccessorsPublic.set(makeAccessorsPublic)
         task.codeDir.set(layout.buildDirectory.dir("$RES_GEN_DIR/kotlin/commonResClass"))
 
         if (generateModulePath) {
             task.packagingDir.set(packagingDir)
         }
+        task.onlyIf { shouldGenerateCode.get() }
     }
 
     //register generated source set
-    resClassSourceSet.kotlin.srcDir(genTask.map { it.codeDir })
+    resClassSourceSet.kotlin.srcDir(
+        genTask.zip(shouldGenerateCode) { task, flag ->
+            if (flag) listOf(task.codeDir) else emptyList()
+        }
+    )
 }
 
 private fun Project.configureResourceAccessorsGeneration(
@@ -128,7 +132,6 @@ private fun Project.configureResourceAccessorsGeneration(
     ) { task ->
         task.packageName.set(packageName)
         task.sourceSetName.set(sourceSet.name)
-        task.shouldGenerateCode.set(shouldGenerateCode)
         task.makeAccessorsPublic.set(makeAccessorsPublic)
         task.resDir.set(resourcesDir)
         task.codeDir.set(layout.buildDirectory.dir("$RES_GEN_DIR/kotlin/${sourceSet.name}ResourceAccessors"))
@@ -136,10 +139,15 @@ private fun Project.configureResourceAccessorsGeneration(
         if (generateModulePath) {
             task.packagingDir.set(packagingDir)
         }
+        task.onlyIf { shouldGenerateCode.get() }
     }
 
     //register generated source set
-    sourceSet.kotlin.srcDir(genTask.map { it.codeDir })
+    sourceSet.kotlin.srcDir(
+        genTask.zip(shouldGenerateCode) { task, flag ->
+            if (flag) listOf(task.codeDir) else emptyList()
+        }
+    )
 }
 
 private fun KotlinSourceSet.getResourceAccessorsGenerationTaskName(): String {
@@ -219,13 +227,17 @@ private fun Project.configureExpectResourceCollectorsGeneration(
         GenerateExpectResourceCollectorsTask::class.java
     ) { task ->
         task.packageName.set(packageName)
-        task.shouldGenerateCode.set(shouldGenerateCode)
         task.makeAccessorsPublic.set(makeAccessorsPublic)
         task.codeDir.set(layout.buildDirectory.dir("$RES_GEN_DIR/kotlin/${sourceSet.name}ResourceCollectors"))
+        task.onlyIf { shouldGenerateCode.get() }
     }
 
     //register generated source set
-    sourceSet.kotlin.srcDir(genTask.map { it.codeDir })
+    sourceSet.kotlin.srcDir(
+        genTask.zip(shouldGenerateCode) { task, flag ->
+            if (flag) listOf(task.codeDir) else emptyList()
+        }
+    )
 }
 
 private fun Project.configureActualResourceCollectorsGeneration(
@@ -257,13 +269,17 @@ private fun Project.configureActualResourceCollectorsGeneration(
         GenerateActualResourceCollectorsTask::class.java
     ) { task ->
         task.packageName.set(packageName)
-        task.shouldGenerateCode.set(shouldGenerateCode)
         task.makeAccessorsPublic.set(makeAccessorsPublic)
         task.useActualModifier.set(useActualModifier)
         task.resourceAccessorDirs.from(accessorDirs)
         task.codeDir.set(layout.buildDirectory.dir("$RES_GEN_DIR/kotlin/${sourceSet.name}ResourceCollectors"))
+        task.onlyIf { shouldGenerateCode.get() }
     }
 
     //register generated source set
-    sourceSet.kotlin.srcDir(genTask.map { it.codeDir })
+    sourceSet.kotlin.srcDir(
+        genTask.zip(shouldGenerateCode) { task, flag ->
+            if (flag) listOf(task.codeDir) else emptyList()
+        }
+    )
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
@@ -21,9 +21,6 @@ internal abstract class GenerateResClassTask : IdeaImportTask() {
     abstract val packagingDir: Property<File>
 
     @get:Input
-    abstract val shouldGenerateCode: Property<Boolean>
-
-    @get:Input
     abstract val makeAccessorsPublic: Property<Boolean>
 
     @get:OutputDirectory
@@ -34,15 +31,11 @@ internal abstract class GenerateResClassTask : IdeaImportTask() {
         dir.deleteRecursively()
         dir.mkdirs()
 
-        if (shouldGenerateCode.get()) {
-            logger.info("Generate $RES_FILE_NAME.kt")
+        logger.info("Generate $RES_FILE_NAME.kt")
 
-            val pkgName = packageName.get()
-            val moduleDirectory = packagingDir.getOrNull()?.let { it.invariantSeparatorsPath + "/" } ?: ""
-            val isPublic = makeAccessorsPublic.get()
-            getResFileSpec(pkgName, RES_FILE_NAME, moduleDirectory, isPublic).writeTo(dir)
-        } else {
-            logger.info("Generation Res class is disabled")
-        }
+        val pkgName = packageName.get()
+        val moduleDirectory = packagingDir.getOrNull()?.let { it.invariantSeparatorsPath + "/" } ?: ""
+        val isPublic = makeAccessorsPublic.get()
+        getResFileSpec(pkgName, RES_FILE_NAME, moduleDirectory, isPublic).writeTo(dir)
     }
 }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -488,8 +488,7 @@ class ResourcesTest : GradlePluginTestBase() {
             )
         }
         gradle("prepareKotlinIdeaImport").checks {
-            check.taskSuccessful(":generateComposeResClass")
-            assertFalse(file("build/generated/compose/resourceGenerator/kotlin/commonResClass/app/group/resources_test/generated/resources/Res.kt").exists())
+            check.taskSkipped(":generateComposeResClass")
         }
 
         modifyText("build.gradle.kts") { str ->
@@ -571,8 +570,14 @@ class ResourcesTest : GradlePluginTestBase() {
                 }
             """.trimIndent()
         )
-        gradle("generateComposeResClass").checks {
-            check.logContains("Generation Res class is disabled")
+        gradle("prepareKotlinIdeaImport").checks {
+            check.taskSkipped(":generateComposeResClass")
+            check.taskSkipped(":generateResourceAccessorsForCommonMain")
+            check.taskSkipped(":generateResourceAccessorsForDesktopMain")
+            check.taskSkipped(":generateResourceAccessorsForAndroidMain")
+            check.taskSkipped(":generateExpectResourceCollectorsForCommonMain")
+            check.taskSkipped(":generateActualResourceCollectorsForDesktopMain")
+            check.taskSkipped(":generateActualResourceCollectorsForAndroidMain")
         }
     }
 


### PR DESCRIPTION
Small refactor: instead of the run tasks in a dumb mode just skip them if the resource accessors generation is disabled.
