### PR TITLE
Fix ProGuard rules for material3

### DIFF
--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -37,7 +37,6 @@
 -dontwarn kotlinx.serialization.Serializable
 -dontwarn kotlinx.datetime.serializers.**
 
-
 # https://github.com/Kotlin/kotlinx.coroutines/issues/2046
 -dontwarn android.annotation.SuppressLint
 

--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -29,6 +29,15 @@
 -dontwarn java.lang.ClassValue
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
+# Kotlinx Datetime
+#   Material3 depends on it, and ir references `kotlinx.serialization`, which is optional
+#   Copied from https://github.com/Kotlin/kotlinx-datetime/blob/v0.6.2/core/jvm/resources/META-INF/proguard/datetime.pro
+#   with one additional rule
+-dontwarn kotlinx.serialization.KSerializer
+-dontwarn kotlinx.serialization.Serializable
+-dontwarn kotlinx.datetime.serializers.**
+
+
 # https://github.com/Kotlin/kotlinx.coroutines/issues/2046
 -dontwarn android.annotation.SuppressLint
 
@@ -46,3 +55,6 @@
 -keep class kotlinx.coroutines.CoroutineScope
 # this is a weird one, but breaks build on some combinations of OS and JDK (reproduced on Windows 10 + Corretto 16)
 -dontwarn org.graalvm.compiler.core.aarch64.AArch64NodeMatchRules_MatchStatementSet*
+
+# Androidx
+-dontnote androidx.**

--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -30,7 +30,7 @@
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 # Kotlinx Datetime
-#   Material3 depends on it, and ir references `kotlinx.serialization`, which is optional
+#   Material3 depends on it, and it references `kotlinx.serialization`, which is optional
 #   Copied from https://github.com/Kotlin/kotlinx-datetime/blob/v0.6.2/core/jvm/resources/META-INF/proguard/datetime.pro
 #   with one additional rule
 -dontwarn kotlinx.serialization.KSerializer

--- a/gradle-plugins/compose/src/test/test-projects/application/proguard/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/proguard/build.gradle
@@ -10,6 +10,7 @@ plugins {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     implementation compose.desktop.currentOs
+    implementation compose.material3
 }
 
 compose.desktop {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7744/Desktop-Execution-failed-for-task-composeAppproguardReleaseJars-when-upgrade-to-CMP-1.8.0-alpha03

Also added `-dontnote androidx.**` to remove unnecessary notes about Compose and other androidx libraries, which users can't fix themselves:
```
Note: androidx.lifecycle.ClassesInfoCache calls 'Method.getAnnotation'
Note: androidx.compose.ui.text.platform.ReflectionUtil$findAssignableField$result$1 calls 'Field.getType'
Note: androidx.compose.ui.text.platform.AwtFontUtils: can't find dynamically referenced class sun.font.CFont
Note: androidx.lifecycle.viewmodel.internal.JvmViewModelProviders accesses a declared constructor '<init>()' dynamically
```

## Testing
- `DesktopApplicationTest.proguard` fails before the fix, success after

## Release Notes
### Fixes - Desktop
- Fix `Execution failed for task ':composeApp:proguardReleaseJars'` when `material3` is included in the project