### PR TITLE
Benchmarks. Mimic the behavior of Skiko rendering

### DIFF
--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -140,7 +140,7 @@ private val pictureRecorder = PictureRecorder()
  *
  * This is a simplified logic and it still can differ from the real cases:
  * - Rendering into an intermediate picture. Benchmarks can show incorrect results without it.
- *   For example, we had a case, when they showed an an improvement by 10%,
+ *   For example, we had a case when they showed an improvement by 10%,
  *   but there was a regression by 10%
  * - Clearing the canvas each frame
  *

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -134,6 +134,19 @@ suspend fun measureComposable(
 
 private val pictureRecorder = PictureRecorder()
 
+/**
+ * Mimic Skiko render logic from https://github.com/JetBrains/skiko/blob/eb1f04ec99d50ff0bdb2f592fdf49711a9251aa7/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt#L531
+ *
+ * This is very simplified logic, and it still can differ from the real cases.
+ *
+ * Though one main function - rendering into picture - was affecting performance.
+ *
+ * Benchmarks showed an improvement by 10%, but there was a regression by 10%.
+ *
+ * Beware that this logic can be changed in some new version of Skiko.
+ *
+ * If Skiko stops using `picture`, we need to remove it here too.
+ */
 @OptIn(InternalComposeUiApi::class)
 fun ComposeScene.mimicSkikoRender(surface: Surface, time: Long, width: Int, height: Int) {
     val pictureCanvas = pictureRecorder.beginRecording(Rect(0f, 0f, width.toFloat(), height.toFloat()))

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -2,12 +2,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.scene.CanvasLayersComposeScene
+import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.IntSize
 import org.jetbrains.skia.Surface
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.*
+import org.jetbrains.skia.Color
+import org.jetbrains.skia.PictureRecorder
+import org.jetbrains.skia.Rect
 import kotlin.time.TimeSource.Monotonic.markNow
 import kotlin.time.measureTime
 
@@ -46,16 +50,15 @@ suspend fun measureComposable(
     graphicsContext: GraphicsContext?,
     content: @Composable () -> Unit
 ): BenchmarkResult  {
+    val surface = graphicsContext?.surface(width, height) ?: Surface.makeNull(width, height)
     val scene = CanvasLayersComposeScene(size = IntSize(width, height))
     try {
         val nanosPerFrame = (1.0 / targetFps.toDouble() * nanosPerSecond).toLong()
         scene.setContent(content)
-        val surface = graphicsContext?.surface(width, height) ?: Surface.makeNull(width, height)
-        val canvas = surface.canvas.asComposeCanvas()
 
         // warmup
         repeat(warmupCount) {
-            scene.render(canvas, it * nanosPerFrame)
+            scene.mimicSkikoRender(surface, it * nanosPerFrame, width, height)
             surface.flushAndSubmit(false)
             graphicsContext?.awaitGPUCompletion()
         }
@@ -67,7 +70,7 @@ suspend fun measureComposable(
         if (Args.isModeEnabled(Mode.CPU)) {
             renderTime = measureTime {
                 repeat(frameCount) {
-                    scene.render(canvas, it * nanosPerFrame)
+                    scene.mimicSkikoRender(surface, it * nanosPerFrame, width, height)
                     surface.flushAndSubmit(false)
                     gpuTime += measureTime {
                         graphicsContext?.awaitGPUCompletion()
@@ -93,7 +96,7 @@ suspend fun measureComposable(
             repeat(frameCount) {
                 val frameStart = markNow()
 
-                scene.render(canvas, nextVSync.inWholeNanoseconds)
+                scene.mimicSkikoRender(surface, it * nextVSync.inWholeNanoseconds, width, height)
                 surface.flushAndSubmit(false)
 
                 val cpuTime = frameStart.elapsedNow()
@@ -124,6 +127,20 @@ suspend fun measureComposable(
         )
     } finally {
         scene.close()
+        surface.close()
         runGC() // cleanup for next benchmarks
     }
+}
+
+private val pictureRecorder = PictureRecorder()
+
+@OptIn(InternalComposeUiApi::class)
+fun ComposeScene.mimicSkikoRender(surface: Surface, time: Long, width: Int, height: Int) {
+    val pictureCanvas = pictureRecorder.beginRecording(Rect(0f, 0f, width.toFloat(), height.toFloat()))
+    render(pictureCanvas.asComposeCanvas(), time)
+    val picture = pictureRecorder.finishRecordingAsPicture()
+
+    surface.canvas.clear(Color.TRANSPARENT)
+    surface.canvas.drawPicture(picture)
+    picture.close()
 }

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -135,16 +135,16 @@ suspend fun measureComposable(
 private val pictureRecorder = PictureRecorder()
 
 /**
- * Mimic Skiko render logic from https://github.com/JetBrains/skiko/blob/eb1f04ec99d50ff0bdb2f592fdf49711a9251aa7/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt#L531
+ * Mimic Skiko render logic from
+ * https://github.com/JetBrains/skiko/blob/eb1f04ec99d50ff0bdb2f592fdf49711a9251aa7/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt#L531
  *
- * This is very simplified logic, and it still can differ from the real cases.
- *
- * Though one main function - rendering into picture - was affecting performance.
- *
- * Benchmarks showed an improvement by 10%, but there was a regression by 10%.
+ * This is a simplified logic and it still can differ from the real cases:
+ * - Rendering into an intermediate picture. Without it, benchmark can show incorrect results.
+ *   For example, we had a case, when they showed an an improvement by 10%,
+ *   but there was a regression by 10%
+ * - Clearing the canvas each frame
  *
  * Beware that this logic can be changed in some new version of Skiko.
- *
  * If Skiko stops using `picture`, we need to remove it here too.
  */
 @OptIn(InternalComposeUiApi::class)

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -91,7 +91,7 @@ suspend fun measureComposable(
             val start = markNow()
 
             repeat(frameCount) {
-                val frameStart = start + nextVSync
+                val frameStart = markNow()
 
                 scene.render(canvas, nextVSync.inWholeNanoseconds)
                 surface.flushAndSubmit(false)

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -139,7 +139,7 @@ private val pictureRecorder = PictureRecorder()
  * https://github.com/JetBrains/skiko/blob/eb1f04ec99d50ff0bdb2f592fdf49711a9251aa7/skiko/src/awtMain/kotlin/org/jetbrains/skiko/SkiaLayer.awt.kt#L531
  *
  * This is a simplified logic and it still can differ from the real cases:
- * - Rendering into an intermediate picture. Without it, benchmark can show incorrect results.
+ * - Rendering into an intermediate picture. Benchmarks can show incorrect results without it.
  *   For example, we had a case, when they showed an an improvement by 10%,
  *   but there was a regression by 10%
  * - Clearing the canvas each frame

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -94,7 +94,7 @@ suspend fun measureComposable(
             val start = markNow()
 
             repeat(frameCount) {
-                val frameStart = markNow()
+                val frameStart = start + nextVSync
 
                 scene.mimicSkikoRender(surface, it * nextVSync.inWholeNanoseconds, width, height)
                 surface.flushAndSubmit(false)

--- a/benchmarks/multiplatform/build.gradle.kts
+++ b/benchmarks/multiplatform/build.gradle.kts
@@ -11,5 +11,6 @@ allprojects {
         google()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        mavenLocal()
     }
 }


### PR DESCRIPTION
- Draw into an intermediate Picture. Without it, benchmarks showed an improvement by 8.61% between old/new layers, but in fact it was [a regression by 5.63%](https://docs.google.com/spreadsheets/d/1KQKDICvlmWDXtTqVoPOqIaqtXUPyQXA6RslTn79VW8o/edit?gid=406066323#gid=406066323):

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/8d231a59-1a0e-4883-ab3e-9a072125e0c9" />

- Clear Canvas each frame

- Add MavenLocal to becnhmark local versions

## Release Notes
N/A