### PR TITLE
Update changelog.main.kts, if (token == null) check

### DIFF
--- a/tools/changelog.main.kts
+++ b/tools/changelog.main.kts
@@ -88,7 +88,7 @@ val argsKeyToValue = args
     .associate { it.substringBefore("=") to it.substringAfter("=") }
 
 val token = argsKeyToValue["token"]
-if (token != null) {
+if (token == null) {
     println("To increase the rate limit, specify token (https://github.com/settings/tokens), adding token=yourtoken in the end")
 }
 


### PR DESCRIPTION
There was a mistake in the previous PR. The warning should be printed only if the token is omitted

# Release Notes
N/A
