### PR TITLE
Update PomDocument.kt

### DIFF
--- a/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/utils/PomDocument.kt
+++ b/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/utils/PomDocument.kt
@@ -135,11 +135,7 @@ internal class PomDocument(file: File) {
     }
 
     private fun Node.children(): List<Node> {
-        val result = ArrayList<Node>(childNodes.length)
-        for (i in 0 until childNodes.length) {
-            result.add(childNodes.item(i))
-        }
-        return result
+        return (0 until childNodes.length).map { childNodes.item(it) }
     }
 
     private fun List<Node>.asMap(): Map<String, Node> =


### PR DESCRIPTION
Instead of manually creating an `ArrayList` and using a loop, we leverage Kotlin’s `map` function to transform the range of indices directly into a list of child nodes. This makes the code more concise and expressive.
