### PR TITLE
Change version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?sort=semver&display_name=release&label=stable&color=brightgreen)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
-[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=blue)](https://github.com/JetBrains/compose-multiplatform/releases)
+[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=yellow)](https://github.com/JetBrains/compose-multiplatform/releases)
 [![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=date&filter=v*%2Bdev*&label=dev&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=stable)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
 [![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=orange&include_prereleases&label=prerelease)](https://github.com/JetBrains/compose-multiplatform/releases)
-[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*+dev*&label=latest)](https://github.com/JetBrains/compose-multiplatform/tags)
+[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*+dev*&label=dev)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?sort=semver&display_name=release&label=stable&color=brightgreen)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
 [![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=blue)](https://github.com/JetBrains/compose-multiplatform/releases)
-[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=date&filter=v*%2Bdev*&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
+[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=date&filter=v*%2Bdev*&label=dev&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?sort=semver&display_name=release&label=stable&color=brightgreen)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
 [![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&filter=*-*&display_name=release&label=prerelease&color=blue)](https://github.com/JetBrains/compose-multiplatform/releases)
-[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=date&filter=v*%2Bdev*&label=dev&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
+[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*%2Bdev*&label=dev&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
-[![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=stable)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
-[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=orange&include_prereleases&label=prerelease)](https://github.com/JetBrains/compose-multiplatform/releases)
-[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*+dev*&label=dev)](https://github.com/JetBrains/compose-multiplatform/tags)
+[![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?sort=semver&display_name=release&label=stable&color=brightgreen)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
+[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=blue)](https://github.com/JetBrains/compose-multiplatform/releases)
+[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*+dev*&label=dev&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?sort=semver&display_name=release&label=stable&color=brightgreen)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
-[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=yellow)](https://github.com/JetBrains/compose-multiplatform/releases)
+[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=brightyellow)](https://github.com/JetBrains/compose-multiplatform/releases)
 [![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=date&filter=v*%2Bdev*&label=dev&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=stable)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
 [![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=orange&include_prereleases&label=prerelease)](https://github.com/JetBrains/compose-multiplatform/releases)
-[![latest](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*&label=latest)](https://github.com/JetBrains/compose-multiplatform/tags)
+[![latest](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*+dev*&label=latest)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
-[![Latest release](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=latest%20release)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
-[![Latest build](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=orange&include_prereleases&label=latest%20build)](https://github.com/JetBrains/compose-multiplatform/releases)
-
-
+[![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=latest%20release)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
+[![latest](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*&label=dev)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=stable)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
+[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=orange&include_prereleases&label=latest%20build)](https://github.com/JetBrains/compose-multiplatform/releases)
 [![latest](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*&label=latest)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=stable)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
 [![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=orange&include_prereleases&label=prerelease)](https://github.com/JetBrains/compose-multiplatform/releases)
-[![latest](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*+dev*&label=latest)](https://github.com/JetBrains/compose-multiplatform/tags)
+[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*+dev*&label=latest)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=stable)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
-[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=orange&include_prereleases&label=latest%20build)](https://github.com/JetBrains/compose-multiplatform/releases)
+[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=orange&include_prereleases&label=prerelease)](https://github.com/JetBrains/compose-multiplatform/releases)
 [![latest](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*&label=latest)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?sort=semver&display_name=release&label=stable&color=brightgreen)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
-[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=blue)](https://github.com/JetBrains/compose-multiplatform/releases)
+[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&filter=*-*&display_name=release&label=prerelease&color=blue)](https://github.com/JetBrains/compose-multiplatform/releases)
 [![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=date&filter=v*%2Bdev*&label=dev&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?sort=semver&display_name=release&label=stable&color=brightgreen)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
-[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=brightyellow)](https://github.com/JetBrains/compose-multiplatform/releases)
+[![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=blue)](https://github.com/JetBrains/compose-multiplatform/releases)
 [![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=date&filter=v*%2Bdev*&label=dev&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
-[![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=latest%20release)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
-[![latest](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*&label=dev)](https://github.com/JetBrains/compose-multiplatform/tags)
+[![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?color=brightgreen&label=stable)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
+[![latest](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*&label=latest)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![stable](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?sort=semver&display_name=release&label=stable&color=brightgreen)](https://github.com/JetBrains/compose-multiplatform/releases/latest)
 [![prerelease](https://img.shields.io/github/v/release/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=*-*&display_name=release&label=prerelease&color=blue)](https://github.com/JetBrains/compose-multiplatform/releases)
-[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=semver&filter=v*+dev*&label=dev&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
+[![dev](https://img.shields.io/github/v/tag/JetBrains/compose-multiplatform?include_prereleases&sort=date&filter=v*%2Bdev*&color=orange)](https://github.com/JetBrains/compose-multiplatform/tags)
 
 # Compose Multiplatform
 


### PR DESCRIPTION
Previously we had:
- A link to the latest stable version from the version list
- A link to the latest prerelease from the version list

Now we have:
- A link to the latest stable version from the version list
- A link to the latest prerelease (excluding stable) from the version list
- A link to the latest dev (nightly) build (excluding stable, prerelease) from the tag list (we no longer add it in the version list)

A tag contains info about all associated libs. [Example](https://github.com/JetBrains/compose-multiplatform/releases/tag/v1.8.0%2Bdev1960)