### PR TITLE
CMP-1974 Added the ability to select a desktop shortcut option in the dialog box during installation

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -100,6 +100,7 @@ abstract class WindowsPlatformSettings : AbstractPlatformSettings() {
     var dirChooser: Boolean = true
     var perUserInstall: Boolean = false
     var shortcut: Boolean = false
+    var shortcutPrompt: Boolean = false
     var menu: Boolean = false
         get() = field || menuGroup != null
     var menuGroup: String? = null

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -384,6 +384,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.winDirChooser.set(provider { win.dirChooser })
                 packageTask.winPerUserInstall.set(provider { win.perUserInstall })
                 packageTask.winShortcut.set(provider { win.shortcut })
+                packageTask.winShortcutPrompt.set(provider { win.shortcutPrompt })
                 packageTask.winMenu.set(provider { win.menu })
                 packageTask.winMenuGroup.set(provider { win.menuGroup })
                 packageTask.winUpgradeUuid.set(provider { win.upgradeUuid })

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -218,6 +218,10 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
+    val winShortcutPrompt: Property<Boolean?> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
     val winMenu: Property<Boolean?> = objects.nullableProperty()
 
     @get:Input
@@ -449,6 +453,7 @@ abstract class AbstractJPackageTask @Inject constructor(
                     cliArg("--win-dir-chooser", winDirChooser)
                     cliArg("--win-per-user-install", winPerUserInstall)
                     cliArg("--win-shortcut", winShortcut)
+                    cliArg("--win-shortcut-prompt", winShortcutPrompt)
                     cliArg("--win-menu", winMenu)
                     cliArg("--win-menu-group", winMenuGroup)
                     cliArg("--win-upgrade-uuid", winUpgradeUuid)


### PR DESCRIPTION
Added the ability to set the 'shortcutPrompt' parameter, which activates the CLI command '--win-shortcut-prompt' in jpackage. A new dialog (shortcut prompt dialog) has been introduced to the UI sequence of Windows installers, featuring checkbox controls that allow users to choose which shortcuts the installer should create.

New CLI option "--win-shortcut-prompt" will control contents of shortcut prompt dialog.
Specification
Add "--win-shortcut-prompt" CLI option. If the option is set, "Shortcut prompt" dialog will be a part of UI installation sequence.
"Shortcut prompt" dialog will have at most two checkbox controls. No other controls must be placed on this dialog.
Checkbox control labeled "Create desktop shortcuts" will be added to the dialog if "--win-shortcut" CLI option is specified.
Checkbox control labeled "Create start menu shortcuts" will be added to the dialog if "--win-menu" CLI option is specified.
If none of "--win-shortcut" or "--win-menu" CLI options are specified, then the dialog will not be a part of installation UI sequence and "--win-shortcut-prompt" CLI option will be silently ignored by jpackage.


Fixes [CMP-1974](https://youtrack.jetbrains.com/issue/CMP-1974)
Fixes [JDK-8261536](https://bugs.openjdk.org/browse/JDK-8261536)

## Testing
- Compile compose-gradle-plugin
- In the application's build.gradle.kts add: 
```
compose.desktop {
    application { 
       nativeDistributions { 
           windows{
                shortcut = true
                shortcutPrompt = true
```
- Compile 'packageMsi'
- Run the compiled MSI package
- During the installation process, a checkbox labeled 'Create Desktop Shortcut' will appear

## Release Notes
### Features - Gradle Plugin
- A new dialog, known as the "shortcut prompt dialog," has been introduced to the UI sequence of Windows installers. This dialog features checkbox controls that allow users to select which shortcuts the installer should create. To activate this dialog:
```
compose.desktop {
    application { 
       nativeDistributions { 
           windows{
                shortcut = true
                shortcutPrompt = true
```
![Screenshot 2024-10-28 202747](https://github.com/user-attachments/assets/2598f732-08fb-4d98-b2af-ad95d25bf871)

