### PR TITLE
feat: redirect navigation tutorial to kmp portal

### DIFF
--- a/tutorials/Navigation/README.md
+++ b/tutorials/Navigation/README.md
@@ -1,5 +1,0 @@
-# Navigation
-
-The [Jetpack Compose navigation library](https://developer.android.com/jetpack/compose/navigation) is currently an Android-only library.
-
-There are a number of libraries available that provide navigation functionality for Compose Multiplatform projects. Refer to the [Awesome Kotlin Multiplatform](https://github.com/terrakok/kmm-awesome#-compose-ui) list for an overview and more information.

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -14,7 +14,7 @@
 * [Keyboard support](Keyboard)
 * [Tab focus navigation](Tab_Navigation)
 * [Swing interoperability](Swing_Integration)
-* [Navigation](Navigation)
+* [Navigation](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-navigation-routing.html)
 * [Accessibility](Accessibility)
 * [Building a native distribution](Native_distributions_and_local_execution)
 * [UI testing](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html)


### PR DESCRIPTION
Part of activity to move tutorials from GitHub to the [Kotlin Multiplatform Development](https://www.jetbrains.com/help/kotlin-multiplatform-dev) portal

Fixes [KT-67534](https://youtrack.jetbrains.com/issue/KT-67534)
