### PR TITLE
Benchmark results serialization into JSON

### DIFF
--- a/benchmarks/multiplatform/benchmarks/build.gradle.kts
+++ b/benchmarks/multiplatform/benchmarks/build.gradle.kts
@@ -59,7 +59,7 @@ kotlin {
                 implementation(compose.components.resources)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.kotlinx.io)
-                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+                implementation(libs.kotlinx.datetime)
             }
         }
 
@@ -79,21 +79,23 @@ compose.desktop {
 }
 
 val runArguments: String? by project
-val composeVersion: String? = project.properties["compose.version"] as? String
-val kotlinVersion: String? = project.properties["kotlin.version"] as? String
-var appArgs = runArguments
-    ?.split(" ")
-    .orEmpty().let {
-       it + listOf("versionInfo=\"$composeVersion (Kotlin $kotlinVersion)\"")
-    }
-    .map {
-        it.replace(" ", "%20")
-    }
 
-println("runArguments: $appArgs")
+val composeVersion = libs.versions.compose.multiplatform
+val kotlinVersion = libs.versions.kotlin
 
 // Handle runArguments property
 gradle.taskGraph.whenReady {
+    var appArgs = runArguments
+        ?.split(" ")
+        .orEmpty().let {
+            it + listOf("versionInfo=\"${composeVersion.get()} (Kotlin ${kotlinVersion.get()})\"")
+        }
+        .map {
+            it.replace(" ", "%20")
+        }
+
+    println("runArguments: $appArgs")
+
     tasks.named<JavaExec>("run") {
         args(appArgs)
     }

--- a/benchmarks/multiplatform/benchmarks/build.gradle.kts
+++ b/benchmarks/multiplatform/benchmarks/build.gradle.kts
@@ -3,9 +3,10 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
 import kotlin.text.replace
 
 plugins {
-    kotlin("multiplatform")
-    id("org.jetbrains.kotlin.plugin.compose")
-    id("org.jetbrains.compose")
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 version = "1.0-SNAPSHOT"
@@ -56,7 +57,8 @@ kotlin {
                 implementation(compose.material)
                 implementation(compose.runtime)
                 implementation(compose.components.resources)
-                implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.6.0")
+                implementation(libs.kotlinx.serialization.json)
+                implementation(libs.kotlinx.io)
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
             }
         }
@@ -64,7 +66,7 @@ kotlin {
         val desktopMain by getting {
             dependencies {
                 implementation(compose.desktop.currentOs)
-                runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.7.1")
+                runtimeOnly(libs.kotlinx.coroutines.swing)
             }
         }
     }

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/Benchmarks.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/Benchmarks.kt
@@ -31,6 +31,7 @@ data class BenchmarkFrame(
         }
 }
 
+@Serializable
 data class BenchmarkConditions(
     val frameCount: Int,
     val warmupCount: Int
@@ -44,6 +45,7 @@ data class BenchmarkConditions(
     }
 }
 
+@Serializable
 data class FrameInfo(
     val cpuTime: Duration,
     val gpuTime: Duration,

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/Benchmarks.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/Benchmarks.kt
@@ -4,6 +4,8 @@ import benchmarks.complexlazylist.components.MainUiNoImageUseModel
 import benchmarks.example1.Example1
 import benchmarks.lazygrid.LazyGrid
 import benchmarks.visualeffects.NYContent
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 
@@ -61,11 +63,13 @@ data class FrameInfo(
     }
 }
 
+@Serializable
 data class BenchmarkPercentileAverage(
     val percentile: Double,
     val average: Duration
 )
 
+@Serializable
 data class MissedFrames(
     val count: Int,
     val ratio: Double
@@ -86,7 +90,11 @@ data class MissedFrames(
     }
 }
 
+private val json = Json { prettyPrint = true }
+
+@Serializable
 data class BenchmarkStats(
+    val name: String,
     val frameBudget: Duration,
     val conditions: BenchmarkConditions,
     val averageFrameInfo: FrameInfo?,
@@ -152,9 +160,12 @@ data class BenchmarkStats(
             )
         }
     }
+
+    fun toJsonString(): String = json.encodeToString(serializer(), this)
 }
 
 class BenchmarkResult(
+    private val name: String,
     private val frameBudget: Duration,
     private val conditions: BenchmarkConditions,
     private val averageFrameInfo: FrameInfo,
@@ -182,6 +193,7 @@ class BenchmarkResult(
         }
 
         return BenchmarkStats(
+            name,
             frameBudget,
             conditions,
             averageFrameInfo,
@@ -221,7 +233,16 @@ suspend fun runBenchmark(
 ) {
     if (Args.isBenchmarkEnabled(name)) {
         println("# $name")
-        val stats = measureComposable(warmupCount, Args.getBenchmarkProblemSize(name, frameCount), width, height, targetFps, graphicsContext, content).generateStats()
+        val stats = measureComposable(
+            name,
+            warmupCount,
+            Args.getBenchmarkProblemSize(name, frameCount),
+            width,
+            height,
+            targetFps,
+            graphicsContext,
+            content
+        ).generateStats()
         stats.prettyPrint()
         if (Args.saveStatsOnDisk) {
             saveBenchmarkStatsOnDisk(name, stats)
@@ -241,6 +262,6 @@ suspend fun runBenchmarks(
     runBenchmark("AnimatedVisibility", width, height, targetFps, 1000, graphicsContext) { AnimatedVisibility() }
     runBenchmark("LazyGrid", width, height, targetFps, 1000, graphicsContext) { LazyGrid() }
     runBenchmark("VisualEffects", width, height, targetFps, 1000, graphicsContext) { NYContent(width, height) }
-    runBenchmark("LazyList", width, height, targetFps, 1000, graphicsContext) { MainUiNoImageUseModel()}
+    runBenchmark("LazyList", width, height, targetFps, 1000, graphicsContext) { MainUiNoImageUseModel() }
     runBenchmark("Example1", width, height, targetFps, 1000, graphicsContext) { Example1() }
 }

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/BenchmarksSave.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/BenchmarksSave.kt
@@ -36,7 +36,15 @@ fun saveBenchmarkStatsOnDisk(name: String, stats: BenchmarkStats) {
 
         SystemFileSystem.createDirectories(path.parent!!)
         SystemFileSystem.sink(path).writeText(text)
-        println("Results saved to ${SystemFileSystem.resolve(path)}")
+        println("CSV results saved to ${SystemFileSystem.resolve(path)}")
+        println()
+
+        val jsonString = stats.toJsonString()
+        val jsonPath = Path("build/benchmarks/json-reports/$name.json")
+
+        SystemFileSystem.createDirectories(jsonPath.parent!!)
+        SystemFileSystem.sink(jsonPath).writeText(jsonString)
+        println("JSON results saved to ${SystemFileSystem.resolve(jsonPath)}")
         println()
     } catch (_: IOException) {
         // IOException "Read-only file system" is thrown on iOS without writing permissions

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -42,6 +42,7 @@ suspend inline fun preciseDelay(duration: Duration) {
 
 @OptIn(ExperimentalTime::class, InternalComposeUiApi::class)
 suspend fun measureComposable(
+    name: String,
     warmupCount: Int,
     frameCount: Int,
     width: Int,
@@ -121,6 +122,7 @@ suspend fun measureComposable(
         }
 
         return BenchmarkResult(
+            name,
             nanosPerFrame.nanoseconds,
             BenchmarkConditions(frameCount, warmupCount),
             FrameInfo(cpuTotalTime / frameCount, gpuTotalTime / frameCount),

--- a/benchmarks/multiplatform/build.gradle.kts
+++ b/benchmarks/multiplatform/build.gradle.kts
@@ -1,9 +1,10 @@
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
-    kotlin("multiplatform") apply false
-    kotlin("plugin.compose") apply false
-    id("org.jetbrains.compose") apply false
+    alias(libs.plugins.composeMultiplatform) apply false
+    alias(libs.plugins.composeCompiler) apply false
+    alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.kotlinSerialization) apply false
 }
 
 allprojects {

--- a/benchmarks/multiplatform/gradle.properties
+++ b/benchmarks/multiplatform/gradle.properties
@@ -1,10 +1,8 @@
-compose.version=1.7.1
-kotlin.version=2.1.0
 org.gradle.jvmargs=-Xmx3g
 kotlin.native.useEmbeddableCompilerJar=true
 compose.desktop.verbose=true
 android.useAndroidX=true
-runArguments=benchmarks= modes=
+runArguments=benchmarks= modes= saveStatsOnDisk=true
 kotlin.js.webpack.major.version=4
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.resources.multimodule.disable=true

--- a/benchmarks/multiplatform/gradle.properties
+++ b/benchmarks/multiplatform/gradle.properties
@@ -5,4 +5,4 @@ android.useAndroidX=true
 runArguments=benchmarks= modes= saveStatsOnDisk=true
 kotlin.js.webpack.major.version=4
 org.jetbrains.compose.experimental.macos.enabled=true
-org.jetbrains.compose.resources.multimodule.disable=true
+org.jetbrains.compose.resources.multimodule.disable=false

--- a/benchmarks/multiplatform/gradle/libs.versions.toml
+++ b/benchmarks/multiplatform/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+compose-multiplatform = "1.8.0-alpha04"
+kotlin = "2.1.10"
+kotlinx-coroutines = "1.8.0"
+kotlinx-serialization = "1.8.0"
+kotlinx-io = "0.7.0"
+
+[libraries]
+kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
+
+[plugins]
+composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
+

--- a/benchmarks/multiplatform/gradle/libs.versions.toml
+++ b/benchmarks/multiplatform/gradle/libs.versions.toml
@@ -4,15 +4,16 @@ kotlin = "2.1.10"
 kotlinx-coroutines = "1.8.0"
 kotlinx-serialization = "1.8.0"
 kotlinx-io = "0.7.0"
+kotlinx-datetime = "0.6.2"
 
 [libraries]
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
-

--- a/benchmarks/multiplatform/gradle/libs.versions.toml
+++ b/benchmarks/multiplatform/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-compose-multiplatform = "1.8.0-alpha04"
-kotlin = "2.1.10"
+compose-multiplatform = "1.8.0-beta01"
+kotlin = "2.1.20"
 kotlinx-coroutines = "1.8.0"
 kotlinx-serialization = "1.8.0"
 kotlinx-io = "0.7.0"

--- a/benchmarks/multiplatform/settings.gradle.kts
+++ b/benchmarks/multiplatform/settings.gradle.kts
@@ -10,4 +10,20 @@ pluginManagement {
 
 rootProject.name = "compose-benchmarks"
 
+dependencyResolutionManagement {
+    versionCatalogs{
+        create("libs") {
+            // Override Kotlin and Compose versions with properties
+            providers.run {
+                with(gradleProperty("kotlin.version")) {
+                    if (isPresent) version("kotlin", get())
+                }
+                with(gradleProperty("compose.version")) {
+                    if (isPresent) version("compose-multiplatform", get())
+                }
+            }
+        }
+    }
+}
+
 include(":benchmarks")

--- a/benchmarks/multiplatform/settings.gradle.kts
+++ b/benchmarks/multiplatform/settings.gradle.kts
@@ -6,14 +6,6 @@ pluginManagement {
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         google()
     }
-
-    plugins {
-        val kotlinVersion = extra["kotlin.version"] as String
-        kotlin("multiplatform").version(kotlinVersion)
-        id("org.jetbrains.kotlin.plugin.compose").version(kotlinVersion)
-        val composeVersion = extra["compose.version"] as String
-        id("org.jetbrains.compose").version(composeVersion)
-    }
 }
 
 rootProject.name = "compose-benchmarks"


### PR DESCRIPTION
Adds serialization to JSON format to collect and analyze the results of benchmark runs.
Additionally, improve the Gradle build by using version catalogues and modern APIs. 

## Testing
A regular benchmarks execution was set on the CI.

## Release Notes
### Features - Multiple Platforms
- Improve benchmarks build and serialize results into JSON for the collection and analysis
