### PR TITLE
Install nodejs to Dockerfile we use in Compose-Web-Linux build

### DIFF
--- a/ci/docker/compose-web/Dockerfile
+++ b/ci/docker/compose-web/Dockerfile
@@ -14,7 +14,7 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
     wget \
     xvfb
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -yqq \
     && wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key \
     && wget -qO- https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs

--- a/ci/docker/compose-web/Dockerfile
+++ b/ci/docker/compose-web/Dockerfile
@@ -14,6 +14,10 @@ RUN dpkg --add-architecture i386 && apt-get update -yqq && apt-get install -y \
     wget \
     xvfb
 
+RUN apt-get update && apt-get install -y \
+    && wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key \
+    && wget -qO- https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs
 
 ARG CHROME_VERSION="google-chrome-stable"
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -


### PR DESCRIPTION
Noticeable amount of builds in our pipeline are failing because kotlin tooling fails to download nodejs. 
The idea behind this particular PR is to have nodejs installed beforehand - exactly like we have chrome and firefox installed