### PR TITLE
Add support for high-refresh rate displays in examples

### DIFF
--- a/examples/chat/iosApp/iosApp/Info.plist
+++ b/examples/chat/iosApp/iosApp/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/examples/codeviewer/iosApp/iosApp/Info.plist
+++ b/examples/codeviewer/iosApp/iosApp/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/examples/graphics-2d/iosApp/iosApp/Info.plist
+++ b/examples/graphics-2d/iosApp/iosApp/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/examples/imageviewer/iosApp/iosApp/Info.plist
+++ b/examples/imageviewer/iosApp/iosApp/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>This app uses camera for capturing photos</string>
 	<key>UIApplicationSceneManifest</key>

--- a/examples/jetsnack/ios/iosApp/Info.plist
+++ b/examples/jetsnack/ios/iosApp/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>This app uses camera for capturing photos</string>
 	<key>UIApplicationSceneManifest</key>

--- a/examples/todoapp-lite/iosApp/iosApp/Info.plist
+++ b/examples/todoapp-lite/iosApp/iosApp/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/examples/widgets-gallery/iosApp/iosApp/Info.plist
+++ b/examples/widgets-gallery/iosApp/iosApp/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
Turns out a number of our samples were still missing

```
	<key>CADisableMinimumFrameDurationOnPhone</key>
	<true/>
```