### PR TITLE
Fix 20s first frame rendering on LazyList benchmark

### DIFF
--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -56,7 +56,10 @@ suspend fun measureComposable(
         // warmup
         repeat(warmupCount) {
             scene.render(canvas, it * nanosPerFrame)
+            surface.flushAndSubmit(false)
         }
+
+        graphicsContext?.awaitGPUCompletion()
 
         runGC()
 
@@ -65,8 +68,10 @@ suspend fun measureComposable(
             renderTime = measureTime {
                 repeat(frameCount) {
                     scene.render(canvas, it * nanosPerFrame)
+                    surface.flushAndSubmit(false)
                 }
             }
+            graphicsContext?.awaitGPUCompletion()
         }
 
         val frames = MutableList(frameCount) {


### PR DESCRIPTION
Fixes [CMP-7195](https://youtrack.jetbrains.com/issue/CMP-7195/Strange-behaviour-of-AnimatedVisibility-and-LazyList-benchmarks)

