### PR TITLE
Fix a resource reading on iOS 12

### DIFF
--- a/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceReader.ios.kt
+++ b/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceReader.ios.kt
@@ -1,12 +1,19 @@
 package org.jetbrains.compose.resources
 
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ObjCObjectVar
 import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
 import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.available
 import platform.Foundation.NSBundle
 import platform.Foundation.NSData
+import platform.Foundation.NSError
 import platform.Foundation.NSFileHandle
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
@@ -16,6 +23,7 @@ import platform.Foundation.readDataOfLength
 import platform.Foundation.seekToFileOffset
 import platform.posix.memcpy
 
+@OptIn(BetaInteropApi::class)
 internal actual fun getPlatformResourceReader(): ResourceReader = object : ResourceReader {
     override suspend fun read(path: String): ByteArray {
         val data = readData(getPathInBundle(path))
@@ -42,7 +50,11 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
     private fun readData(path: String, offset: Long, size: Long): NSData {
         val fileHandle = NSFileHandle.fileHandleForReadingAtPath(path) ?: throw MissingResourceException(path)
         if (available(OS.Ios to OSVersion(major = 13))) {
-            fileHandle.seekToOffset(offset.toULong(), null)
+            memScoped {
+                val error = alloc<ObjCObjectVar<NSError?>>()
+                fileHandle.seekToOffset(offset.toULong(), error.ptr)
+                error.value?.let { err -> error(err.localizedDescription) }
+            }
         } else {
             fileHandle.seekToFileOffset(offset.toULong())
         }


### PR DESCRIPTION
Use deprecated `seekToFileOffset` on iOS 12 to fix a crash on old Apple devices

Fixes https://youtrack.jetbrains.com/issue/CMP-5967

## Release Notes
### Fixes - Resources
- _(prerelease fix)_ Fix a resource reading on iOS 12
