### PR TITLE
fix: Incorrect Web Build Command

### DIFF
--- a/examples/imageviewer/README.md
+++ b/examples/imageviewer/README.md
@@ -29,7 +29,7 @@ Choose a run configuration for an appropriate target in IDE and run it.
 
 ## Run on Web via Gradle
 
-`./gradlew :web:wasmJsRun`
+`./gradlew :composeApp:wasmJsRun`
 
 ### Running Android application
 

--- a/examples/jetsnack/README.md
+++ b/examples/jetsnack/README.md
@@ -84,7 +84,7 @@ To build and run the Jetsnack application with Compose Multiplatform for web and
 
 * **Web version:**
 
-  `./gradlew :web:wasmJsRun`
+  `./gradlew :composeApp:wasmJsRun`
   <br>&nbsp;<br>
 
   Once the application starts, open the following URL in your browser: 


### PR DESCRIPTION
### Overview
Corrected the Web build command for Jetsnack and Imageviewer. The previously documented command ```./gradlew :web:wasmJsRun``` resulted in a build failure due to the project 'web' not being found. The correct command is ```./gradlew :composeApp:wasmJsRun``` . This update ensures accurate instructions for building the Web component.

Example of the error message when using the incorrect command:
```
Cannot locate tasks that match ':web:wasmJsRun' as project 'web' not found in root project 'KotlinProject'.
```

## Testing
- Confirmed the fixed command ```./gradlew :composeApp:wasmJsRun``` successfully starts up the localhost and displays the contents.

### Section - Subsection
Web
Build System
(prerelease fix) Corrected the Web build command from ```./gradlew :web:wasmJsRun``` to ```./gradlew :composeApp:wasmJsRun```, fixing a bug introduced in a prerelease version. This ensures the correct project is targeted during the build process.

### Section - Subsection
N/A