### PR TITLE
Expose APIs for working with resource environment

### DIFF
--- a/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/ImagesRes.kt
+++ b/components/resources/demo/shared/src/commonMain/kotlin/org/jetbrains/compose/resources/demo/shared/ImagesRes.kt
@@ -1,23 +1,54 @@
 package org.jetbrains.compose.resources.demo.shared
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import components.resources.demo.shared.generated.resources.Res
-import components.resources.demo.shared.generated.resources.*
-import org.jetbrains.compose.resources.DrawableResource
+import components.resources.demo.shared.generated.resources.compose
+import components.resources.demo.shared.generated.resources.droid_icon
+import components.resources.demo.shared.generated.resources.insta_icon
+import components.resources.demo.shared.generated.resources.land
+import org.jetbrains.compose.resources.ComposeEnvironment
+import org.jetbrains.compose.resources.DefaultComposeEnvironment
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.LocalComposeEnvironment
+import org.jetbrains.compose.resources.ResourceEnvironment
+import org.jetbrains.compose.resources.ThemeQualifier
 import org.jetbrains.compose.resources.imageResource
-import org.jetbrains.compose.resources.vectorResource
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.vectorResource
 
+@OptIn(ExperimentalResourceApi::class)
+private val InvertedThemeComposeEnvironment = object : ComposeEnvironment {
+    @Composable
+    override fun rememberEnvironment(): ResourceEnvironment {
+        val defaultEnvironment = DefaultComposeEnvironment.rememberEnvironment()
+        return remember(defaultEnvironment) {
+            val invertedTheme = when (defaultEnvironment.theme) {
+                ThemeQualifier.LIGHT -> ThemeQualifier.DARK
+                ThemeQualifier.DARK -> ThemeQualifier.LIGHT
+            }
+
+            defaultEnvironment.copy(theme = invertedTheme)
+        }
+    }
+}
+
+@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun ImagesRes(contentPadding: PaddingValues) {
     Column(
@@ -34,6 +65,32 @@ fun ImagesRes(contentPadding: PaddingValues) {
                     painter = painterResource(Res.drawable.compose),
                     contentDescription = null
                 )
+                Text(
+                    """
+                        Image(
+                          painter = painterResource(Res.drawable.compose)
+                        )
+                    """.trimIndent()
+                )
+            }
+        }
+        OutlinedCard(modifier = Modifier.padding(8.dp)) {
+            Column(
+                modifier = Modifier.padding(16.dp).fillMaxWidth().fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("Inverted ThemeQualifier")
+
+                CompositionLocalProvider(
+                    value = LocalComposeEnvironment provides InvertedThemeComposeEnvironment
+                ) {
+                    Image(
+                        modifier = Modifier.size(100.dp),
+                        painter = painterResource(Res.drawable.compose),
+                        contentDescription = null
+                    )
+                }
+
                 Text(
                     """
                         Image(

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/Qualifier.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/Qualifier.kt
@@ -2,7 +2,7 @@ package org.jetbrains.compose.resources
 
 interface Qualifier
 
-@InternalResourceApi
+@ExperimentalResourceApi
 class LanguageQualifier(
     val language: String
 ) : Qualifier {
@@ -24,7 +24,7 @@ class LanguageQualifier(
     }
 }
 
-@InternalResourceApi
+@ExperimentalResourceApi
 class RegionQualifier(
     val region: String
 ) : Qualifier {
@@ -46,7 +46,7 @@ class RegionQualifier(
     }
 }
 
-@InternalResourceApi
+@ExperimentalResourceApi
 enum class ThemeQualifier : Qualifier {
     LIGHT,
     DARK;
@@ -58,7 +58,7 @@ enum class ThemeQualifier : Qualifier {
 }
 
 //https://developer.android.com/guide/topics/resources/providing-resources
-@InternalResourceApi
+@ExperimentalResourceApi
 enum class DensityQualifier(val dpi: Int) : Qualifier {
     LDPI(120),
     MDPI(160),

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.kt
@@ -6,41 +6,21 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.intl.Locale
 
 @ExperimentalResourceApi
-class ResourceEnvironment internal constructor(
-    internal val language: LanguageQualifier,
-    internal val region: RegionQualifier,
-    internal val theme: ThemeQualifier,
-    internal val density: DensityQualifier
-) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
+data class ResourceEnvironment(
+    val language: LanguageQualifier,
+    val region: RegionQualifier,
+    val theme: ThemeQualifier,
+    val density: DensityQualifier
+)
 
-        other as ResourceEnvironment
-
-        if (language != other.language) return false
-        if (region != other.region) return false
-        if (theme != other.theme) return false
-        if (density != other.density) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = language.hashCode()
-        result = 31 * result + region.hashCode()
-        result = 31 * result + theme.hashCode()
-        result = 31 * result + density.hashCode()
-        return result
-    }
-}
-
-internal interface ComposeEnvironment {
+@ExperimentalResourceApi
+interface ComposeEnvironment {
     @Composable
     fun rememberEnvironment(): ResourceEnvironment
 }
 
-internal val DefaultComposeEnvironment = object : ComposeEnvironment {
+@ExperimentalResourceApi
+val DefaultComposeEnvironment = object : ComposeEnvironment {
     @Composable
     override fun rememberEnvironment(): ResourceEnvironment {
         val composeLocale = Locale.current
@@ -60,7 +40,8 @@ internal val DefaultComposeEnvironment = object : ComposeEnvironment {
 }
 
 //ComposeEnvironment provider will be overridden for tests
-internal val LocalComposeEnvironment = staticCompositionLocalOf { DefaultComposeEnvironment }
+@ExperimentalResourceApi
+val LocalComposeEnvironment = staticCompositionLocalOf { DefaultComposeEnvironment }
 
 /**
  * Returns an instance of [ResourceEnvironment].

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GeneratedResClassSpec.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GeneratedResClassSpec.kt
@@ -249,6 +249,7 @@ private fun getChunkFileSpec(
         chunkFile.addAnnotation(
             AnnotationSpec.builder(ClassName("kotlin", "OptIn"))
                 .addMember("org.jetbrains.compose.resources.InternalResourceApi::class")
+                .addMember("org.jetbrains.compose.resources.ExperimentalResourceApi::class")
                 .build()
         )
 
@@ -355,6 +356,7 @@ internal fun getActualResourceCollectorsFileSpec(
     file.addAnnotation(
         AnnotationSpec.builder(ClassName("kotlin", "OptIn"))
             .addMember("org.jetbrains.compose.resources.InternalResourceApi::class")
+            .addMember("org.jetbrains.compose.resources.ExperimentalResourceApi::class")
             .build()
     )
 


### PR DESCRIPTION
Expose APIs for working with resources environment for more control in the following cases:
1. Load localized strings inside iOS extension targets (e.g. Notification Extension):
`NSLocal` always returns default system language, even if we override `"AppLanguages"` in `NSUserDefaults.standardUserDefaults`. Passing a custom `ResourceEnvironment` to `getString` with the preferred locale fixes the issue.
2. Use a custom `ResourceEnvironment` to display a preview when customizing the App theme, without changing the configuration for the entire app. We can achieve this using `LocalComposeEnvironment`.
3. Use a custom `ResourceEnvironment` in dark-only screens, such as video players, or image editors. We can achieve this using `LocalComposeEnvironment`.
4. Use `copy` to change specific environment properties, and keep the rest as system default.

## Testing
- Changes were tested in the sample project (Code snippets are included in the PR).
- unit tests for this case already exist. They run successfully. Changes are unnecessary.
