### PR TITLE
Compose HTML: add `StyleScope.inset` extension functions

### DIFF
--- a/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/position.kt
+++ b/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/position.kt
@@ -46,3 +46,14 @@ fun StyleScope.right(value: CSSAutoKeyword) {
     property("right", value)
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/CSS/inset
+fun StyleScope.inset(vararg value: CSSLengthOrPercentageValue) {
+    // no Typed OM yet
+    property("inset", value.joinToString(" "))
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/inset
+fun StyleScope.inset(vararg value: CSSAutoKeyword) {
+    // no Typed OM yet
+    property("inset", value.joinToString(" "))
+}


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/CSS/inset:

> The `inset` CSS property is a shorthand that corresponds to the `top`, `right`, `bottom`, and/or `left` properties.

## Testing

I didn't add tests yet as I see there are no tests for the existing inset functions such as `StyleScope.top`.

## Release Notes

### Features - HTML library
- Add `StyleScope.inset` extension functions
