### PR TITLE
Fix changelog path not found error

### DIFF
--- a/tools/changelog.main.kts
+++ b/tools/changelog.main.kts
@@ -61,7 +61,7 @@ val standardSubsections = listOf(
     "Navigation",
 )
 
-val changelogFile = __FILE__.resolve("../../CHANGELOG.md")
+val changelogFile = __FILE__.resolve("../../CHANGELOG.md").canonicalFile
 
 //endregion
 


### PR DESCRIPTION
Fixed the error with 
```
java.io.FileNotFoundException: changelog.main.kts/../../CHANGELOG.md (Not a directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
        at kotlin.io.FilesKt__FileReadWriteKt.readText(FileReadWrite.kt:125)
        at kotlin.io.FilesKt__FileReadWriteKt.readText$default(FileReadWrite.kt:125)
        at Changelog_main.<init>(changelog.main.kts:85)
```
it happens because without `.canonicalFile` there is no path resolving and this leads to the mentioned error.