### PR TITLE
Update Release Notes categories

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,10 +20,10 @@ If we definitely shouldn't add Release Notes, add only N/A.
 Or enumerate sections, subsections and all changes.
 
 Possible sections:
-- Highlights             // new major features that need to be highlighted
-- Known Issues           // issues that has workaround and will be fixed
+- Highlights             // major features
+- Known Issues           // issues planned to be fixed, with possible workarounds
 - Migration Notes        // deprecations, experimental removals, minimal versions increases, behavior changes, compatibility breaking changes
-- Features               // new minor features. new API, behavior improvements
+- Features               // minor features
 - Fixes                  // bug fixes
 
 Possible subsections:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,14 +28,14 @@ Possible sections:
 
 Possible subsections:
 - Multiple Platforms     // any module, 2 or more platform changes
-- iOS                    // any module, iOS only changes
-- Desktop                // any module, Desktop only changes
-- Web                    // any module, Web only changes
-- Android                // any module, Android only changes
-- Resources              // specific module, prefer using instead of the general ones
-- Gradle Plugin          // specific module, prefer using instead of the general ones
-- Lifecycle              // specific module, prefer using instead of the general ones
-- Navigation             // specific module, prefer using instead of the general ones
+- iOS                    // any module, iOS-only changes
+- Desktop                // any module, Desktop-only changes
+- Web                    // any module, Web-only changes
+- Android                // any module, Android-only changes
+- Resources              // specific module, prefer using instead of the platform one
+- Gradle Plugin          // specific module, prefer using instead of the platform one
+- Lifecycle              // specific module, prefer using instead of the platform one
+- Navigation             // specific module, prefer using instead of the platform one
 -->
 ### Section - Subsection
 - Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ Or enumerate sections, subsections and all changes.
 
 Possible sections:
 - Highlights             // new major features that need to be highlighted
-- Known Issues           // issues in the current release that has workaround or/and will be fixed
+- Known Issues           // issues that has workaround and will be fixed
 - Migration Notes        // deprecations, experimental removals, minimal versions increases, behavior changes, backward compatibility breaking changes
 - Features               // new minor features. new API, behavior improvements
 - Fixes                  // bug fixes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,19 +27,19 @@ Possible sections:
 - Fixes                  // bug fixes
 
 Possible subsections:
-- Multiple Platforms     // Compose only
-- iOS                    // Compose only
-- Desktop                // Compose only
-- Web                    // Compose only
-- Android                // Compose only
-- Resources
-- Gradle Plugin
-- Lifecycle
-- Navigation
+- Multiple Platforms     // any module, 2 or more platform changes
+- iOS                    // any module, iOS only changes
+- Desktop                // any module, Desktop only changes
+- Web                    // any module, Web only changes
+- Android                // any module, Android only changes
+- Resources              // specific module, prefer using instead of the general ones
+- Gradle Plugin          // specific module, prefer using instead of the general ones
+- Lifecycle              // specific module, prefer using instead of the general ones
+- Navigation             // specific module, prefer using instead of the general ones
 -->
 ### Section - Subsection
 - Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md
-- _(prerelease fix)_ Fix some bug that introduced in a prerelease version (dev/beta). It will be included in a dev/beta changelog, but excluded from a stable changelog
+- _(prerelease fix)_ Fix some bug that introduced in a prerelease version (alpha/beta). It will be included in a dev/beta changelog, but excluded from a stable changelog
 
 ### Section - Subsection
 - Describe another change if needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,7 +39,7 @@ Possible subsections:
 -->
 ### Section - Subsection
 - Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md
-- _(prerelease fix)_ Fix some bug that introduced in a prerelease version (alpha/beta). It will be included in a dev/beta changelog, but excluded from a stable changelog
+- _(prerelease fix)_ Fix some bug that introduced in a prerelease version (alpha/beta). It will be included in a alpha/beta changelog, but excluded from a stable changelog
 
 ### Section - Subsection
 - Describe another change if needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Or enumerate sections, subsections and all changes.
 Possible sections:
 - Highlights             // new major features that need to be highlighted
 - Known Issues           // issues that has workaround and will be fixed
-- Migration Notes        // deprecations, experimental removals, minimal versions increases, behavior changes, backward compatibility breaking changes
+- Migration Notes        // deprecations, experimental removals, minimal versions increases, behavior changes, compatibility breaking changes
 - Features               // new minor features. new API, behavior improvements
 - Fixes                  // bug fixes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,20 +20,22 @@ If we definitely shouldn't add Release Notes, add only N/A.
 Or enumerate sections, subsections and all changes.
 
 Possible sections:
-- Highlights
-- Known Issues
-- Breaking Changes
-- Features
-- Fixes
+- Highlights             // new major features that need to be highlighted
+- Known Issues           // issues in the current release that has workaround or/and will be fixed
+- Migration Notes        // deprecations, experimental removals, minimal versions increases, behavior changes, backward compatibility breaking changes
+- Features               // new minor features. new API, behavior improvements
+- Fixes                  // bug fixes
 
 Possible subsections:
-- Multiple Platforms
-- iOS
-- Desktop
-- Web
-- Android
+- Multiple Platforms     // Compose only
+- iOS                    // Compose only
+- Desktop                // Compose only
+- Web                    // Compose only
+- Android                // Compose only
 - Resources
 - Gradle Plugin
+- Lifecycle
+- Navigation
 -->
 ### Section - Subsection
 - Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Or enumerate sections, subsections and all changes.
 Possible sections:
 - Highlights             // major features
 - Known Issues           // issues planned to be fixed, with possible workarounds
-- Migration Notes        // deprecations, experimental removals, minimal versions increases, behavior changes, compatibility breaking changes
+- Migration Notes        // deprecations, removals, compatibility changes
 - Features               // minor features
 - Fixes                  // bug fixes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,9 +22,10 @@ Or enumerate sections, subsections and all changes.
 Possible sections:
 - Highlights             // major features
 - Known Issues           // issues planned to be fixed, with possible workarounds
-- Migration Notes        // deprecations, removals, minimal version increases, compatibility changes
+- Breaking Changes       // incompatible changes without deprecation cycle
+- Migration Notes        // deprecations, removals, minimal version increases, defined behavior changes
 - Features               // minor features
-- Fixes                  // bug fixes
+- Fixes                  // bug fixes, undefined behavior changes
 
 Possible subsections:
 - Multiple Platforms     // any module, 2 or more platform changes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,10 +32,10 @@ Possible subsections:
 - Desktop                // any module, Desktop-only changes
 - Web                    // any module, Web-only changes
 - Android                // any module, Android-only changes
-- Resources              // specific module, prefer using instead of the platform one
-- Gradle Plugin          // specific module, prefer using instead of the platform one
-- Lifecycle              // specific module, prefer using instead of the platform one
-- Navigation             // specific module, prefer using instead of the platform one
+- Resources              // specific module, prefer it over the platform ones
+- Gradle Plugin          // specific module, prefer it over the platform ones
+- Lifecycle              // specific module, prefer it over the platform ones
+- Navigation             // specific module, prefer it over the platform ones
 -->
 ### Section - Subsection
 - Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,7 +39,7 @@ Possible subsections:
 -->
 ### Section - Subsection
 - Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md
-- _(prerelease fix)_ Fix some bug that introduced in a prerelease version (alpha/beta). It will be included in a alpha/beta changelog, but excluded from a stable changelog
+- _(prerelease fix)_ Fix some bug that introduced in a prerelease version (alpha/beta/rc). It will be included in a alpha/beta/rc changelog, but excluded from a stable changelog
 
 ### Section - Subsection
 - Describe another change if needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Or enumerate sections, subsections and all changes.
 Possible sections:
 - Highlights             // major features
 - Known Issues           // issues planned to be fixed, with possible workarounds
-- Migration Notes        // deprecations, removals, compatibility changes
+- Migration Notes        // deprecations, removals, minimal version increases, compatibility changes
 - Features               // minor features
 - Fixes                  // bug fixes
 

--- a/tools/changelog.main.kts
+++ b/tools/changelog.main.kts
@@ -59,6 +59,7 @@ import kotlin.system.exitProcess
 val standardSections = listOf(
     "Highlights",
     "Known Issues",
+    "Breaking Changes",
     "Migration Notes",
     "Features",
     "Fixes",

--- a/tools/changelog.main.kts
+++ b/tools/changelog.main.kts
@@ -59,7 +59,7 @@ import kotlin.system.exitProcess
 val standardSections = listOf(
     "Highlights",
     "Known Issues",
-    "Breaking Changes",
+    "Migration Notes",
     "Features",
     "Fixes",
 )


### PR DESCRIPTION
- Rename `Breaking Changes` to `Migration Notes`
- Add Lifecycle/Navigation. We used them in [CHANGELOG.md](https://github.com/JetBrains/compose-multiplatform/blob/release/1.8.0-alpha03/CHANGELOG.md), and have it in the script, but didn't have in the template
- Describe each category
- Use platform categories as general ones. It contradicts with my comments [here](https://github.com/JetBrains/compose-multiplatform/pull/5231#discussion_r1953385844) and [here](https://github.com/JetBrains/compose-multiplatform-core/pull/1844#discussion_r1958445125), that it was only Compose related. But after thinking, we need some category for changes that don't fall under Compose or any other existing one. We can use platform categories (probably only Compose and some Compose components fall into this category right now)

## Release Notes
N/A