### PR TITLE
Upgrade CMP IJ Plugin dependencies & setup

### DIFF
--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -51,12 +51,11 @@ intellijPlatform {
 }
 
 tasks {
-    // Set the compatibility versions to 1.8
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "21"
+        targetCompatibility = "21"
     }
-    withType<KotlinJvmCompile> { compilerOptions.jvmTarget.set(JvmTarget.JVM_11) }
+    withType<KotlinJvmCompile> { compilerOptions.jvmTarget.set(JvmTarget.JVM_21) }
 }
 
 class ProjectProperties(private val project: Project) {

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -32,7 +32,13 @@ dependencies {
 }
 
 intellijPlatform {
-    pluginConfiguration { name = "Compose Multiplatform IDE Support" }
+    pluginConfiguration {
+        name = "Compose Multiplatform IDE Support"
+        ideaVersion {
+            sinceBuild = "231.*"
+            untilBuild = "243.*"
+        }
+    }
     buildSearchableOptions = false
     autoReload = false
 

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -1,44 +1,47 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("java")
     alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.intellij.sdk)
+    alias(libs.plugins.intellij.plugin)
     alias(libs.plugins.intellij.changelog)
 }
 
 val projectProperties = ProjectProperties(project)
 
 group = "org.jetbrains.compose.desktop.ide"
+
 version = projectProperties.deployVersion
 
 repositories {
     mavenCentral()
+
+    intellijPlatform { defaultRepositories() }
 }
 
 dependencies {
     implementation("org.jetbrains.compose:preview-rpc")
+
+    intellijPlatform {
+        intellijIdeaCommunity(libs.versions.idea)
+        instrumentationTools()
+
+        bundledPlugins("com.intellij.java", "org.jetbrains.kotlin", "com.intellij.gradle")
+    }
 }
 
-intellij {
-    pluginName.set("Compose Multiplatform IDE Support")
-    type.set(projectProperties.platformType)
-    version.set(projectProperties.platformVersion)
-    downloadSources.set(projectProperties.platformDownloadSources)
-    updateSinceUntilBuild.set(false)
+intellijPlatform {
+    pluginConfiguration { name = "Compose Multiplatform IDE Support" }
+    buildSearchableOptions = false
+    autoReload = false
 
-    plugins.set(
-        listOf(
-            "java",
-            "com.intellij.gradle",
-            "org.jetbrains.kotlin"
-        )
-    )
-}
+    publishing {
+        token = System.getenv("IDE_PLUGIN_PUBLISH_TOKEN")
+        channels = projectProperties.pluginChannels
+    }
 
-tasks.buildSearchableOptions {
-    // temporary workaround
-    enabled = false
+    pluginVerification { ides { recommended() } }
 }
 
 tasks {
@@ -47,30 +50,18 @@ tasks {
         sourceCompatibility = "11"
         targetCompatibility = "11"
     }
-    withType<KotlinJvmCompile> {
-        kotlinOptions.jvmTarget = "11"
-    }
-
-    publishPlugin {
-        token.set(System.getenv("IDE_PLUGIN_PUBLISH_TOKEN"))
-        channels.set(projectProperties.pluginChannels)
-    }
-
-    runPluginVerifier {
-        ideVersions.set(projectProperties.pluginVerifierIdeVersions)
-    }
+    withType<KotlinJvmCompile> { compilerOptions.jvmTarget.set(JvmTarget.JVM_11) }
 }
 
 class ProjectProperties(private val project: Project) {
-    val deployVersion get() = stringProperty("deploy.version")
-    val platformType get() = stringProperty("platform.type")
-    val platformVersion get() = stringProperty("platform.version")
-    val platformDownloadSources get() = stringProperty("platform.download.sources").toBoolean()
-    val pluginChannels get() = listProperty("plugin.channels")
-    val pluginVerifierIdeVersions get() = listProperty("plugin.verifier.ide.versions")
+    val deployVersion
+        get() = stringProperty("deploy.version")
 
-    private fun stringProperty(key: String): String =
-        project.findProperty(key)!!.toString()
+    val pluginChannels
+        get() = listProperty("plugin.channels")
+
+    private fun stringProperty(key: String): String = project.findProperty(key)!!.toString()
+
     private fun listProperty(key: String): List<String> =
         stringProperty(key).split(",").map { it.trim() }
 }

--- a/idea-plugin/gradle.properties
+++ b/idea-plugin/gradle.properties
@@ -5,10 +5,3 @@ kotlin.stdlib.default.dependency=false
 deploy.version=0.1-SNAPSHOT
 
 plugin.channels=snapshots
-# Intellij since-build should be updated directly in src/main/resources/META-INF/plugin.xml
-# See https://jb.gg/intellij-platform-builds-list for available build versions.
-plugin.verifier.ide.versions=2022.1, 2022.2, 2022.3
-
-platform.type=IC
-platform.version=2022.1.1
-platform.download.sources=true

--- a/idea-plugin/gradle/libs.versions.toml
+++ b/idea-plugin/gradle/libs.versions.toml
@@ -1,9 +1,10 @@
 [versions]
-kotlin = "1.9.0"
-
-[libraries]
+kotlin = "1.9.23"
+ideaPlugin = "2.0.1"
+idea = "2024.2.1"
+changelog = "2.2.0"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-intellij-sdk = "org.jetbrains.intellij:1.15.0"
-intellij-changelog = "org.jetbrains.changelog:2.2.0"
+intellij-plugin = { id = "org.jetbrains.intellij.platform", version.ref = "ideaPlugin" }
+intellij-changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/idea-plugin/gradle/libs.versions.toml
+++ b/idea-plugin/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.9.23"
-ideaPlugin = "2.0.1"
+ideaPlugin = "2.1.0"
 idea = "2024.2.1"
 changelog = "2.2.0"
 

--- a/idea-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/idea-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR prepares the IJ plugin to be fixed/improved upon by a follow-up PR, by:

1. Migrating to IJP Gradle plugin 2.x
2. Upgrading Gradle to 8.10
3. Bumping IJ target to 2024.2.1
4. Cleaning up after migration