### PR TITLE
Get rid of delay from AnimatedVisibility benchmark 

### DIFF
--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/benchmarks/animation/AnimatedVisibility.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/benchmarks/animation/AnimatedVisibility.kt
@@ -1,6 +1,8 @@
 package benchmarks.animation
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterExitState
+import androidx.compose.animation.core.Transition
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,11 +13,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import compose_benchmarks.benchmarks.generated.resources.Res
 import compose_benchmarks.benchmarks.generated.resources.compose_multiplatform
-import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 
@@ -24,12 +26,17 @@ import org.jetbrains.compose.resources.painterResource
 fun AnimatedVisibility() {
     MaterialTheme {
         var showImage by remember { mutableStateOf(false) }
+        var transition: Transition<EnterExitState>? = null
         LaunchedEffect(showImage) {
-            delay(200)
+            do {
+                withFrameNanos {}
+            } while (transition?.isRunning == true)
+
             showImage = !showImage
         }
         Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
             AnimatedVisibility(showImage) {
+                transition = this.transition
                 Image(
                     painterResource(Res.drawable.compose_multiplatform),
                     null


### PR DESCRIPTION
Fixes [CMP-7195](https://youtrack.jetbrains.com/issue/CMP-7195/Strange-behaviour-of-AnimatedVisibility-and-LazyList-benchmarks)
