### PR TITLE
eng: update a comment, unit test for better clarity about why the start = Lazy

### DIFF
--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/AsyncCache.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/AsyncCache.kt
@@ -15,7 +15,7 @@ internal class AsyncCache<K, V> {
         val deferred = mutex.withLock {
             var cached = cache[key]
             if (cached == null || cached.isCancelled) {
-                //LAZY - to free the mutex lock as fast as possible
+                // LAZY - to release the mutex as quickly as possible and defer the work
                 cached = async(start = CoroutineStart.LAZY) { load() }
                 cache[key] = cached
             }

--- a/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/AsyncCacheTest.kt
+++ b/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/AsyncCacheTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020-2024 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.compose.resources
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AsyncCacheTest {
+
+    private lateinit var cache: AsyncCache<String, String>
+
+    @BeforeTest
+    fun setup() {
+        cache = AsyncCache()
+    }
+
+    @Test
+    fun `test cache stores and retrieves value`() = runTest {
+        val key = "testKey"
+        val expectedValue = "Hello, World!"
+
+        val value = cache.getOrLoad(key) { expectedValue }
+
+        assertEquals(expectedValue, value)
+    }
+
+    @Test
+    fun `test cache returns same instance for same key`() = runTest {
+        val key = "testKey"
+        var loadCount = 0
+
+        val firstLoad = cache.getOrLoad(key) {
+            loadCount++
+            "Hello"
+        }
+        val secondLoad = cache.getOrLoad(key) { "NewValue" }
+
+        assertEquals("Hello", firstLoad)
+        assertEquals("Hello", secondLoad)
+        assertEquals(1, loadCount) // Ensures the load function runs only once
+    }
+
+    @Test
+    fun `test concurrent access to cache`() = runTest {
+        val key = "testKey"
+        var loadCount = 0
+
+        coroutineScope {
+            repeat(10) {
+                launch {
+                    cache.getOrLoad(key) {
+                        delay(100) // Simulate work
+                        loadCount++
+                        "Concurrent Value"
+                    }
+                }
+            }
+        }
+
+        assertEquals(1, loadCount) // Ensures only one load operation happened
+    }
+
+    @Test
+    fun `test cache invalidation on clear`() = runTest {
+        val key = "testKey"
+
+        cache.getOrLoad(key) { "InitialValue" }
+        cache.clear()
+
+        val newValue = cache.getOrLoad(key) { "NewValue" }
+
+        assertEquals("NewValue", newValue)
+    }
+}


### PR DESCRIPTION
```
// LAZY - to release the mutex as quickly as possible and defer the work
```
The only change is in the comment // LAZY - to release the mutex as quickly as possible and defer the work for better clarity about why the start = CoroutineStart.LAZY is used.

<img width="392" alt="Screenshot 2025-02-09 at 11 17 57" src="https://github.com/user-attachments/assets/96a9f45b-5e5e-473b-8736-d8c427d837a6" />

