### PR TITLE
Update workflow dependencies

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-14, windows-2022]
         gradle: [7.4, 8.10.2]
         agp: [8.1.0, 8.5.0, 8.8.0-alpha08]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
           java-version: '17'
@@ -33,9 +33,9 @@ jobs:
           ./gradlew assemble
           ./gradlew --continue :preview-rpc:test :compose:test ':compose:test-Gradle(${{ matrix.gradle }})-Agp(${{ matrix.agp }})'
       - name: Upload Reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: Test-Reports
+          name: Test-Reports-${{ matrix.os }}-Gradle-${{ matrix.gradle }}-Agp${{ matrix.agp }}
           path: gradle-plugins/compose/build/reports
         if: always()
       - name: Print summary


### PR DESCRIPTION
Due to https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/.
I made the following changes:
`ubuntu-20.04` -> `ubuntu-24.04`
`actions/checkout@v3` -> `actions/checkout@v4`
`actions/setup-java@v3` -> `actions/setup-java@v4`
`actions/upload-artifact@v3` -> `actions/upload-artifact@v4`