### PR TITLE
Add opportunity to use multiple refs in attributes

### DIFF
--- a/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
+++ b/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
@@ -155,7 +155,7 @@ open class AttrsScopeBuilder<TElement : Element>(
                 onDispose {
                     onDisposes.forEach { disposableEffectResult ->
                         runCatching {
-                            disposableEffectResult.invoke()
+                            disposableEffectResult.dispose()
                         }
                     }
                 }
@@ -252,7 +252,7 @@ open class AttrsScopeBuilder<TElement : Element>(
 
     @ComposeWebInternalApi
     internal fun copyFrom(attrsScope: AttrsScopeBuilder<TElement>) {
-        refEffect = attrsScope.refEffect
+        refEffects.addAll(attrsScope.refEffects)
         styleScope.copyFrom(attrsScope.styleScope)
 
         attributesMap.putAll(attrsScope.attributesMap)

--- a/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
+++ b/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
@@ -153,9 +153,9 @@ open class AttrsScopeBuilder<TElement : Element>(
                 }
 
                 onDispose {
-                    onDisposes.forEach {
+                    onDisposes.forEach { disposableEffectResult ->
                         runCatching {
-                            it()
+                            disposableEffectResult.invoke()
                         }
                     }
                 }


### PR DESCRIPTION
I am coding a lot of things in compose for html and from time to time I facing with the problem that there is no opportunity to make configuration of ref in attributes from different places which should not know about each other. By this PR I am proposing solution of this problem

This should be tested by QA

## Release Notes

Add opportunity to use several `ref`s in one attribute section
