### PR TITLE
Check Release Notes GitHub workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,33 +14,4 @@ Describe how you tested your changes. If possible and needed:
 This should be tested by QA
 
 ## Release Notes
-<!--
-If we definitely shouldn't add Release Notes, add only N/A.
-
-Or enumerate sections, subsections and all changes.
-
-Possible sections:
-- Highlights             // major features
-- Known Issues           // issues planned to be fixed, with possible workarounds
-- Breaking Changes       // incompatible changes without deprecation cycle
-- Migration Notes        // deprecations, removals, minimal version increases, defined behavior changes
-- Features               // minor features
-- Fixes                  // bug fixes, undefined behavior changes
-
-Possible subsections:
-- Multiple Platforms     // any module, 2 or more platform changes
-- iOS                    // any module, iOS-only changes
-- Desktop                // any module, Desktop-only changes
-- Web                    // any module, Web-only changes
-- Android                // any module, Android-only changes
-- Resources              // specific module, prefer it over the platform ones
-- Gradle Plugin          // specific module, prefer it over the platform ones
-- Lifecycle              // specific module, prefer it over the platform ones
-- Navigation             // specific module, prefer it over the platform ones
--->
-### Section - Subsection
-- Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md
-- _(prerelease fix)_ Fix some bug that introduced in a prerelease version (alpha/beta/rc). It will be included in a alpha/beta/rc changelog, but excluded from a stable changelog
-
-### Section - Subsection
-- Describe another change if needed
+See the format in https://github.com/JetBrains/compose-multiplatform/blob/master/tools/changelog/PR_FORMAT.md

--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -1,0 +1,21 @@
+# Checks Release Notes in the PR description, runs when:
+#   opened - PR is opened
+#   edited - The title/description are changed
+#   synchronize - New commits appeared.
+#                 We don't use the new content, but we still need to mark this commit Green/Red in GitHub UI
+
+name: Check Release Notes in the description
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: 'tools/changelog/check-release-notes-github-action'
+      - uses: ./tools/changelog/check-release-notes-github-action
+        with:
+          checkout_ref: ${{ github.ref }}

--- a/tools/changelog/PR_FORMAT.md
+++ b/tools/changelog/PR_FORMAT.md
@@ -1,0 +1,75 @@
+Each Pull Request should contain "## Release Notes" section that describes changes in this PR.
+
+Each release, changes from all PRs are combined into a list and added to CHANGELOG.md
+(by [changelog.main.kts](changelog.main.kts) script).
+
+## Possible Release Notes
+
+### No Release Notes
+```
+## Release Notes
+N/A
+```
+
+### Simple Change
+```
+## Release Notes
+### Highlights - iOS
+- Describe a change
+```
+
+### Simple Change with Details
+```
+## Release Notes
+### Highlights - iOS
+- Describe a change
+  - Describe details 1
+  - Describe details 2
+```
+
+### Multiple Changes
+```
+## Release Notes
+### Features - Desktop
+- Describe change 1
+  - Describe details
+- Describe change 2
+
+### Fixes - Web
+- Describe change 3
+```
+
+### Prerelease Fix
+Will be includede in alpha/beta/rc changelog, excluded from stable.
+```
+## Release Notes
+### Fixes - Multiple Platforms
+- _(prerelease fix)_ Fixed CPU overheating on pressing Shift appeared in 1.8.0-alpha02
+```
+
+## Possible Sections
+
+### Sections
+<!-- This is parsed by changelog.main.kts -->
+```
+- Highlights             # major features
+- Known Issues           # issues planned to be fixed, with possible workarounds
+- Breaking Changes       # incompatible changes without deprecation cycle
+- Migration Notes        # deprecations, removals, minimal version increases, defined behavior changes
+- Features               # minor features
+- Fixes                  # bug fixes, undefined behavior changes
+```
+
+### Subsections
+<!-- This is parsed by changelog.main.kts -->
+```
+- Multiple Platforms     # any module, 2 or more platform changes
+- iOS                    # any module, iOS-only changes
+- Desktop                # any module, Desktop-only changes
+- Web                    # any module, Web-only changes
+- Android                # any module, Android-only changes
+- Resources              # specific module, prefer it over the platform ones
+- Gradle Plugin          # specific module, prefer it over the platform ones
+- Lifecycle              # specific module, prefer it over the platform ones
+- Navigation             # specific module, prefer it over the platform ones
+```

--- a/tools/changelog/check-release-notes-github-action/action.yml
+++ b/tools/changelog/check-release-notes-github-action/action.yml
@@ -1,0 +1,26 @@
+# Reusable GitHub action needed to check Release Notes in the PR description. Used by multiple Compose repositories.
+
+name: Check Release Notes in the description
+
+inputs:
+  checkout_ref:
+    type: string
+    default: 'master'
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: JetBrains/compose-multiplatform
+        ref: ${{ inputs.checkout_ref }}
+        sparse-checkout: 'tools/changelog'
+    - name: Check Release Notes in the description
+      shell: bash
+      env:
+        # To avoid injections as suggested in https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        PR_DESCRIPTION: ${{ github.event.pull_request.body }}
+      run: |
+        cd tools/changelog
+        echo "$PR_DESCRIPTION" > prDescription.txt
+        kotlin changelog.main.kts action=checkPr prDescription.txt token=""


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7409/Add-a-CI-check-for-PR-containing-Release-Notes

- Add a GitHub workflow that checks Release Notes are correctly added. Runs automatically on creation and description change
- Move the guide into one file from the PR templates
- Parse categories for the script instead of hardcoding them (to have a single source of truth in the guide)
- Don't do network requests to avoid rate limit (60 requests per hour), read the description from the workflow variable

Also added to [compose-multiplatform-core](https://github.com/JetBrains/compose-multiplatform-core/pull/1900)

## Testing
1. Change Release Notes in this PR
2. CI successes with correct Release Notes
3. CI fails with incorrect ones

(Replace RR by R, otherwise the check picks a wrong section, I think no need to write additional logic just for this PR)


Correct N/A:
```
## RRelease Notes
N/A
```
Correct change:
```
## RRelease Notes
### Features - iOS
- Simple feature
```
Release notes missing:
```

```
Title is incorrect:
```
## RRelease Note
### Features - iOS
- Simple feature
```
Section isn't standard:
```
## RRelease Notes
### Features - Compose
- Simple feature
```
Items are missing:
```
## RRelease Notes
### Features - iOS
```
Sections are missing:
```
## RRelease Notes
- Simple feature
```

## Testing
Tested for injections
1. For script injection
```
"; echo QQ > prDescription.txt #
```

2. For workflow injection
```
q
      run: |
        echo "QQ"
```

3. Verified that injection into `changelog.main.kts` isn't possible, as it doesn't execute anything parsed (including links)

## Release Notes
N/A