### PR TITLE
Add missing jpackage options

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -100,6 +100,7 @@ abstract class WindowsPlatformSettings : AbstractPlatformSettings() {
     var dirChooser: Boolean = true
     var perUserInstall: Boolean = false
     var shortcut: Boolean = false
+    var shortcutPrompt: Boolean = false
     var menu: Boolean = false
         get() = field || menuGroup != null
     var menuGroup: String? = null

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -104,6 +104,7 @@ abstract class WindowsPlatformSettings : AbstractPlatformSettings() {
     var menu: Boolean = false
         get() = field || menuGroup != null
     var menuGroup: String? = null
+    var updateUrl: String? = null
     var upgradeUuid: String? = null
     var msiPackageVersion: String? = null
     var exePackageVersion: String? = null

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -36,6 +36,8 @@ abstract class AbstractMacOSPlatformSettings : AbstractPlatformSettings() {
     var appCategory: String? = null
     var minimumSystemVersion: String? = null
 
+    var dmgContents = ArrayList<String>()
+
 
     /**
      * An application's unique identifier across Apple's ecosystem.

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -85,6 +85,7 @@ open class InfoPlistSettings {
 
 abstract class LinuxPlatformSettings : AbstractPlatformSettings() {
     var shortcut: Boolean = false
+    var packageDeps: String? = null
     var packageName: String? = null
     var appRelease: String? = null
     var appCategory: String? = null

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -36,7 +36,7 @@ abstract class AbstractMacOSPlatformSettings : AbstractPlatformSettings() {
     var appCategory: String? = null
     var minimumSystemVersion: String? = null
 
-    var dmgContents = ArrayList<String>()
+    var dmgContents: String? = null
 
 
     /**

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -384,6 +384,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.winDirChooser.set(provider { win.dirChooser })
                 packageTask.winPerUserInstall.set(provider { win.perUserInstall })
                 packageTask.winShortcut.set(provider { win.shortcut })
+                packageTask.winShortcutPrompt.set(provider { win.shortcutPrompt })
                 packageTask.winMenu.set(provider { win.menu })
                 packageTask.winMenuGroup.set(provider { win.menuGroup })
                 packageTask.winUpgradeUuid.set(provider { win.upgradeUuid })

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -371,6 +371,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.linuxAppRelease.set(provider { linux.appRelease })
                 packageTask.linuxDebMaintainer.set(provider { linux.debMaintainer })
                 packageTask.linuxMenuGroup.set(provider { linux.menuGroup })
+                packageTask.linuxPackageDeps.set(provider { linux.packageDeps })
                 packageTask.linuxPackageName.set(provider { linux.packageName })
                 packageTask.linuxRpmLicenseType.set(provider { linux.rpmLicenseType })
                 packageTask.iconFile.set(linux.iconFile.orElse(defaultResources.get { linuxIcon }))

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -387,6 +387,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.winShortcutPrompt.set(provider { win.shortcutPrompt })
                 packageTask.winMenu.set(provider { win.menu })
                 packageTask.winMenuGroup.set(provider { win.menuGroup })
+                packageTask.winUpdateUrl.set(provider { win.updateUrl })
                 packageTask.winUpgradeUuid.set(provider { win.upgradeUuid })
                 packageTask.iconFile.set(win.iconFile.orElse(defaultResources.get { windowsIcon }))
                 packageTask.installationPath.set(win.installationPath)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -397,6 +397,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
         }
         OS.MacOS -> {
             app.nativeDistributions.macOS.also { mac ->
+                packageTask.macDmgContents.set(provider { mac.dmgContents })
                 packageTask.macPackageName.set(provider { mac.packageName })
                 packageTask.macDockName.set(
                     if (mac.setDockNameSameAsPackageName)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -218,6 +218,10 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
+    val winShortcutPrompt: Property<Boolean?> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
     val winMenu: Property<Boolean?> = objects.nullableProperty()
 
     @get:Input
@@ -449,6 +453,7 @@ abstract class AbstractJPackageTask @Inject constructor(
                     cliArg("--win-dir-chooser", winDirChooser)
                     cliArg("--win-per-user-install", winPerUserInstall)
                     cliArg("--win-shortcut", winShortcut)
+                    cliArg("--win-shortcut-prompt", winShortcutPrompt)
                     cliArg("--win-menu", winMenu)
                     cliArg("--win-menu-group", winMenuGroup)
                     cliArg("--win-upgrade-uuid", winUpgradeUuid)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -230,6 +230,10 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
+    val winUpdateUrl: Property<String?> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
     val winUpgradeUuid: Property<String?> = objects.nullableProperty()
 
     @get:InputDirectory
@@ -456,6 +460,7 @@ abstract class AbstractJPackageTask @Inject constructor(
                     cliArg("--win-shortcut-prompt", winShortcutPrompt)
                     cliArg("--win-menu", winMenu)
                     cliArg("--win-menu-group", winMenuGroup)
+                    cliArg("--win-update-url", winUpdateUrl)
                     cliArg("--win-upgrade-uuid", winUpgradeUuid)
                 }
                 OS.MacOS -> {}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -206,7 +206,7 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    val macDmgContents: ListProperty<String> = objects.listProperty<String>(String::class.java)
+    val macDmgContents: Property<String?> = objects.nullableProperty()
 
     @get:Input
     @get:Optional
@@ -474,11 +474,8 @@ abstract class AbstractJPackageTask @Inject constructor(
                 }
                 OS.MacOS -> {
                     if (jvmRuntimeInfo.majorVersion >= 18) {
-                        macDmgContents.get().forEach {
-                            cliArg("--mac-dmg-content", it)
-                        }
+                        cliArg("--mac-dmg-content", macDmgContents)
                     }
-
                 }
             }
         }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -473,9 +473,12 @@ abstract class AbstractJPackageTask @Inject constructor(
                     cliArg("--win-upgrade-uuid", winUpgradeUuid)
                 }
                 OS.MacOS -> {
-                    macDmgContents.get().forEach {
-                        cliArg("--mac-dmg-content", it)
+                    if (jvmRuntimeInfo.majorVersion >= 18) {
+                        macDmgContents.get().forEach {
+                            cliArg("--mac-dmg-content", it)
+                        }
                     }
+
                 }
             }
         }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -206,6 +206,10 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
+    val macDmgContents: ListProperty<String> = objects.listProperty<String>(String::class.java)
+
+    @get:Input
+    @get:Optional
     val winConsole: Property<Boolean?> = objects.nullableProperty()
 
     @get:Input
@@ -468,7 +472,11 @@ abstract class AbstractJPackageTask @Inject constructor(
                     cliArg("--win-update-url", winUpdateUrl)
                     cliArg("--win-upgrade-uuid", winUpgradeUuid)
                 }
-                OS.MacOS -> {}
+                OS.MacOS -> {
+                    macDmgContents.get().forEach {
+                        cliArg("--mac-dmg-content", it)
+                    }
+                }
             }
         }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -473,8 +473,12 @@ abstract class AbstractJPackageTask @Inject constructor(
                     cliArg("--win-upgrade-uuid", winUpgradeUuid)
                 }
                 OS.MacOS -> {
-                    if (jvmRuntimeInfo.majorVersion >= 18) {
-                        cliArg("--mac-dmg-content", macDmgContents)
+                    if (macDmgContents.isPresent) {
+                        if (jvmRuntimeInfo.majorVersion >= 18) {
+                            cliArg("--mac-dmg-content", macDmgContents)
+                        } else {
+                            logger.warn("Option --mac-dmg-content is only supported from jdk 18")
+                        }
                     }
                 }
             }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -134,6 +134,10 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
+    val linuxPackageDeps: Property<String?> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
     val linuxPackageName: Property<String?> = objects.nullableProperty()
 
     @get:Input
@@ -446,6 +450,7 @@ abstract class AbstractJPackageTask @Inject constructor(
             when (currentOS) {
                 OS.Linux -> {
                     cliArg("--linux-shortcut", linuxShortcut)
+                    cliArg("--linux-package-deps", linuxPackageDeps)
                     cliArg("--linux-package-name", linuxPackageName)
                     cliArg("--linux-app-release", linuxAppRelease)
                     cliArg("--linux-app-category", linuxAppCategory)


### PR DESCRIPTION
Describe proposed changes and the issue being fixed

Adds additional jpackage options, introduced in jdk 17 and 21:

- --win-shortcut-prompt (from jdk 17)
- --win-update-url (from jdk 17)
- --linux-package-deps (from jdk 17) - (although I am unsure how to use that option, naming suggests an argument but there is no argument documented)
- --mac-dmg-content (from jdk 21)

<!-- Optional -->
Fixes 
- https://youtrack.jetbrains.com/issue/CMP-7580
- https://youtrack.jetbrains.com/issue/CMP-2236

## Testing
<!-- Optional -->
Describe how you tested your changes. If possible and needed:
- Test it on a sample project
- Write unit tests
- Provide a code snippet

<!-- Optional -->
This should be tested by QA

## Release Notes
### Features - Desktop
- Native distribution: added `jpackage` options `--win-shortcut-prompt`, `--win-update-url`, `--linux-package-deps` and `--mac-dmg-content`
