### PR TITLE
Add a redundancy warning to skiko.js for k/wasm target

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -46,6 +46,7 @@ class GradlePluginTest : GradlePluginTestBase() {
         jsCanvasEnabled(true)
         gradle(":build").checks {
             check.taskSuccessful(":unpackSkikoWasmRuntime")
+            check.taskSuccessful(":processSkikoRuntimeForKWasm")
             check.taskSuccessful(":compileKotlinJs")
             check.taskSuccessful(":compileKotlinWasmJs")
             check.taskSuccessful(":wasmJsBrowserDistribution")
@@ -69,6 +70,7 @@ class GradlePluginTest : GradlePluginTestBase() {
                 val distributionFiles = listFiles()!!.map { it.name }.toList()
                 assertTrue(distributionFiles.contains("skiko.wasm"))
                 assertTrue(distributionFiles.contains("skiko.js"))
+                assertFalse(this.resolve("skiko.js").readText().contains("skiko.js is redundant"))
             }
         }
     }


### PR DESCRIPTION
skiko.js used to be required for k/wasm projects. But some time ago it was refactored to use skiko.mjs, so skiko.js is not needed anymore (for k/wasm, still needed for k/js). But there are k/wasm  projects still including skiko.js in index.html which leads to extra loading time. The intention is to notify them without causing 404 errors for now.


## Testing
- updated a test
- tested manually

<img width="856" alt="Screenshot 2024-09-10 at 15 34 41" src="https://github.com/user-attachments/assets/9ad9b790-d3fa-4907-b9ee-f5e682f38858">

## Release Notes
### Highlights - Web
- `skiko.js` is redundant in case of K/Wasm Compose for Web applications and it can be removed from index.html files to not load redundant files. We are going to remove `skiko.js` from the k/wasm distribution in the future releases. `skiko.js` is still needed in case of K/JS Compose for Web apps. 

