### PR TITLE
Typo fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -859,7 +859,7 @@ _Changes since 1.6.10_
 
 ### Resources
 
-- [Fix a cached font if the resource acessor was changed](https://github.com/JetBrains/compose-multiplatform/pull/4864)
+- [Fix a cached font if the resource accessor was changed](https://github.com/JetBrains/compose-multiplatform/pull/4864)
 
 ### Gradle Plugin
 


### PR DESCRIPTION
# Typo Fix in `CHANGELOG.md`

## Description
This pull request corrects a typo in the `CHANGELOG.md` file:
- Changed "acessor" to "accessor" for proper spelling.
