### PR TITLE
Update actions/upload-artifact to v3

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -33,7 +33,7 @@ jobs:
           ./gradlew assemble
           ./gradlew --continue :preview-rpc:test :compose:test ':compose:test-Gradle(${{ matrix.gradle }})-Agp(${{ matrix.agp }})'
       - name: Upload Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Test-Reports
           path: gradle-plugins/compose/build/reports

--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -33,7 +33,7 @@ jobs:
           ./gradlew assemble
           ./gradlew --continue :preview-rpc:test :compose:test ':compose:test-Gradle(${{ matrix.gradle }})-Agp(${{ matrix.agp }})'
       - name: Upload Reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Test-Reports
           path: gradle-plugins/compose/build/reports


### PR DESCRIPTION
According to https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/ v2 is deprecated. Besides that the workflow doesn't work with v2 anoymore - https://github.com/JetBrains/compose-multiplatform/actions/runs/10794252433/job/29978381803?pr=5134 :

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/


The suggested version is v4. But it requires more changes to the workflow configuration (see https://github.com/actions/upload-artifact/issues/478). Let's use v3 for now.
