### PR TITLE
Simplify PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Describe proposed changes and the issue being fixed
 (Optional) This should be tested by QA
 
 ## Release Notes
-### Section - subsection
+### Section - Subsection
 - Describe change in format https://github.com/JetBrains/compose-multiplatform/blob/master/tools/changelog/PR_FORMAT.md
   - Sections: Highlights, Known Issues, Breaking Changes, Migration Notes, Features, Fixes
   - Subsections: Multiple Platforms, iOS, Desktop, Web, Android, Resources, Gradle Plugin, Lifecycle, Navigation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,15 @@
 Describe proposed changes and the issue being fixed
 
-<!-- Optional -->
-Fixes [link to the issue]
+(Optional) Fixes [link to the issue]
 
 ## Testing
-<!-- Optional -->
-Describe how you tested your changes. If possible and needed:
-- Test it on a sample project
-- Write unit tests
-- Provide a code snippet
+(Optional) Describe how you tested your changes (provide a snippet or/and steps)
 
-<!-- Optional -->
-This should be tested by QA
+(Optional) This should be tested by QA
 
 ## Release Notes
-See the format in https://github.com/JetBrains/compose-multiplatform/blob/master/tools/changelog/PR_FORMAT.md
+### Section - subsection
+- Describe change in format https://github.com/JetBrains/compose-multiplatform/blob/master/tools/changelog/PR_FORMAT.md
+  - Sections: Highlights, Known Issues, Breaking Changes, Migration Notes, Features, Fixes
+  - Subsections: Multiple Platforms, iOS, Desktop, Web, Android, Resources, Gradle Plugin, Lifecycle, Navigation
+  - 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,3 @@ Describe proposed changes and the issue being fixed
 - Describe change in format https://github.com/JetBrains/compose-multiplatform/blob/master/tools/changelog/PR_FORMAT.md
   - Sections: Highlights, Known Issues, Breaking Changes, Migration Notes, Features, Fixes
   - Subsections: Multiple Platforms, iOS, Desktop, Web, Android, Resources, Gradle Plugin, Lifecycle, Navigation
-  - 

--- a/tools/changelog/PR_FORMAT.md
+++ b/tools/changelog/PR_FORMAT.md
@@ -48,9 +48,13 @@ Will be includede in alpha/beta/rc changelog, excluded from stable.
 ```
 
 ## Possible Sections
-
+<!-- 
+When change this, please keep in mind that it is parsed by [changelog.main.kts], and the PR templates should be updated too:
+https://github.com/JetBrains/compose-multiplatform/edit/jb-main/.github/PULL_REQUEST_TEMPLATE.md
+https://github.com/JetBrains/compose-multiplatform-core/edit/jb-main/.github/PULL_REQUEST_TEMPLATE.md
+-->
+ 
 ### Sections
-<!-- This is parsed by changelog.main.kts -->
 ```
 - Highlights             # major features, performance improvements
 - Known Issues           # issues planned to be fixed, with possible workarounds
@@ -61,7 +65,6 @@ Will be includede in alpha/beta/rc changelog, excluded from stable.
 ```
 
 ### Subsections
-<!-- This is parsed by changelog.main.kts -->
 ```
 - Multiple Platforms     # any module, 2 or more platform changes
 - iOS                    # any module, iOS-only changes

--- a/tools/changelog/PR_FORMAT.md
+++ b/tools/changelog/PR_FORMAT.md
@@ -49,7 +49,8 @@ Will be includede in alpha/beta/rc changelog, excluded from stable.
 
 ## Possible Sections
 <!-- 
-When change this, please keep in mind that it is parsed by [changelog.main.kts], and the PR templates should be updated too:
+- Note that this is parsed by [changelog.main.kts]
+- Update the PR templates after changing the sections:
 https://github.com/JetBrains/compose-multiplatform/edit/jb-main/.github/PULL_REQUEST_TEMPLATE.md
 https://github.com/JetBrains/compose-multiplatform-core/edit/jb-main/.github/PULL_REQUEST_TEMPLATE.md
 -->

--- a/tools/changelog/changelog.main.kts
+++ b/tools/changelog/changelog.main.kts
@@ -261,7 +261,7 @@ fun checkPr() {
     when {
         releaseNotes is ReleaseNotes.Specified && releaseNotes.entries.isEmpty() -> {
             err.println("""
-                "## Release Notes" doesn't contain any items, or section isn't specified
+                "## Release Notes" doesn't contain any items, or "### Section - Subsection" isn't specified
             
                 See the format in $prFormatLink
             """.trimIndent())
@@ -269,7 +269,7 @@ fun checkPr() {
         }
         releaseNotes is ReleaseNotes.Specified && nonstandardSections.isNotEmpty() -> {
             err.println("""
-                "## Release Notes" contains nonstandard section - subsection pairs:
+                "## Release Notes" contains nonstandard "Section - Subsection" pairs:
                 ${nonstandardSections.joinToString(", ")}
             
                 Allowed sections: ${standardSections.joinToString(", ")}

--- a/tools/changelog/changelog.main.kts
+++ b/tools/changelog/changelog.main.kts
@@ -269,7 +269,7 @@ fun checkPr() {
         }
         releaseNotes is ReleaseNotes.Specified && nonstandardSections.isNotEmpty() -> {
             err.println("""
-                "## Release Notes" contains nonstandard sections:
+                "## Release Notes" contains nonstandard section - subsection pairs:
                 ${nonstandardSections.joinToString(", ")}
             
                 Allowed sections: ${standardSections.joinToString(", ")}

--- a/tools/changelog/changelog.main.kts
+++ b/tools/changelog/changelog.main.kts
@@ -260,22 +260,31 @@ fun checkPr() {
 
     when {
         releaseNotes is ReleaseNotes.Specified && releaseNotes.entries.isEmpty() -> {
-            err.println("\"## Release Notes\" doesn't contain any items, or section isn't specified")
-            err.println()
-            err.println("See the format in $prFormatLink")
+            err.println("""
+                "## Release Notes" doesn't contain any items, or section isn't specified
+            
+                See the format in $prFormatLink
+            """.trimIndent())
             exitProcess(1)
         }
         releaseNotes is ReleaseNotes.Specified && nonstandardSections.isNotEmpty() -> {
-            err.println("\"## Release Notes\" contains nonstandard sections:")
-            err.println(nonstandardSections.joinToString(", "))
-            err.println()
-            err.println("See possible sections in $prFormatLink#possible-sections")
+            err.println("""
+                "## Release Notes" contains nonstandard sections:
+                ${nonstandardSections.joinToString(", ")}
+            
+                Allowed sections: ${standardSections.joinToString(", ")}
+                Allowed subsections: ${standardSubsections.joinToString(", ")}
+            
+                See the full format in $prFormatLink
+            """.trimIndent())
             exitProcess(1)
         }
         releaseNotes == null -> {
-            err.println("\"## Release Notes\" section is missing in the PR description")
-            err.println()
-            err.println("See the format in $prFormatLink")
+            err.println("""
+                "## Release Notes" section is missing in the PR description
+            
+                See the format in $prFormatLink
+            """.trimIndent())
             exitProcess(1)
         }
         else -> {


### PR DESCRIPTION
- Add sections. It is easier to copy them.  They aren't the source of truth here, but should be duplicated from [PR_FORMAT.md](https://github.com/JetBrains/compose-multiplatform/blob/master/tools/changelog/PR_FORMAT.md#possible-sections)
- Reduce vertical height of the template (to debloat it)

## Testing
The new script changes are tested by changing this PR description

## Release Notes
N/A