### PR TITLE
Fix will typos in `SplitPaneDSL`

### DIFF
--- a/components/SplitPane/library/src/commonMain/kotlin/org/jetbrains/compose/splitpane/SplitPaneDSL.kt
+++ b/components/SplitPane/library/src/commonMain/kotlin/org/jetbrains/compose/splitpane/SplitPaneDSL.kt
@@ -19,7 +19,7 @@ interface SplitPaneScope {
      * Set up first composable item if SplitPane, for [HorizontalSplitPane] it will be
      * Left part, for [VerticalSplitPane] it will be Top part
      * @param minSize a minimal size of composable item.
-     * For [HorizontalSplitPane] it will be minimal width, for [VerticalSplitPane] it wil be minimal Heights.
+     * For [HorizontalSplitPane] it will be minimal width, for [VerticalSplitPane] it will be minimal Heights.
      * In this context minimal mean that this composable item could not be smaller than specified value.
      * @param content composable item content.
      * */
@@ -32,7 +32,7 @@ interface SplitPaneScope {
      * Set up second composable item if SplitPane.
      * For [HorizontalSplitPane] it will be Right part, for [VerticalSplitPane] it will be Bottom part
      * @param minSize a minimal size of composable item.
-     * For [HorizontalSplitPane] it will be minimal width, for [VerticalSplitPane] it wil be minimal Heights.
+     * For [HorizontalSplitPane] it will be minimal width, for [VerticalSplitPane] it will be minimal Heights.
      * In this context minimal mean that this composable item could not be smaller than specified value.
      * @param content composable item content.
      * */


### PR DESCRIPTION
Fix a couple of `wil` -> `will` typos.

