### PR TITLE
Add to support Tajik language

### DIFF
--- a/components/resources/library/CLDRPluralRules/plurals.xml
+++ b/components/resources/library/CLDRPluralRules/plurals.xml
@@ -44,7 +44,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
             <pluralRule count="one">n = 0..1 or n = 11..99 @integer 0, 1, 11~24 @decimal 0.0, 1.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0</pluralRule>
             <pluralRule count="other"> @integer 2~10, 100~106, 1000, 10000, 100000, 1000000, … @decimal 0.1~0.9, 1.1~1.7, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>
-        <pluralRules locales="af an asa az bal bem bez bg brx ce cgg chr ckb dv ee el eo eu fo fur gsw ha haw hu jgo jmc ka kaj kcg kk kkj kl ks ksb ku ky lb lg mas mgo ml mn mr nah nb nd ne nn nnh no nr ny nyn om or os pap ps rm rof rwk saq sd sdh seh sn so sq ss ssy st syr ta te teo tig tk tn tr ts ug uz ve vo vun wae xh xog">
+        <pluralRules locales="af an asa az bal bem bez bg brx ce cgg chr ckb dv ee el eo eu fo fur gsw ha haw hu jgo jmc ka kaj kcg kk kkj kl ks ksb ku ky lb lg mas mgo ml mn mr nah nb nd ne nn nnh no nr ny nyn om or os pap ps rm rof rwk saq sd sdh seh sn so sq ss ssy st syr ta te teo tg tig tk tn tr ts ug uz ve vo vun wae xh xog">
             <pluralRule count="one">n = 1 @integer 1 @decimal 1.0, 1.00, 1.000, 1.0000</pluralRule>
             <pluralRule count="other"> @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~0.9, 1.1~1.6, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …</pluralRule>
         </pluralRules>


### PR DESCRIPTION
**Describe proposed changes and the issue being fixed**  
Added support for the Tajik language (`tg`) in the pluralization rules generation. Updated the rules based on CLDR to include pluralization logic specific to the Tajik language. This change ensures that the `tg` locale is handled correctly during resource generation.

<!-- Optional -->
Fixes: N/A (no linked issue)

---

## Testing
<!-- Optional -->
Unfortunately, I was unable to test the changes because the project cannot be indexed in my environment. It would be great if someone from the team could verify the correctness of this fix, including:
- Running the generation task using `./gradlew :resources:library:generatePluralRuleLists`.
- Checking the correctness of the generated pluralization rules for the Tajik language.

---

## Release Notes

### Resources - Gradle Plugin
- **Feature:** Added support for the Tajik language (`tg`) in pluralization rules.