### PR TITLE
Fix deprecation warning for `forUseAtConfigurationTime`

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
@@ -12,6 +12,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import org.gradle.util.GradleVersion
 
 internal inline fun <reified T> ObjectFactory.new(vararg params: Any): T =
     newInstance(T::class.java, *params)
@@ -38,11 +39,13 @@ internal fun ProviderFactory.valueOrNull(prop: String): Provider<String?> =
     }
 
 private fun Provider<String?>.forUseAtConfigurationTimeSafe(): Provider<String?> =
-    try {
-        forUseAtConfigurationTime()
-    } catch (e: NoSuchMethodError) {
-        // todo: remove once we drop support for Gradle 6.4
+    // forUseAtConfigurationTime is a no-op starting at Gradle 7.4 and just produces deprecation warnings. 
+    // See https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.provider/-provider/for-use-at-configuration-time.html
+    if (GradleVersion.current() >= GradleVersion.version("7.4")) {
         this
+    } else {
+        // todo: remove once we drop support for Gradle 6.4
+        forUseAtConfigurationTime()
     }
 
 internal fun Provider<String?>.toBooleanProvider(defaultValue: Boolean): Provider<Boolean> =


### PR DESCRIPTION
`forUseAtConfigurationTime` is a no-op starting at Gradle 7.4, so it can safely not be used starting at this version. This will have no affect other than to prevent a deprecation warning for those using newer gradle versions.

Describe proposed changes and the issue being fixed

<!-- Optional -->
Fixes https://youtrack.jetbrains.com/issue/CMP-3945/The-Provider.forUseAtConfigurationTime-method-has-been-deprecated
