### PR TITLE
[resources] Add image bitmap/xml/svg bytearray converters to the corresponding source sets.

### DIFF
--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.kt
@@ -1,11 +1,27 @@
 package org.jetbrains.compose.resources
 
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Density
 import org.jetbrains.compose.resources.vector.toImageVector
 
 /**
+ * Decodes a byte array of a Bitmap to an ImageBitmap. Supports JPEG, PNG, BMP, WEBP
+ *
+ * Different platforms can support additional formats.
+ *
+ * @return The converted ImageBitmap.
+ */
+@ExperimentalResourceApi
+fun ByteArray.decodeToImageBitmap(): ImageBitmap {
+    val dumbDensity = 0 //any equal source and target density disable scaling here
+    return this.toImageBitmap(dumbDensity, dumbDensity)
+}
+
+/**
  * Decodes a byte array of a vector XML file to an ImageVector.
+ *
+ * @param density density to apply during converting the source units to the [ImageVector] units.
  *
  * @return The converted ImageVector.
  */

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.compose.resources
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Density
+import org.jetbrains.compose.resources.vector.toImageVector
+
+/**
+ * Decodes a byte array of a vector XML file to an ImageVector.
+ *
+ * @return The converted ImageVector.
+ */
+@ExperimentalResourceApi
+fun ByteArray.decodeToImageVector(density: Density): ImageVector {
+    return this.toXmlElement().toImageVector(density)
+}

--- a/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.skiko.kt
+++ b/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.skiko.kt
@@ -1,10 +1,13 @@
 package org.jetbrains.compose.resources
 
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Density
 
 /**
  * Decodes a byte array of an SVG file to a compose Painter.
+ *
+ * @param density density to apply during converting the source units to the [Painter] units.
  *
  * @return The converted Painter.
  */

--- a/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.skiko.kt
+++ b/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.skiko.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.compose.resources
+
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Density
+
+/**
+ * Decodes a byte array of an SVG file to a compose Painter.
+ *
+ * @return The converted Painter.
+ */
+@ExperimentalResourceApi
+fun ByteArray.decodeToSvgPainter(density: Density): Painter {
+    return this.toSvgElement().toSvgPainter(density)
+}


### PR DESCRIPTION
The PR adds a method to convert a bitmap bytearray to the ImageBitma, a vector XML content bytearray to the ImageVector in the common code. And the same for an SVG files on non-android targets.

<!-- Optional -->
Fixes https://youtrack.jetbrains.com/issue/CMP-3869
Fixes https://youtrack.jetbrains.com/issue/CMP-4925

## Release Notes
### Features - Resources
- Added utility functions to decode `Bitmap ByteArray as ImageVector` and `XML ByteArray as ImageVector` in the common code and `SVG ByteArray as Painter` in the non-android code
