### PR TITLE
[gradle] Add "compose.material3AdaptiveNavigationSuite" shortcut

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -72,6 +72,7 @@ abstract class ComposePlugin : Plugin<Project> {
         val foundation get() = composeDependency("org.jetbrains.compose.foundation:foundation")
         val material get() = composeDependency("org.jetbrains.compose.material:material")
         val material3 get() = composeDependency("org.jetbrains.compose.material3:material3")
+        val material3AdaptiveNavigationSuite get() = composeDependency("org.jetbrains.compose.material3:material3-adaptive-navigation-suite")
         val runtime get() = composeDependency("org.jetbrains.compose.runtime:runtime")
         val runtimeSaveable get() = composeDependency("org.jetbrains.compose.runtime:runtime-saveable")
         val ui get() = composeDependency("org.jetbrains.compose.ui:ui")


### PR DESCRIPTION
Add `compose.material3AdaptiveNavigationSuite` shortcut:

```kotlin
kotlin {
    sourceSets {
        commonMain.dependencies {
            implementation(compose.material3AdaptiveNavigationSuite)
        }
    }
}
```

## Release Notes
### Features - Gradle Plugin
- New `compose.material3AdaptiveNavigationSuite` shortcut in the gradle plugin
