### PR TITLE
Don't keep custom launcher in Docker image for compose-web builds

### DIFF
--- a/ci/docker/compose-web/Dockerfile
+++ b/ci/docker/compose-web/Dockerfile
@@ -34,6 +34,3 @@ RUN wget https://github.com/mozilla/geckodriver/releases/download/v0.29.1/geckod
 RUN export CHROME_DRIVER_VERSION=$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE) \
     && wget https://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip -P ~/tmp \
     && mkdir -p /root/.gradle/selenium/chrome &&  unzip -d /root/.gradle/selenium/chrome  ~/tmp/chromedriver_linux64.zip && rm ~/tmp/chromedriver_linux64.zip
-
-COPY chrome-no-sandbox /usr/bin/chrome-no-sandbox 
-RUN chmod u+x /usr/bin/chrome-no-sandbox

--- a/ci/docker/compose-web/chrome-no-sandbox
+++ b/ci/docker/compose-web/chrome-no-sandbox
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-google-chrome-stable --no-sandbox "$@"


### PR DESCRIPTION
For a quite a while we have an opportunity to customise launcher on the product side (see, for instance, https://youtrack.jetbrains.com/issue/KT-38040/Make-Chrome-Headless-use-no-sandbox-configurable-for-Docker)
The goal of this PR is not to have such configurations in Docker, thus potentially creating issues with different configurations in dev and pipeline. 