### PR TITLE
[resources] Add a font cache on non-android targets

### DIFF
--- a/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/FontResources.skiko.kt
+++ b/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/FontResources.skiko.kt
@@ -29,13 +29,18 @@ private val emptyFontBase64 =
 @OptIn(ExperimentalEncodingApi::class)
 private val defaultEmptyFont by lazy { Font("org.jetbrains.compose.emptyFont", Base64.decode(emptyFontBase64)) }
 
+private val fontCache = AsyncCache<String, Font>()
+
 @Composable
 actual fun Font(resource: FontResource, weight: FontWeight, style: FontStyle): Font {
     val resourceReader = LocalResourceReader.currentOrPreview
     val fontFile by rememberResourceState(resource, weight, style, { defaultEmptyFont }) { env ->
         val path = resource.getResourceItemByEnvironment(env).path
-        val fontBytes = resourceReader.read(path)
-        Font(path, fontBytes, weight, style)
+        val key = "$path:$weight:$style"
+        fontCache.getOrLoad(key) {
+            val fontBytes = resourceReader.read(path)
+            Font(path, fontBytes, weight, style)
+        }
     }
     return fontFile
 }


### PR DESCRIPTION
Add a font cache on non-android targets.
Android targets already have own font caching.

Fixes https://youtrack.jetbrains.com/issue/CMP-1477

## Release Notes
### Features - Resources
- To avoid constant reading raw font bytes on each Font usage on non-android targets, there was added the font cache. Android has own font cache inside the platform implementation.