### PR TITLE
Fix 

### DIFF
--- a/ci/build-helpers/buildSrc/build.gradle.kts
+++ b/ci/build-helpers/buildSrc/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     val jacksonVersion = "2.12.5"
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
-    implementation("io.ktor:ktor-client-okhttp:1.6.4")
+    implementation("io.ktor:ktor-client-okhttp:2.3.13")
     implementation("org.apache.tika:tika-parsers:1.24.1")
     implementation("org.jsoup:jsoup:1.14.3")
     implementation("org.jetbrains:space-sdk-jvm:2024.3-185883")


### PR DESCRIPTION
Fix NoClassDefFoundError HttpTimeout
```
Caused by: java.lang.NoClassDefFoundError: io/ktor/client/features/HttpTimeout
```
When run:
```
gradlew reuploadArtifactsToMavenCentral --info --stacktrace -Pmaven.central.sign=false -Pmaven.central.coordinates=org.jetbrains.compose.ui -Pmaven.central.stage=org.jetbrains.compose
```

By upgrading ktor, as Ktor 1 and Ktor 2 aren't backward compatible.

2 versions were used:

```
gradlew buildSrc:dependencyInsight --configuration compileClasspath --dependency ktor-client-core
```

```
io.ktor:ktor-client-core-jvm:2.3.13
\--- io.ktor:ktor-client-core:2.3.13
     +--- io.ktor:ktor-client-okhttp:1.6.4 (requested io.ktor:ktor-client-core:1.6.4)
     |    \--- compileClasspath
     \--- org.jetbrains:space-sdk-jvm:2024.3-185883
          \--- compileClasspath
```

## Release Notes
N/A