### PR TITLE
Drop support for versions lower than Gradle 8.0

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-14, windows-2022]
-        gradle: [8.0, 8.10.2]
-        agp: [8.1.0, 8.5.0, 8.8.0-alpha08]
+        os: [ ubuntu-20.04, macos-14, windows-2022 ]
+        gradle: [ '8.0', '8.10.2' ]
+        agp: [ '8.1.0', '8.5.0', '8.8.0-alpha08' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-14, windows-2022]
-        gradle: [7.4, 8.10.2]
+        gradle: [8.0, 8.10.2]
         agp: [8.1.0, 8.5.0, 8.8.0-alpha08]
     runs-on: ${{ matrix.os }}
     steps:

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -34,8 +34,10 @@ subprojects {
             compilerOptions {
                 // must be set to a language version of the kotlin compiler & runtime,
                 // which is bundled to the oldest supported Gradle
-                languageVersion.set(KotlinVersion.KOTLIN_1_5)
-                apiVersion.set(KotlinVersion.KOTLIN_1_5)
+                // Current oldest-supported Gradle is 8.0,
+                // follow the https://docs.gradle.org/current/userguide/compatibility.html#kotlin
+                languageVersion.set(KotlinVersion.KOTLIN_1_8)
+                apiVersion.set(KotlinVersion.KOTLIN_1_8)
                 jvmTarget.set(JvmTarget.JVM_11)
             }
         }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
@@ -12,7 +12,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
-import org.gradle.util.GradleVersion
 
 internal inline fun <reified T> ObjectFactory.new(vararg params: Any): T =
     newInstance(T::class.java, *params)
@@ -35,17 +34,7 @@ internal inline fun <reified T> Task.provider(noinline fn: () -> T): Provider<T>
 
 internal fun ProviderFactory.valueOrNull(prop: String): Provider<String?> =
     provider {
-        gradleProperty(prop).forUseAtConfigurationTimeSafe().orNull
-    }
-
-private fun Provider<String?>.forUseAtConfigurationTimeSafe(): Provider<String?> =
-    // forUseAtConfigurationTime is a no-op starting at Gradle 7.4 and just produces deprecation warnings. 
-    // See https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.provider/-provider/for-use-at-configuration-time.html
-    if (GradleVersion.current() >= GradleVersion.version("7.4")) {
-        this
-    } else {
-        // todo: remove once we drop support for Gradle 6.4
-        forUseAtConfigurationTime()
+        gradleProperty(prop).orNull
     }
 
 internal fun Provider<String?>.toBooleanProvider(defaultValue: Boolean): Provider<Boolean> =
@@ -53,5 +42,5 @@ internal fun Provider<String?>.toBooleanProvider(defaultValue: Boolean): Provide
 
 internal fun Project.findLocalOrGlobalProperty(name: String, default: String = ""): Provider<String> = provider {
     if (extraProperties.has(name)) extraProperties.get(name).toString()
-    else providers.gradleProperty(name).forUseAtConfigurationTimeSafe().getOrElse(default)
+    else providers.gradleProperty(name).getOrElse(default)
 }

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -15,7 +15,7 @@ compose.tests.kotlin.version=2.0.0
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config
 # minimal and current gradle version
-compose.tests.gradle.versions=7.4, 8.10.2
+compose.tests.gradle.versions=8.0, 8.10.2
 compose.tests.agp.versions=8.1.0, 8.5.0, 8.8.0-alpha08
 
 # A version of Gradle plugin, that will be published,


### PR DESCRIPTION
Since Compose Multiplatform 1.7.1, the minimum AGP version has been raised to 8.1.0. This means the minimum Gradle version is 8.0. Thus, we can safely remove this function.
https://www.jetbrains.com/help/kotlin-multiplatform-dev/whats-new-compose-170.html#minimum-agp-version-raised-to-8-1-0
https://developer.android.com/build/releases/past-releases/agp-8-1-0-release-notes