### PR TITLE
CMP-7288 explicitly specify IJ platform compatibility range

### DIFF
--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -33,7 +33,13 @@ dependencies {
 }
 
 intellijPlatform {
-    pluginConfiguration { name = "Compose Multiplatform IDE Support" }
+    pluginConfiguration {
+        name = "Compose Multiplatform IDE Support"
+        ideaVersion {
+            sinceBuild = "242.20224"
+            untilBuild = provider { null }
+        }
+    }
     buildSearchableOptions = false
     autoReload = false
 


### PR DESCRIPTION
Explicitly specify compatible IJ platform builds: current version as a minimum and open range as maximum

Fixes https://youtrack.jetbrains.com/issue/CMP-7288
