### PR TITLE
Compose HTML: add an `AttrsScope.attr` overload for boolean attributes

### DIFF
--- a/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
+++ b/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
@@ -246,3 +246,10 @@ open class AttrsScopeBuilder<TElement : Element>(
 private val setClassList: (HTMLElement, Array<out String>) -> Unit = { e, classList ->
     e.classList.add(*classList)
 }
+
+/**
+ * Adds a boolean attribute.
+ * @see AttrsScope.attr
+ */
+fun AttrsScope<*>.attr(attr: String, value: Boolean = true) =
+    attr(attr, value.toString())

--- a/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
+++ b/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
@@ -97,9 +97,16 @@ interface AttrsScope<out TElement : Element> : EventsListenerScope {
      * @param attr - the name of the attribute
      * @param value - the value of the attribute
      *
-     * For boolean attributes cast boolean value to String and pass it as value.
+     * For boolean attributes, use the other overload with a boolean [value] parameter, or cast boolean value to String and pass it as value.
      */
     fun attr(attr: String, value: String): AttrsScope<TElement>
+
+    /**
+     * Adds a boolean attribute.
+     * @see AttrsScope.attr
+     */
+    fun attr(attr: String, value: Boolean = true) =
+        attr(attr, value.toString())
 
     /**
      * [prop] allows setting values of element's properties which can't be set using [attr].
@@ -198,7 +205,7 @@ open class AttrsScopeBuilder<TElement : Element>(
      * @param attr - the name of the attribute
      * @param value - the value of the attribute
      *
-     * For boolean attributes cast boolean value to String and pass it as value.
+     * For boolean attributes, use the other overload with a boolean [value] parameter, or cast boolean value to String and pass it as value.
      */
     override fun attr(attr: String, value: String): AttrsScope<TElement> {
         attributesMap[attr] = value
@@ -246,10 +253,3 @@ open class AttrsScopeBuilder<TElement : Element>(
 private val setClassList: (HTMLElement, Array<out String>) -> Unit = { e, classList ->
     e.classList.add(*classList)
 }
-
-/**
- * Adds a boolean attribute.
- * @see AttrsScope.attr
- */
-fun AttrsScope<*>.attr(attr: String, value: Boolean = true) =
-    attr(attr, value.toString())

--- a/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
+++ b/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
@@ -97,16 +97,16 @@ interface AttrsScope<out TElement : Element> : EventsListenerScope {
      * @param attr - the name of the attribute
      * @param value - the value of the attribute
      *
-     * For boolean attributes, use the other overload with a boolean [value] parameter, or cast boolean value to String and pass it as value.
+     * For boolean attributes, use the other overload with a boolean [condition].
      */
     fun attr(attr: String, value: String): AttrsScope<TElement>
 
     /**
-     * Adds a boolean attribute.
+     * Adds a boolean attribute if [condition] is `true` (empty value); omits it if `false`.
      * @see AttrsScope.attr
      */
-    fun attr(attr: String, value: Boolean = true) =
-        attr(attr, value.toString())
+    fun attr(attr: String, condition: Boolean): AttrsScope<TElement> =
+        if (condition) attr(attr, "") else this
 
     /**
      * [prop] allows setting values of element's properties which can't be set using [attr].
@@ -205,7 +205,7 @@ open class AttrsScopeBuilder<TElement : Element>(
      * @param attr - the name of the attribute
      * @param value - the value of the attribute
      *
-     * For boolean attributes, use the other overload with a boolean [value] parameter, or cast boolean value to String and pass it as value.
+     * For boolean attributes, use the other overload with a boolean [condition].
      */
     override fun attr(attr: String, value: String): AttrsScope<TElement> {
         attributesMap[attr] = value

--- a/html/core/src/jsTest/kotlin/elements/AttributesTests.kt
+++ b/html/core/src/jsTest/kotlin/elements/AttributesTests.kt
@@ -1,8 +1,8 @@
 package org.jetbrains.compose.web.core.tests
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import kotlinx.browser.document
 import kotlinx.dom.clear
@@ -10,11 +10,10 @@ import org.jetbrains.compose.web.attributes.*
 import org.jetbrains.compose.web.css.*
 import org.jetbrains.compose.web.dom.*
 import org.jetbrains.compose.web.dom.Text
+import org.jetbrains.compose.web.testutils.runTest
+import org.w3c.dom.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.jetbrains.compose.web.testutils.*
-import org.w3c.dom.*
-import kotlin.test.assertContains
 import kotlin.test.assertTrue
 
 class AttributesTests {
@@ -459,7 +458,7 @@ class AttributesTests {
                     id("id$readKey")
                 }
             ) {
-            @Suppress("DEPRECATION")
+                @Suppress("DEPRECATION")
                 DisposableRefEffect(readKey) {
                     val p = document.createElement("p").also { it.innerHTML = "Key=$readKey" }
                     it.appendChild(p)
@@ -508,7 +507,7 @@ class AttributesTests {
         with(child) {
             val attrs = getAttributeNames().toList()
             assertEquals(2, attrs.size)
-            assertTrue(attrs.containsAll(listOf("style", "class",)))
+            assertTrue(attrs.containsAll(listOf("style", "class")))
 
             assertEquals("button", tagName.lowercase())
             assertEquals("a", getAttribute("class"))

--- a/html/core/src/jsTest/kotlin/elements/AttributesTests.kt
+++ b/html/core/src/jsTest/kotlin/elements/AttributesTests.kt
@@ -579,4 +579,16 @@ class AttributesTests {
             assertEquals("400", attrsMap["height"])
         }
     }
+
+    @Test
+    fun booleanAttributeTest() = runTest {
+        composition {
+            TextInput {
+                attr("required", true)
+            }
+        }
+        with(nextChild()) {
+            assertEquals("true", getAttribute("required"))
+        }
+    }
 }

--- a/html/core/src/jsTest/kotlin/elements/AttributesTests.kt
+++ b/html/core/src/jsTest/kotlin/elements/AttributesTests.kt
@@ -580,14 +580,22 @@ class AttributesTests {
     }
 
     @Test
-    fun booleanAttributeTest() = runTest {
+    fun booleanAttributeAddedOnlyWhenTrue() = runTest {
+        var required by mutableStateOf(false)
+
         composition {
             TextInput {
-                attr("required", true)
+                attr("required", required)
             }
         }
+
         with(nextChild()) {
-            assertEquals("true", getAttribute("required"))
+            assertEquals(null, getAttribute("required"))
+
+            required = true
+            waitForChanges()
+
+            assertEquals("", getAttribute("required"))
         }
     }
 }


### PR DESCRIPTION
The `AttrsScope.attr` member function supports bolean attributes via "For boolean attributes cast boolean value to String and pass it as value.". This feature turns out to be frequently used in this [compose-html-material](https://github.com/huanshankeji/compose-html-material) project I have been working on. So I'd like to propose to add this to the core library.

Reformatted AttributesTests.kt with IntelliJ IDEA BTW.