### PR TITLE
Fix skiko.js unpacking for k/js target

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -85,6 +85,7 @@ internal fun configureWebApplication(
 
     targets.forEach { target ->
         target.compilations.all { compilation ->
+            // `wasmTargetType` is available starting with kotlin 1.9.2x
             if (target.wasmTargetType != null) {
                 // Kotlin/Wasm uses ES module system to depend on skiko through skiko.mjs.
                 // Further bundler could process all files by its own (both skiko.mjs and skiko.wasm) and then emits its own version.

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -10,7 +10,9 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.artifacts.UnresolvedDependency
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.provider.Provider
+import org.gradle.language.jvm.tasks.ProcessResources
 import org.jetbrains.compose.ComposeBuildConfig
 import org.jetbrains.compose.ComposeExtension
 import org.jetbrains.compose.internal.utils.detachedComposeDependency
@@ -77,8 +79,16 @@ internal fun configureWebApplication(
     }
 
     project.tasks.withType(IncrementalSyncTask::class.java) {
+        if (it.name.contains("wasmJs", ignoreCase = true)) {
+            it.dependsOn(unpackRuntime)
+            it.from.from(unpackedRuntimeDir)
+        }
+    }
+
+    project.tasks.named("jsProcessResources", ProcessResources::class.java) {
+        it.from(unpackedRuntimeDir)
         it.dependsOn(unpackRuntime)
-        it.from.from(unpackedRuntimeDir)
+        it.exclude("META-INF")
     }
 }
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -49,6 +49,7 @@ class GradlePluginTest : GradlePluginTestBase() {
             check.taskSuccessful(":compileKotlinJs")
             check.taskSuccessful(":compileKotlinWasmJs")
             check.taskSuccessful(":wasmJsBrowserDistribution")
+            check.taskSuccessful(":jsBrowserDistribution")
 
             file("./build/dist/wasmJs/productionExecutable").apply {
                 checkExists()
@@ -60,6 +61,14 @@ class GradlePluginTest : GradlePluginTestBase() {
                 )
                 // one file is the app wasm file and another one is skiko wasm file with a mangled name
                 assertEquals(2, distributionFiles.filter { it.endsWith(".wasm") }.size)
+            }
+
+            file("./build/dist/js/productionExecutable").apply {
+                checkExists()
+                assertTrue(isDirectory)
+                val distributionFiles = listFiles()!!.map { it.name }.toList()
+                assertTrue(distributionFiles.contains("skiko.wasm"))
+                assertTrue(distributionFiles.contains("skiko.js"))
             }
         }
     }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/KotlinCompatibilityTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/KotlinCompatibilityTest.kt
@@ -16,7 +16,7 @@ class KotlinCompatibilityTest : GradlePluginTestBase() {
     fun testKotlinMpp_1_9_10() = testMpp("1.9.10")
 
     @Test
-    fun testKotlinJsMpp_1_9_10() = testJsMpp("1.9.10")
+    fun testKotlinJsMpp_1_9_24() = testJsMpp("1.9.24")
 
     @Test
     fun testKotlinMpp_1_9_20() = testMpp("1.9.20")


### PR DESCRIPTION
K/JS and K/Wasm have differences in the packaging logic, and therefore we need to account for it when unpacking Skiko files.

Fixes [CMP-5649](https://youtrack.jetbrains.com/issue/CMP-5649)


## Testing
- Added a test, which checks the state of k/js distribution


This should be tested by QA

