### PR TITLE
[gradle] Avoid usage of "findProperty" to support project isolation.

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
@@ -8,8 +8,10 @@ package org.jetbrains.compose.desktop.application.internal
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.compose.internal.utils.findLocalOrGlobalProperty
 import org.jetbrains.compose.internal.utils.toBooleanProvider
 import org.jetbrains.compose.internal.utils.valueOrNull
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
 internal object ComposeProperties {
     internal const val VERBOSE = "compose.desktop.verbose"
@@ -59,7 +61,6 @@ internal object ComposeProperties {
         providers.valueOrNull(DISABLE_MULTIMODULE_RESOURCES).toBooleanProvider(false)
 
     //providers.valueOrNull works only with root gradle.properties
-    fun dontSyncResources(project: Project): Provider<Boolean> = project.provider {
-        project.findProperty(SYNC_RESOURCES_PROPERTY)?.toString().equals("false", true)
-    }
+    fun dontSyncResources(project: Project): Provider<Boolean> =
+        project.findLocalOrGlobalProperty(SYNC_RESOURCES_PROPERTY).map { it == "false" }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/wixToolset.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/wixToolset.kt
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.Copy
 import org.jetbrains.compose.desktop.application.tasks.AbstractJPackageTask
 import org.jetbrains.compose.internal.utils.OS
 import org.jetbrains.compose.internal.utils.currentOS
+import org.jetbrains.compose.internal.utils.findLocalOrGlobalProperty
 import org.jetbrains.compose.internal.utils.ioFile
 import java.io.File
 
@@ -32,7 +33,8 @@ internal fun JvmApplicationContext.configureWix() {
         return
     }
 
-    if (project.findProperty(DOWNLOAD_WIX_PROPERTY) == "false") return
+    val disableWixDownload = project.findLocalOrGlobalProperty(DOWNLOAD_WIX_PROPERTY).map { it == "false" }
+    if (disableWixDownload.get()) return
 
     val root = project.rootProject
     val wixDir = project.gradle.gradleUserHomeDir.resolve("compose-jb")

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/checkExperimentalTargets.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/checkExperimentalTargets.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.compose.experimental.internal
 
 import org.gradle.api.Project
+import org.jetbrains.compose.internal.utils.findLocalOrGlobalProperty
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 
@@ -74,7 +75,8 @@ private fun checkTarget(project: Project, target: KotlinTarget): CheckResult {
                 it.id.displayName.contains(SKIKO_ARTIFACT_PREFIX)
             }
             if (containsSkikoArtifact) {
-                if (project.findProperty(targetType.gradlePropertyName) != "true") {
+                val targetIsDisabled = project.findLocalOrGlobalProperty(targetType.gradlePropertyName).map { it != "true" }
+                if (targetIsDisabled.get()) {
                     return CheckResult.Fail(targetType)
                 }
             }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
@@ -5,11 +5,13 @@
 
 package org.jetbrains.compose.internal.utils
 
+import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
 internal inline fun <reified T> ObjectFactory.new(vararg params: Any): T =
     newInstance(T::class.java, *params)
@@ -45,3 +47,8 @@ private fun Provider<String?>.forUseAtConfigurationTimeSafe(): Provider<String?>
 
 internal fun Provider<String?>.toBooleanProvider(defaultValue: Boolean): Provider<Boolean> =
     orElse(defaultValue.toString()).map { "true" == it }
+
+internal fun Project.findLocalOrGlobalProperty(name: String, default: String = ""): Provider<String> = provider {
+    if (extraProperties.has(name)) extraProperties.get(name).toString()
+    else providers.gradleProperty(name).getOrElse(default)
+}


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-5901

## Release Notes
### Fixes - Gradle Plugin
- Internal refactor to support project isolation. 