### PR TITLE
Changelog. Support passing a range

### DIFF
--- a/tools/changelog.main.kts
+++ b/tools/changelog.main.kts
@@ -104,6 +104,11 @@ val androidxLibToPreviousVersion = previousVersionCommitArg?.let(::androidxLibTo
 val androidxLibToVersion = androidxLibToVersion(versionCommit)
 val androidxLibToRedirectingVersion = androidxLibToRedirectingVersion(versionCommit)
 
+fun formatAndroidxLibPreviousVersion(libName: String) =
+    androidxLibToPreviousVersion?.get(libName) ?: "PLACEHOLDER".also {
+        println("Can't find $libName previous version. Using PLACEHOLDER")
+    }
+
 fun formatAndroidxLibVersion(libName: String) =
     androidxLibToVersion[libName] ?: "PLACEHOLDER".also {
         println("Can't find $libName version. Using PLACEHOLDER")
@@ -138,9 +143,16 @@ val previousChangelog =
         currentChangelog
     }
 
-val previousVersionInChangelog = previousChangelog.substringAfter("# ").substringBefore(" (")
-val previousVersionCommit = previousVersionCommitArg ?: "v$previousVersionInChangelog"
-val previousVersion = androidxLibToPreviousVersion?.get("COMPOSE") ?: previousVersionInChangelog
+var previousVersionCommit: String
+var previousVersion: String
+if (previousVersionCommitArg != null) {
+    previousVersionCommit = previousVersionCommitArg!!
+    previousVersion = formatAndroidxLibPreviousVersion("COMPOSE")
+} else {
+    val previousVersionInChangelog = previousChangelog.substringAfter("# ").substringBefore(" (")
+    previousVersionCommit = "v$previousVersionInChangelog"
+    previousVersion = previousVersionInChangelog
+}
 
 println()
 println("Generating changelog between $previousVersion and $versionName")

--- a/tools/changelog.main.kts
+++ b/tools/changelog.main.kts
@@ -1,11 +1,15 @@
 /**
  * Script for creating a changelog. Call:
  * ```
- * kotlin changelog.main.kts release/1.6.0 1.6.0-rc02
+ * kotlin changelog.main.kts 1.7.0-dev555
+ * ```
+ * or:
+ * ```
+ * kotlin changelog.main.kts 1.7.0..1.7.1-dev555
  * ```
  * where:
- * release/1.6.0 - the commit of the version
- * 1.6.0-rc02 - the name of the version
+ * 1.7.0-dev555 - the tag/branch of the version. The previous version will be read from CHANGELOG.md
+ * 1.7.0..1.7.1-dev555 - the range of tag/branches for the changelog
  *
  * It modifies CHANGELOG.md and adds new changes between the last version in CHANGELOG.md and the specified version.
  *
@@ -74,15 +78,29 @@ val argsKeyToValue = args
     .filter { it.contains("=") }
     .associate { it.substringBefore("=") to it.substringAfter("=") }
 
-val versionCommit = argsKeyless.getOrNull(0) ?: "HEAD"
+val commitsArg = argsKeyless.getOrNull(0) ?: "HEAD"
+
+var previousVersionCommitArg: String?
+var versionCommitArg: String
+if (commitsArg.contains("..")) {
+    previousVersionCommitArg = commitsArg.substringBefore("..")
+    versionCommitArg = commitsArg.substringAfter("..",)
+} else {
+    previousVersionCommitArg = null
+    versionCommitArg = commitsArg
+}
+
+val versionCommit = versionCommitArg
+
 val token = argsKeyToValue["token"]
 
-println("Note. The script supports optional arguments: kotlin changelog.main.kts [versionCommit] [versionName] [token=githubToken]")
+println("Note. The script supports optional arguments: kotlin changelog.main.kts [previousVersionCommit..versionCommit] [token=githubToken]")
 if (token == null) {
     println("To increase the rate limit, specify token (https://github.com/settings/tokens)")
 }
 println()
 
+val androidxLibToPreviousVersion = previousVersionCommitArg?.let(::androidxLibToVersion)
 val androidxLibToVersion = androidxLibToVersion(versionCommit)
 val androidxLibToRedirectingVersion = androidxLibToRedirectingVersion(versionCommit)
 
@@ -120,12 +138,14 @@ val previousChangelog =
         currentChangelog
     }
 
-val previousVersion = previousChangelog.substringAfter("# ").substringBefore(" (")
+val previousVersionInChangelog = previousChangelog.substringAfter("# ").substringBefore(" (")
+val previousVersionCommit = previousVersionCommitArg ?: "v$previousVersionInChangelog"
+val previousVersion = androidxLibToPreviousVersion?.get("COMPOSE") ?: previousVersionInChangelog
 
 println()
 println("Generating changelog between $previousVersion and $versionName")
 
-val newChangelog = getChangelog("v$previousVersion", versionCommit, previousVersion)
+val newChangelog = getChangelog(previousVersionCommit, versionCommit, previousVersion)
 
 changelogFile.writeText(
     newChangelog + previousChangelog

--- a/tools/changelog.main.kts
+++ b/tools/changelog.main.kts
@@ -84,7 +84,7 @@ var previousVersionCommitArg: String?
 var versionCommitArg: String
 if (commitsArg.contains("..")) {
     previousVersionCommitArg = commitsArg.substringBefore("..")
-    versionCommitArg = commitsArg.substringAfter("..",)
+    versionCommitArg = commitsArg.substringAfter("..")
 } else {
     previousVersionCommitArg = null
     versionCommitArg = commitsArg

--- a/tools/changelog.main.kts
+++ b/tools/changelog.main.kts
@@ -1,15 +1,15 @@
 /**
  * Script for creating a changelog. Call:
  * ```
- * kotlin changelog.main.kts 1.7.0-dev555
+ * kotlin changelog.main.kts v1.7.0-dev555
  * ```
  * or:
  * ```
- * kotlin changelog.main.kts 1.7.0..1.7.1-dev555
+ * kotlin changelog.main.kts v1.7.0..v1.7.1-dev555
  * ```
  * where:
- * 1.7.0-dev555 - the tag/branch of the version. The previous version will be read from CHANGELOG.md
- * 1.7.0..1.7.1-dev555 - the range of tag/branches for the changelog
+ * v1.7.0-dev555 - the tag/branch of the version. The previous version will be read from CHANGELOG.md
+ * v1.7.0..1.7.1-dev555 - the range of tag/branches for the changelog
  *
  * It modifies CHANGELOG.md and adds new changes between the last version in CHANGELOG.md and the specified version.
  *


### PR DESCRIPTION
Needed for 1.7.2:
```
kotlin changelog.main.kts v1.7.1..release/1.7.2
```

Otherwise it compares with `1.8.0-alpha01`