### PR TITLE
Fix cocoapods integration

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResources.kt
@@ -86,8 +86,8 @@ internal fun Project.configureSyncIosComposeResources(
     plugins.withId(COCOAPODS_PLUGIN_ID) {
         (kotlinExtension as ExtensionAware).extensions.getByType(CocoapodsExtension::class.java).apply {
             framework { podFramework ->
-                val syncDir = podFramework.getFinalResourcesDir().get().asFile.relativeTo(projectDir)
-                val specAttr = "['${syncDir.path}']"
+                val syncDir = podFramework.getFinalResourcesDir().get().asFile
+                val specAttr = "['${syncDir.relativeTo(projectDir).path}']"
                 val specAttributes = extraSpecAttributes
                 val buildFile = project.buildFile
                 val projectPath = project.path
@@ -97,7 +97,7 @@ internal fun Project.configureSyncIosComposeResources(
                         if (specAttributes["resources"] != specAttr) error(
                             """
                                 |Kotlin.cocoapods.extraSpecAttributes["resources"] is not compatible with Compose Multiplatform's resources management for iOS.
-                                |  * Recommended action: remove extraSpecAttributes["resources"] from '$buildFile' and run '$projectPath:podInstall' once;
+                                |  * Recommended action: remove extraSpecAttributes["resources"] from '$buildFile' and run '$projectPath:podspec' once;
                                 |  * Alternative action: turn off Compose Multiplatform's resources management for iOS by adding '${ComposeProperties.SYNC_RESOURCES_PROPERTY}=false' to your gradle.properties;
                             """.trimMargin()
                         )

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -591,6 +591,14 @@ class ResourcesTest : GradlePluginTestBase() {
         )
 
         with(TestProject("misc/iosResources", testEnv)) {
+            gradle(":podspec", "-Pkotlin.native.cocoapods.generate.wrapper=true").checks {
+                assertEqualTextFiles(
+                    file("iosResources.podspec"),
+                    file("expected/iosResources.podspec")
+                )
+                file("build/compose/cocoapods/compose-resources").checkExists()
+            }
+
             gradle(
                 ":syncFramework",
                 "-Pkotlin.native.cocoapods.platform=${iosEnv["PLATFORM_NAME"]}",
@@ -655,13 +663,6 @@ class ResourcesTest : GradlePluginTestBase() {
 
                 file("build/compose/cocoapods/compose-resources/composeResources/iosresources.generated.resources/drawable/compose-multiplatform.xml").checkExists()
                 file("build/compose/cocoapods/compose-resources/composeResources/iosresources.generated.resources/drawable/icon.xml").checkExists()
-            }
-
-            gradle(":podspec", "-Pkotlin.native.cocoapods.generate.wrapper=true").checks {
-                assertEqualTextFiles(
-                    file("iosResources.podspec"),
-                    file("expected/iosResources.podspec")
-                )
             }
         }
     }


### PR DESCRIPTION
Use a correct file to configure the cocoapods resources integration instead of a relative path.

Fixes https://youtrack.jetbrains.com/issue/CMP-4303

## Release Notes
### Fixes - Resources
- _(prerelease fix)_ Fix cocoapods resources integration which leaded to a lack resources in ios apps