### PR TITLE
Maven Test project - update JvmTarget to 11

### DIFF
--- a/ci/templates/maven-test-project/pom.xml
+++ b/ci/templates/maven-test-project/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
+        <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
         <kotlin.version>2.1.0</kotlin.version>
         <compose.version>1.8.0-alpha02</compose.version>
     </properties>


### PR DESCRIPTION
We support only 11 minimal for Desktop. It fails with latest builds

(it also fails because of another reason, which I will fix separately)

## Release Notes
N/A