### PR TITLE
Fix of CMP-6802

### DIFF
--- a/html/compose-compiler-integration/src/jsTest/kotlin/AnonymousObjectsInComposable.kt
+++ b/html/compose-compiler-integration/src/jsTest/kotlin/AnonymousObjectsInComposable.kt
@@ -18,7 +18,7 @@ class AnonymousObjectsInComposable {
             content.Abc()
         }
 
-        assertEquals("<div>Abc</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div>Abc</div>", document.body!!.lastElementChild!!.outerHTML)
     }
 
     @Test
@@ -30,7 +30,7 @@ class AnonymousObjectsInComposable {
             HasLocalClassWithComposable()
         }
 
-        assertEquals("<div>Abc2</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div>Abc2</div>", document.body!!.lastElementChild!!.outerHTML)
     }
 
     @Test
@@ -41,7 +41,7 @@ class AnonymousObjectsInComposable {
             TestConstructor { return@TestConstructor 111 }.otherComposable!!.invoke()
         }
 
-        assertEquals("<div>Abc223-111</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div>Abc223-111</div>", document.body!!.lastElementChild!!.outerHTML)
     }
 }
 

--- a/html/compose-compiler-integration/src/jsTest/kotlin/ComposableLambdaCalls.kt
+++ b/html/compose-compiler-integration/src/jsTest/kotlin/ComposableLambdaCalls.kt
@@ -25,7 +25,7 @@ class ComposableLambdaCalls {
             }
         }
 
-        assertEquals("<div>SomeText</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div>SomeText</div>", document.body!!.lastElementChild!!.outerHTML)
     }
 
     @Test
@@ -36,7 +36,7 @@ class ComposableLambdaCalls {
             }
         }
 
-        assertEquals("<div>Text1</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div>Text1</div>", document.body!!.lastElementChild!!.outerHTML)
     }
 
     @Test
@@ -51,7 +51,7 @@ class ComposableLambdaCalls {
             }
         }
 
-        assertEquals("<div>TextA</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div>TextA</div>", document.body!!.lastElementChild!!.outerHTML)
     }
 
     @Test
@@ -64,7 +64,7 @@ class ComposableLambdaCalls {
             }
         }
 
-        assertEquals("<div></div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div></div>", document.body!!.lastElementChild!!.outerHTML)
     }
 
     @Test
@@ -84,7 +84,7 @@ class ComposableLambdaCalls {
             }
         }
 
-        assertEquals("<div></div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div></div>", document.body!!.lastElementChild!!.outerHTML)
         assertEquals(false, someIntInvoked, message = "someInt() should never be invoked as `l` is null")
     }
 
@@ -107,7 +107,7 @@ class ComposableLambdaCalls {
             }
         }
 
-        assertEquals("<div>Text10</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div>Text10</div>", document.body!!.lastElementChild!!.outerHTML)
         assertEquals(true, someIntInvoked)
     }
 
@@ -123,7 +123,7 @@ class ComposableLambdaCalls {
             }
         }
 
-        assertEquals("<div>Text-SomeText</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div>Text-SomeText</div>", document.body!!.lastElementChild!!.outerHTML)
     }
 
     @Test
@@ -136,6 +136,6 @@ class ComposableLambdaCalls {
             }
         }
 
-        assertEquals("<div>SuperText</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals("<div>SuperText</div>", document.body!!.lastElementChild!!.outerHTML)
     }
 }


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/CMP-6802

**Bug Description**

In case if composition must be disposed, it clears all the data in container instead of data it has created

**Affected Platforms**

Select one or multiple affected platforms below:

- [x] Web (K/JS) - HTML library

**Versions**
- Compose Multiplatform version*: 1.7.0-rc01
- Kotlin version*: 2.0.20
- OS (name, version, arch): Any
- Browser (for Web issues): Any

**Reproduction Steps**

1. Clone https://github.com/InsanusMokrassar/IssueHtmlDomNodeWrapperReproducer_3d1c3e12
2. Call `jsBrowserDevelopmentExecutableDistribution` gradle task
3. Run test index.html in browser
4. Await while all body will be cleared (even script tag)

**Expected Behavior**

Only create by compose data cleared