### PR TITLE
Add Windows ARM alias to Gradle plugin

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -98,6 +98,7 @@ abstract class ComposePlugin : Plugin<Project> {
         val linux_x64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-linux-x64")
         val linux_arm64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-linux-arm64")
         val windows_x64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-windows-x64")
+        val windows_arm64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-windows-arm64")
         val macos_x64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-macos-x64")
         val macos_arm64 = composeDependency("org.jetbrains.compose.desktop:desktop-jvm-macos-arm64")
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-2584/Publish-Windows-ARM-library#focus=Comments-27-11356341.0-0

## Testing
1. On `codeviewer` example. Add windows_arm64:
```
            dependencies {
                implementation(compose.desktop.currentOs)
                implementation(compose.desktop.windows_arm64)
                implementation(project(":shared"))
            }
```

2. Run on Windows x86:
```
./gradlew createDistributable
```
3. Check that `build/compose/binaries/main/app/ComposeCodeViewer/app` contains 2 files:
![image](https://github.com/user-attachments/assets/95733d72-4795-4d2d-af08-cfeeb3811ab5)
