### PR TITLE
Changelog script. Read dependencies, support N/A

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,7 @@ Subsections:
 - Gradle Plugin
 -->
 ### Section - Subsection
+<!-- Optional, in case we definitely shouldn't add Release Notes --> N/A
 - Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md
 - _(prerelease fix)_ Fix some bug that introduced in a prerelease version (dev/beta). It will be included in a dev/beta changelog, but excluded from a stable changelog
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,16 +15,18 @@ This should be tested by QA
 
 ## Release Notes
 <!--
-Optional, if omitted - won't be included in the changelog
+If we definitely shouldn't add Release Notes, add only N/A.
 
-Sections:
+Or enumerate sections, subsections and all changes.
+
+Possible sections:
 - Highlights
 - Known Issues
 - Breaking Changes
 - Features
 - Fixes
 
-Subsections:
+Possible subsections:
 - Multiple Platforms
 - iOS
 - Desktop
@@ -34,7 +36,6 @@ Subsections:
 - Gradle Plugin
 -->
 ### Section - Subsection
-<!-- Optional, in case we definitely shouldn't add Release Notes --> N/A
 - Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md
 - _(prerelease fix)_ Fix some bug that introduced in a prerelease version (dev/beta). It will be included in a dev/beta changelog, but excluded from a stable changelog
 

--- a/tools/changelog.main.kts
+++ b/tools/changelog.main.kts
@@ -281,6 +281,8 @@ fun GitHubPullEntry.extractReleaseNotes(link: String): List<ChangelogEntry> {
         before?.trim()
     }
 
+    if (relNoteBody?.trim()?.lowercase() == "n/a") return emptyList()
+
     val list = mutableListOf<ChangelogEntry>()
     var section: String? = null
     var subsection: String? = null


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7203/Changelog-script.-Generate-Dependencies-section
Fixes https://youtrack.jetbrains.com/issue/CMP-7137/Changelog-script-small-fixes

- Read dependencies from git repos
- Support N/A
- Supports any prefix. For example `- (experimental) Change`
- Try to fix the line start

Can be read commit by commit.