### PR TITLE
Maven Project. Fail on warnings

### DIFF
--- a/ci/templates/maven-test-project/README.md
+++ b/ci/templates/maven-test-project/README.md
@@ -1,5 +1,5 @@
 The purpose of this test project is to check if Compose Multiplatform is resolvable via pom files, which are used by JPS, which is used by IntelliJ
 
 ```
-mvn install exec:java -Dexec.mainClass="MainKt" -Dkotlin.version=2.1.0 -Dcompose.version=1.8.0-alpha02
+./check.sh -Dkotlin.version=2.1.0 -Dcompose.version=1.8.0-alpha02
 ```

--- a/ci/templates/maven-test-project/check.sh
+++ b/ci/templates/maven-test-project/check.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# For failing on warnings like
+# [WARNING] The POM for org.jetbrains.kotlin:kotlin-stdlib:jar:unspecified is missing, no dependency information available
+# There is no a flag in Maven to fail on warnings in dependency resolution
+
+set -o pipefail
+
+tempfile=$(mktemp)
+
+# Pipe output to the file and terminal
+if ! mvn clean install exec:java -Dexec.mainClass="MainKt" "$@" | tee "$tempfile"; then
+    exit 1
+fi
+
+if grep -q "\[WARNING\]" "$tempfile"; then
+    echo "[ERROR] Warnings found"
+    exit 1
+fi

--- a/ci/templates/maven-test-project/check.sh
+++ b/ci/templates/maven-test-project/check.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# For failing on warnings like
-# [WARNING] The POM for org.jetbrains.kotlin:kotlin-stdlib:jar:unspecified is missing, no dependency information available
-# There is no a flag in Maven to fail on warnings in dependency resolution
-
 set -o pipefail
 
 tempfile=$(mktemp)
@@ -12,6 +8,11 @@ tempfile=$(mktemp)
 if ! mvn clean install exec:java -Dexec.mainClass="MainKt" "$@" | tee "$tempfile"; then
     exit 1
 fi
+
+# For failing on warnings like
+#   [WARNING] The POM for org.jetbrains.kotlin:kotlin-stdlib:jar:unspecified is missing, no dependency information available
+#
+# There is no a flag in Maven to fail on warnings in dependency resolution
 
 if grep -q "\[WARNING\]" "$tempfile"; then
     echo "[ERROR] Warnings found"


### PR DESCRIPTION
A script for extended CI check to not miss issues like https://youtrack.jetbrains.com/issue/CMP-7738/Compose-fails-to-sync-in-Bazel

## Testing
```
./gradlew publishComposeJbToMavenLocal
```
```
./check.sh -Dkotlin.version=2.1.0 -Dcompose.version=9999.0.0-SNAPSHOT
```
doesn't fail on the latest jb-main, fails on 1.8.0-alpha04

## Release Notes
N/A