### PR TITLE
Support generated custom resources class name

### DIFF
--- a/gradle-plugins/.gitignore
+++ b/gradle-plugins/.gitignore
@@ -37,3 +37,5 @@ jacoco.exec
 # Layout Inspector creates it.
 captures/
 __pycache__
+
+.kotlin/

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
@@ -9,12 +9,11 @@ import org.jetbrains.compose.internal.IdeaImportTask
 import java.io.File
 
 internal abstract class GenerateResClassTask : IdeaImportTask() {
-    companion object {
-        private const val RES_FILE_NAME = "Res"
-    }
-
     @get:Input
     abstract val packageName: Property<String>
+
+    @get:Input
+    abstract val resClassName: Property<String>
 
     @get:Input
     @get:Optional
@@ -31,11 +30,12 @@ internal abstract class GenerateResClassTask : IdeaImportTask() {
         dir.deleteRecursively()
         dir.mkdirs()
 
-        logger.info("Generate $RES_FILE_NAME.kt")
+        val resClassName = resClassName.get()
+        logger.info("Generate $resClassName.kt")
 
         val pkgName = packageName.get()
         val moduleDirectory = packagingDir.getOrNull()?.let { it.invariantSeparatorsPath + "/" } ?: ""
         val isPublic = makeAccessorsPublic.get()
-        getResFileSpec(pkgName, RES_FILE_NAME, moduleDirectory, isPublic).writeTo(dir)
+        getResFileSpec(pkgName, resClassName, moduleDirectory, isPublic).writeTo(dir)
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResourceAccessorsTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResourceAccessorsTask.kt
@@ -19,6 +19,9 @@ internal abstract class GenerateResourceAccessorsTask : IdeaImportTask() {
     abstract val packageName: Property<String>
 
     @get:Input
+    abstract val resClassName: Property<String>
+
+    @get:Input
     abstract val sourceSetName: Property<String>
 
     @get:Input
@@ -68,9 +71,10 @@ internal abstract class GenerateResourceAccessorsTask : IdeaImportTask() {
 
         val pkgName = packageName.get()
         val moduleDirectory = packagingDir.getOrNull()?.let { it.invariantSeparatorsPath + "/" } ?: ""
+        val resClassName = resClassName.get()
         val isPublic = makeAccessorsPublic.get()
         getAccessorsSpecs(
-            resources, pkgName, sourceSet, moduleDirectory, isPublic
+            resources, pkgName, sourceSet, moduleDirectory, resClassName, isPublic
         ).forEach { it.writeTo(kotlinDir) }
     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResourceCollectorsTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResourceCollectorsTask.kt
@@ -16,6 +16,9 @@ internal abstract class GenerateExpectResourceCollectorsTask : IdeaImportTask() 
     abstract val packageName: Property<String>
 
     @get:Input
+    abstract val resClassName: Property<String>
+
+    @get:Input
     abstract val makeAccessorsPublic: Property<Boolean>
 
     @get:OutputDirectory
@@ -31,8 +34,9 @@ internal abstract class GenerateExpectResourceCollectorsTask : IdeaImportTask() 
         logger.info("Generate expect ResourceCollectors for $kotlinDir")
 
         val pkgName = packageName.get()
+        val resClassName = resClassName.get()
         val isPublic = makeAccessorsPublic.get()
-        val spec = getExpectResourceCollectorsFileSpec(pkgName, "ExpectResourceCollectors", isPublic)
+        val spec = getExpectResourceCollectorsFileSpec(pkgName, "ExpectResourceCollectors", resClassName, isPublic)
         spec.writeTo(kotlinDir)
     }
 }
@@ -40,6 +44,9 @@ internal abstract class GenerateExpectResourceCollectorsTask : IdeaImportTask() 
 internal abstract class GenerateActualResourceCollectorsTask : IdeaImportTask() {
     @get:Input
     abstract val packageName: Property<String>
+
+    @get:Input
+    abstract val resClassName: Property<String>
 
     @get:Input
     abstract val makeAccessorsPublic: Property<Boolean>
@@ -89,11 +96,13 @@ internal abstract class GenerateActualResourceCollectorsTask : IdeaImportTask() 
         }.groupBy({ it.first }, { it.second })
 
         val pkgName = packageName.get()
+        val resClassName = resClassName.get()
         val isPublic = makeAccessorsPublic.get()
         val useActual = useActualModifier.get()
         val spec = getActualResourceCollectorsFileSpec(
             pkgName,
             "ActualResourceCollectors",
+            resClassName,
             isPublic,
             useActual,
             funNames

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesDSL.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesDSL.kt
@@ -22,6 +22,13 @@ abstract class ResourcesExtension {
      */
     var packageOfResClass: String = ""
 
+    /**
+     * The name of the generated resources accessors class.
+     *
+     * The default is "Res".
+     */
+    var resClassName: String = "Res"
+
     enum class ResourceClassGeneration { Auto, Always, Never }
 
     //to support groovy DSL


### PR DESCRIPTION
Assume we have two modules, as shown below.

### On app module

`app/build.gradle.kts`
```kotlin
dependencies {
    implementation(project(":core"))
}
```

### On core module

`core/build.gradle.kts`
```kotlin
compose {
    resources {
        publicResClass = true
    }
}
```

`core/src/kotlin/CoreRes.kt`
```kotlin
typealias CoreRes = Res
```

Now we cannot use `CoreRes.strings.xxx` like `Res.strings.xxx`.

So, we need to add the ability to let users define custom resource class name.

Usage:

```
compose {
    resources {
        resClassName = "CoreRes"
    }
}
```
