### PR TITLE
Fix resources regionCode crash before macOS 14; Use first of preferred locales instead of current

### DIFF
--- a/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.macos.kt
+++ b/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.macos.kt
@@ -7,7 +7,10 @@ import platform.CoreGraphics.CGDisplayScreenSize
 import platform.Foundation.*
 
 internal actual fun getSystemEnvironment(): ResourceEnvironment {
-    val locale = NSLocale.currentLocale()
+    val locale = NSLocale.preferredLanguages.firstOrNull()
+        ?.let { NSLocale(it as String) }
+        ?: NSLocale.currentLocale
+
     val languageCode = locale.languageCode
     val regionCode = locale.objectForKey(NSLocaleCountryCode) as? String
     val isDarkTheme = NSUserDefaults.standardUserDefaults.stringForKey("AppleInterfaceStyle") == "Dark"

--- a/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.macos.kt
+++ b/components/resources/library/src/macosMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.macos.kt
@@ -8,6 +8,8 @@ import platform.Foundation.*
 
 internal actual fun getSystemEnvironment(): ResourceEnvironment {
     val locale = NSLocale.currentLocale()
+    val languageCode = locale.languageCode
+    val regionCode = locale.objectForKey(NSLocaleCountryCode) as? String
     val isDarkTheme = NSUserDefaults.standardUserDefaults.stringForKey("AppleInterfaceStyle") == "Dark"
 
     val dpi = NSScreen.mainScreen?.let { screen ->
@@ -24,8 +26,8 @@ internal actual fun getSystemEnvironment(): ResourceEnvironment {
     } ?: 0
 
     return ResourceEnvironment(
-        language = LanguageQualifier(locale.languageCode),
-        region = RegionQualifier(locale.regionCode.orEmpty()),
+        language = LanguageQualifier(languageCode),
+        region = RegionQualifier(regionCode.orEmpty()),
         theme = ThemeQualifier.selectByValue(isDarkTheme),
         density = DensityQualifier.selectByValue(dpi)
     )


### PR DESCRIPTION
`NSLocale.regionCode` is only available on macOS 14 and higher. This PR changes the code so it works on older versions, similar to #4473 but for macOS instead of iOS

https://developer.apple.com/documentation/foundation/nslocale/4172868-regioncode?language=objc


In addition to the fix explained above, I also applied the another fix as on iOS here: https://github.com/JetBrains/compose-multiplatform/pull/4507. 

I tested it with these settings:

![Screenshot 2024-12-09 at 21 27 11](https://github.com/user-attachments/assets/4673ff41-1c0e-46dc-9292-ab8da57b6e53)
Resulting in:
```
println(NSLocale.currentLocale().localeIdentifier) -> en_NL
println(NSLocale.preferredLanguages().first().let { NSLocale(it as String) }.localeIdentifier) -> en-GB
```

In this case I think `preferredLanguages` is the better option as compose is interested in the actual set language, which is English (UK).

Note that there are still some additional issues explained in detail here: https://youtrack.jetbrains.com/issue/CMP-6614/iOS-Localization-strings-for-language-qualifiers-that-are-not-the-same-between-platforms-appear-not-translated

For this PR, I decided to just match the iOS behaviour for now, so at least it is consistent. In the future I guess some locale mapping is required (see my comment in YouTrack)