### PR TITLE
[IDEA plugin] Override project name to avoid conflicts with other plugins

### DIFF
--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -42,6 +42,7 @@ intellijPlatform {
     }
     buildSearchableOptions = false
     autoReload = false
+    projectName = "compose-multiplatform-plugin"
 
     publishing {
         token = System.getenv("IDE_PLUGIN_PUBLISH_TOKEN")


### PR DESCRIPTION
Support issue: https://platform.jetbrains.com/t/impossible-to-install-both-valkyrie-plugin-and-compose-multiplatform-ide-support-plugin/731

Original issue reproduces with Valkyrie plugin and Compose plugin 1.7.3: https://github.com/ComposeGears/Valkyrie/issues/361
Fix: https://github.com/ComposeGears/Valkyrie/pull/370

plugin folder name before:
<img width="372" alt="Screenshot 2025-02-28 at 23 20 40" src="https://github.com/user-attachments/assets/11d12f13-2d8d-494f-881d-cd271776b797" />

plugin folder name after:
<img width="383" alt="Screenshot 2025-02-28 at 23 32 13" src="https://github.com/user-attachments/assets/415ca090-ee66-47c6-be61-2c1e856d102b" />



