### PR TITLE
Stable resources API

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-14, windows-2022]
-        gradle: [7.4, 8.10.2]
-        agp: [8.1.0, 8.5.0, 8.8.0-alpha08]
+        gradle: [7.4, 8.13]
+        agp: [8.6.0, 8.9.0]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/AndroidContextProvider.kt
+++ b/components/resources/library/src/androidMain/kotlin/org/jetbrains/compose/resources/AndroidContextProvider.kt
@@ -31,7 +31,6 @@ internal val androidInstrumentedContext get() = InstrumentationRegistry.getInstr
  * }
  * ```
  */
-@ExperimentalResourceApi
 @Composable
 fun PreviewContextConfigurationEffect() {
     if (LocalInspectionMode.current) {

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/FontResources.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/FontResources.kt
@@ -66,7 +66,6 @@ expect fun Font(
  * @param resource The font resource.
  * @return The byte array representing the font resource.
  */
-@ExperimentalResourceApi
 suspend fun getFontResourceBytes(
     environment: ResourceEnvironment,
     resource: FontResource

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.kt
@@ -12,7 +12,6 @@ import org.jetbrains.compose.resources.vector.toImageVector
  *
  * @return The converted ImageBitmap.
  */
-@ExperimentalResourceApi
 fun ByteArray.decodeToImageBitmap(): ImageBitmap {
     val dumbDensity = 0 //any equal source and target density disable scaling here
     return this.toImageBitmap(dumbDensity, dumbDensity)
@@ -25,7 +24,6 @@ fun ByteArray.decodeToImageBitmap(): ImageBitmap {
  *
  * @return The converted ImageVector.
  */
-@ExperimentalResourceApi
 fun ByteArray.decodeToImageVector(density: Density): ImageVector {
     return this.toXmlElement().toImageVector(density)
 }

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ImageResources.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ImageResources.kt
@@ -130,7 +130,6 @@ private fun svgPainter(resource: DrawableResource): Painter {
  * @param resource The drawable resource.
  * @return The byte array representing the drawable resource.
  */
-@ExperimentalResourceApi
 suspend fun getDrawableResourceBytes(
     environment: ResourceEnvironment,
     resource: DrawableResource

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/PluralStringResources.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/PluralStringResources.kt
@@ -55,7 +55,6 @@ suspend fun getPluralString(resource: PluralStringResource, quantity: Int): Stri
  *
  * @throws IllegalArgumentException If the provided ID or the pluralization is not found in the resource file.
  */
-@ExperimentalResourceApi
 suspend fun getPluralString(
     environment: ResourceEnvironment,
     resource: PluralStringResource,
@@ -130,7 +129,6 @@ suspend fun getPluralString(resource: PluralStringResource, quantity: Int, varar
  *
  * @throws IllegalArgumentException If the provided ID or the pluralization is not found in the resource file.
  */
-@ExperimentalResourceApi
 suspend fun getPluralString(
     environment: ResourceEnvironment,
     resource: PluralStringResource,

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.intl.Locale
 
-@ExperimentalResourceApi
 class ResourceEnvironment internal constructor(
     internal val language: LanguageQualifier,
     internal val region: RegionQualifier,
@@ -69,7 +68,6 @@ internal val LocalComposeEnvironment = staticCompositionLocalOf { DefaultCompose
  *
  * @return An instance of [ResourceEnvironment] representing the current environment.
  */
-@ExperimentalResourceApi
 @Composable
 fun rememberResourceEnvironment(): ResourceEnvironment {
     val composeEnvironment = LocalComposeEnvironment.current
@@ -86,7 +84,6 @@ internal var getResourceEnvironment = ::getSystemEnvironment
  * Provides the resource environment for non-composable access to resources.
  * It is an expensive operation! Don't use it in composable functions with no cache!
  */
-@ExperimentalResourceApi
 fun getSystemResourceEnvironment(): ResourceEnvironment = getResourceEnvironment()
 
 @OptIn(InternalResourceApi::class)

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/StringArrayResources.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/StringArrayResources.kt
@@ -57,7 +57,6 @@ suspend fun getStringArray(resource: StringArrayResource): List<String> =
  *
  * @throws IllegalStateException if the string array with the given ID is not found.
  */
-@ExperimentalResourceApi
 suspend fun getStringArray(
     environment: ResourceEnvironment,
     resource: StringArrayResource

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/StringResources.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/StringResources.kt
@@ -50,7 +50,6 @@ suspend fun getString(resource: StringResource): String =
  *
  * @throws IllegalArgumentException If the provided ID is not found in the resource file.
  */
-@ExperimentalResourceApi
 suspend fun getString(environment: ResourceEnvironment, resource: StringResource): String =
     loadString(resource, DefaultResourceReader, environment)
 
@@ -109,7 +108,6 @@ suspend fun getString(resource: StringResource, vararg formatArgs: Any): String 
  *
  * @throws IllegalArgumentException If the provided ID is not found in the resource file.
  */
-@ExperimentalResourceApi
 suspend fun getString(
     environment: ResourceEnvironment,
     resource: StringResource,

--- a/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.skiko.kt
+++ b/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/ImageDecoders.skiko.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.unit.Density
  *
  * @return The converted Painter.
  */
-@ExperimentalResourceApi
 fun ByteArray.decodeToSvgPainter(density: Density): Painter {
     return this.toSvgElement().toSvgPainter(density)
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GeneratedResClassSpec.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GeneratedResClassSpec.kt
@@ -55,9 +55,6 @@ private fun ResourceType.requiresKeyName() =
     this in setOf(ResourceType.STRING, ResourceType.STRING_ARRAY, ResourceType.PLURAL_STRING)
 
 private val resourceItemClass = ClassName("org.jetbrains.compose.resources", "ResourceItem")
-private val experimentalAnnotation = AnnotationSpec.builder(
-    ClassName("org.jetbrains.compose.resources", "ExperimentalResourceApi")
-).build()
 private val internalAnnotation = AnnotationSpec.builder(
     ClassName("org.jetbrains.compose.resources", "InternalResourceApi")
 ).build()
@@ -138,7 +135,6 @@ internal fun getResFileSpec(
         file.addAnnotation(
             AnnotationSpec.builder(ClassName("kotlin", "OptIn"))
                 .addMember("org.jetbrains.compose.resources.InternalResourceApi::class")
-                .addMember("org.jetbrains.compose.resources.ExperimentalResourceApi::class")
                 .build()
         )
         file.addType(TypeSpec.objectBuilder("Res").also { resObject ->
@@ -158,7 +154,6 @@ internal fun getResFileSpec(
                     @return The content of the file as a byte array.
                 """.trimIndent()
                     )
-                    .addAnnotation(experimentalAnnotation)
                     .addParameter("path", String::class)
                     .addModifiers(KModifier.SUSPEND)
                     .returns(ByteArray::class)
@@ -180,7 +175,6 @@ internal fun getResFileSpec(
                     @return The URI string of the file.
                 """.trimIndent()
                     )
-                    .addAnnotation(experimentalAnnotation)
                     .addParameter("path", String::class)
                     .returns(String::class)
                     .addStatement("""return %M("$moduleDir" + path)""", getResourceUri)
@@ -335,7 +329,6 @@ internal fun getExpectResourceCollectorsFileSpec(
                         KModifier.EXPECT,
                         resModifier
                     )
-                    .addAnnotation(experimentalAnnotation)
                     .receiver(ClassName(packageName, "Res"))
                     .build()
             )
@@ -383,7 +376,6 @@ internal fun getActualResourceCollectorsFileSpec(
                 MAP.parameterizedBy(String::class.asClassName(), typeClassName),
                 mods
             )
-            .addAnnotation(experimentalAnnotation)
             .receiver(ClassName(packageName, "Res"))
             .delegate(initBlock)
             .build()

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/androidMainResourceCollectors/my/lib/res/ActualResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/androidMainResourceCollectors/my/lib/res/ActualResourceCollectors.kt
@@ -6,13 +6,11 @@ import kotlin.OptIn
 import kotlin.String
 import kotlin.collections.Map
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-@ExperimentalResourceApi
 public actual val Res.allDrawableResources: Map<String, DrawableResource> by lazy {
   val map = mutableMapOf<String, DrawableResource>()
   _collectCommonMainDrawable0Resources(map)
@@ -20,7 +18,6 @@ public actual val Res.allDrawableResources: Map<String, DrawableResource> by laz
 }
 
 
-@ExperimentalResourceApi
 public actual val Res.allStringResources: Map<String, StringResource> by lazy {
   val map = mutableMapOf<String, StringResource>()
   _collectAndroidMainString0Resources(map)
@@ -29,14 +26,12 @@ public actual val Res.allStringResources: Map<String, StringResource> by lazy {
 }
 
 
-@ExperimentalResourceApi
 public actual val Res.allStringArrayResources: Map<String, StringArrayResource> by lazy {
   val map = mutableMapOf<String, StringArrayResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 public actual val Res.allPluralStringResources: Map<String, PluralStringResource> by lazy {
   val map = mutableMapOf<String, PluralStringResource>()
   _collectCommonMainPlurals0Resources(map)
@@ -44,7 +39,6 @@ public actual val Res.allPluralStringResources: Map<String, PluralStringResource
 }
 
 
-@ExperimentalResourceApi
 public actual val Res.allFontResources: Map<String, FontResource> by lazy {
   val map = mutableMapOf<String, FontResource>()
   _collectCommonMainFont0Resources(map)

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceCollectors/my/lib/res/ExpectResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceCollectors/my/lib/res/ExpectResourceCollectors.kt
@@ -3,23 +3,17 @@ package my.lib.res
 import kotlin.String
 import kotlin.collections.Map
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-@ExperimentalResourceApi
 public expect val Res.allDrawableResources: Map<String, DrawableResource>
 
-@ExperimentalResourceApi
 public expect val Res.allStringResources: Map<String, StringResource>
 
-@ExperimentalResourceApi
 public expect val Res.allStringArrayResources: Map<String, StringArrayResource>
 
-@ExperimentalResourceApi
 public expect val Res.allPluralStringResources: Map<String, PluralStringResource>
 
-@ExperimentalResourceApi
 public expect val Res.allFontResources: Map<String, FontResource>

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonResClass/my/lib/res/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonResClass/my/lib/res/Res.kt
@@ -1,14 +1,10 @@
-@file:OptIn(
-  org.jetbrains.compose.resources.InternalResourceApi::class,
-  org.jetbrains.compose.resources.ExperimentalResourceApi::class,
-)
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
 
 package my.lib.res
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
@@ -21,7 +17,6 @@ public object Res {
    * @param path The path of the file to read in the compose resource's directory.
    * @return The content of the file as a byte array.
    */
-  @ExperimentalResourceApi
   public suspend fun readBytes(path: String): ByteArray =
       readResourceBytes("composeResources/my.lib.res/" + path)
 
@@ -33,7 +28,6 @@ public object Res {
    * @param path The path of the file in the compose resource's directory.
    * @return The URI string of the file.
    */
-  @ExperimentalResourceApi
   public fun getUri(path: String): String = getResourceUri("composeResources/my.lib.res/" + path)
 
   public object drawable

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/desktopMainResourceCollectors/my/lib/res/ActualResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/desktopMainResourceCollectors/my/lib/res/ActualResourceCollectors.kt
@@ -6,13 +6,11 @@ import kotlin.OptIn
 import kotlin.String
 import kotlin.collections.Map
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-@ExperimentalResourceApi
 public actual val Res.allDrawableResources: Map<String, DrawableResource> by lazy {
   val map = mutableMapOf<String, DrawableResource>()
   _collectCommonMainDrawable0Resources(map)
@@ -20,7 +18,6 @@ public actual val Res.allDrawableResources: Map<String, DrawableResource> by laz
 }
 
 
-@ExperimentalResourceApi
 public actual val Res.allStringResources: Map<String, StringResource> by lazy {
   val map = mutableMapOf<String, StringResource>()
   _collectDesktopMainString0Resources(map)
@@ -29,14 +26,12 @@ public actual val Res.allStringResources: Map<String, StringResource> by lazy {
 }
 
 
-@ExperimentalResourceApi
 public actual val Res.allStringArrayResources: Map<String, StringArrayResource> by lazy {
   val map = mutableMapOf<String, StringArrayResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 public actual val Res.allPluralStringResources: Map<String, PluralStringResource> by lazy {
   val map = mutableMapOf<String, PluralStringResource>()
   _collectCommonMainPlurals0Resources(map)
@@ -44,7 +39,6 @@ public actual val Res.allPluralStringResources: Map<String, PluralStringResource
 }
 
 
-@ExperimentalResourceApi
 public actual val Res.allFontResources: Map<String, FontResource> by lazy {
   val map = mutableMapOf<String, FontResource>()
   _collectCommonMainFont0Resources(map)

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/androidMainResourceCollectors/app/group/resources_test/generated/resources/ActualResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/androidMainResourceCollectors/app/group/resources_test/generated/resources/ActualResourceCollectors.kt
@@ -6,13 +6,11 @@ import kotlin.OptIn
 import kotlin.String
 import kotlin.collections.Map
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-@ExperimentalResourceApi
 internal actual val Res.allDrawableResources: Map<String, DrawableResource> by lazy {
   val map = mutableMapOf<String, DrawableResource>()
   _collectCommonMainDrawable0Resources(map)
@@ -20,7 +18,6 @@ internal actual val Res.allDrawableResources: Map<String, DrawableResource> by l
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allStringResources: Map<String, StringResource> by lazy {
   val map = mutableMapOf<String, StringResource>()
   _collectAndroidMainString0Resources(map)
@@ -29,14 +26,12 @@ internal actual val Res.allStringResources: Map<String, StringResource> by lazy 
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allStringArrayResources: Map<String, StringArrayResource> by lazy {
   val map = mutableMapOf<String, StringArrayResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allPluralStringResources: Map<String, PluralStringResource> by lazy {
   val map = mutableMapOf<String, PluralStringResource>()
   _collectCommonMainPlurals0Resources(map)
@@ -44,7 +39,6 @@ internal actual val Res.allPluralStringResources: Map<String, PluralStringResour
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allFontResources: Map<String, FontResource> by lazy {
   val map = mutableMapOf<String, FontResource>()
   _collectCommonMainFont0Resources(map)

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/commonMainResourceCollectors/app/group/resources_test/generated/resources/ExpectResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/commonMainResourceCollectors/app/group/resources_test/generated/resources/ExpectResourceCollectors.kt
@@ -3,23 +3,17 @@ package app.group.resources_test.generated.resources
 import kotlin.String
 import kotlin.collections.Map
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-@ExperimentalResourceApi
 internal expect val Res.allDrawableResources: Map<String, DrawableResource>
 
-@ExperimentalResourceApi
 internal expect val Res.allStringResources: Map<String, StringResource>
 
-@ExperimentalResourceApi
 internal expect val Res.allStringArrayResources: Map<String, StringArrayResource>
 
-@ExperimentalResourceApi
 internal expect val Res.allPluralStringResources: Map<String, PluralStringResource>
 
-@ExperimentalResourceApi
 internal expect val Res.allFontResources: Map<String, FontResource>

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/commonResClass/app/group/resources_test/generated/resources/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/commonResClass/app/group/resources_test/generated/resources/Res.kt
@@ -1,14 +1,10 @@
-@file:OptIn(
-  org.jetbrains.compose.resources.InternalResourceApi::class,
-  org.jetbrains.compose.resources.ExperimentalResourceApi::class,
-)
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
 
 package app.group.resources_test.generated.resources
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
@@ -21,7 +17,6 @@ internal object Res {
    * @param path The path of the file to read in the compose resource's directory.
    * @return The content of the file as a byte array.
    */
-  @ExperimentalResourceApi
   public suspend fun readBytes(path: String): ByteArray =
       readResourceBytes("composeResources/app.group.resources_test.generated.resources/" + path)
 
@@ -33,7 +28,6 @@ internal object Res {
    * @param path The path of the file in the compose resource's directory.
    * @return The URI string of the file.
    */
-  @ExperimentalResourceApi
   public fun getUri(path: String): String =
       getResourceUri("composeResources/app.group.resources_test.generated.resources/" + path)
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/desktopMainResourceCollectors/app/group/resources_test/generated/resources/ActualResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/desktopMainResourceCollectors/app/group/resources_test/generated/resources/ActualResourceCollectors.kt
@@ -6,13 +6,11 @@ import kotlin.OptIn
 import kotlin.String
 import kotlin.collections.Map
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-@ExperimentalResourceApi
 internal actual val Res.allDrawableResources: Map<String, DrawableResource> by lazy {
   val map = mutableMapOf<String, DrawableResource>()
   _collectCommonMainDrawable0Resources(map)
@@ -20,7 +18,6 @@ internal actual val Res.allDrawableResources: Map<String, DrawableResource> by l
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allStringResources: Map<String, StringResource> by lazy {
   val map = mutableMapOf<String, StringResource>()
   _collectDesktopMainString0Resources(map)
@@ -29,14 +26,12 @@ internal actual val Res.allStringResources: Map<String, StringResource> by lazy 
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allStringArrayResources: Map<String, StringArrayResource> by lazy {
   val map = mutableMapOf<String, StringArrayResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allPluralStringResources: Map<String, PluralStringResource> by lazy {
   val map = mutableMapOf<String, PluralStringResource>()
   _collectCommonMainPlurals0Resources(map)
@@ -44,7 +39,6 @@ internal actual val Res.allPluralStringResources: Map<String, PluralStringResour
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allFontResources: Map<String, FontResource> by lazy {
   val map = mutableMapOf<String, FontResource>()
   _collectCommonMainFont0Resources(map)

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/src/commonMain/kotlin/App.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/src/commonMain/kotlin/App.kt
@@ -11,7 +11,6 @@ import app.group.resources_test.generated.resources.emptyFont
 import app.group.resources_test.generated.resources.vector
 import org.jetbrains.compose.resources.*
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun App() {
     Column {

--- a/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/commonMainResourceCollectors/app/group/empty_res/generated/resources/ExpectResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/commonMainResourceCollectors/app/group/empty_res/generated/resources/ExpectResourceCollectors.kt
@@ -3,23 +3,17 @@ package app.group.empty_res.generated.resources
 import kotlin.String
 import kotlin.collections.Map
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-@ExperimentalResourceApi
 internal expect val Res.allDrawableResources: Map<String, DrawableResource>
 
-@ExperimentalResourceApi
 internal expect val Res.allStringResources: Map<String, StringResource>
 
-@ExperimentalResourceApi
 internal expect val Res.allStringArrayResources: Map<String, StringArrayResource>
 
-@ExperimentalResourceApi
 internal expect val Res.allPluralStringResources: Map<String, PluralStringResource>
 
-@ExperimentalResourceApi
 internal expect val Res.allFontResources: Map<String, FontResource>

--- a/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/commonResClass/app/group/empty_res/generated/resources/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/commonResClass/app/group/empty_res/generated/resources/Res.kt
@@ -1,14 +1,10 @@
-@file:OptIn(
-  org.jetbrains.compose.resources.InternalResourceApi::class,
-  org.jetbrains.compose.resources.ExperimentalResourceApi::class,
-)
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
 
 package app.group.empty_res.generated.resources
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
@@ -21,7 +17,6 @@ internal object Res {
    * @param path The path of the file to read in the compose resource's directory.
    * @return The content of the file as a byte array.
    */
-  @ExperimentalResourceApi
   public suspend fun readBytes(path: String): ByteArray =
       readResourceBytes("composeResources/app.group.empty_res.generated.resources/" + path)
 
@@ -33,7 +28,6 @@ internal object Res {
    * @param path The path of the file in the compose resource's directory.
    * @return The URI string of the file.
    */
-  @ExperimentalResourceApi
   public fun getUri(path: String): String =
       getResourceUri("composeResources/app.group.empty_res.generated.resources/" + path)
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/desktopMainResourceCollectors/app/group/empty_res/generated/resources/ActualResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/desktopMainResourceCollectors/app/group/empty_res/generated/resources/ActualResourceCollectors.kt
@@ -6,41 +6,35 @@ import kotlin.OptIn
 import kotlin.String
 import kotlin.collections.Map
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-@ExperimentalResourceApi
 internal actual val Res.allDrawableResources: Map<String, DrawableResource> by lazy {
   val map = mutableMapOf<String, DrawableResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allStringResources: Map<String, StringResource> by lazy {
   val map = mutableMapOf<String, StringResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allStringArrayResources: Map<String, StringArrayResource> by lazy {
   val map = mutableMapOf<String, StringArrayResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allPluralStringResources: Map<String, PluralStringResource> by lazy {
   val map = mutableMapOf<String, PluralStringResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 internal actual val Res.allFontResources: Map<String, FontResource> by lazy {
   val map = mutableMapOf<String, FontResource>()
   return@lazy map

--- a/gradle-plugins/compose/src/test/test-projects/misc/iosResources/src/commonMain/kotlin/App.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/iosResources/src/commonMain/kotlin/App.kt
@@ -12,11 +12,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import iosResources.generated.resources.*
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun App() {
     MaterialTheme {

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/commonResClass/me/app/jvmonlyresources/generated/resources/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/commonResClass/me/app/jvmonlyresources/generated/resources/Res.kt
@@ -1,14 +1,10 @@
-@file:OptIn(
-  org.jetbrains.compose.resources.InternalResourceApi::class,
-  org.jetbrains.compose.resources.ExperimentalResourceApi::class,
-)
+@file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
 
 package me.app.jvmonlyresources.generated.resources
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
@@ -21,7 +17,6 @@ internal object Res {
    * @param path The path of the file to read in the compose resource's directory.
    * @return The content of the file as a byte array.
    */
-  @ExperimentalResourceApi
   public suspend fun readBytes(path: String): ByteArray =
     readResourceBytes("composeResources/me.app.jvmonlyresources.generated.resources/" + path)
 
@@ -33,7 +28,6 @@ internal object Res {
    * @param path The path of the file in the compose resource's directory.
    * @return The URI string of the file.
    */
-  @ExperimentalResourceApi
   public fun getUri(path: String): String =
     getResourceUri("composeResources/me.app.jvmonlyresources.generated.resources/" + path)
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/mainResourceCollectors/me/app/jvmonlyresources/generated/resources/ActualResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/mainResourceCollectors/me/app/jvmonlyresources/generated/resources/ActualResourceCollectors.kt
@@ -6,13 +6,11 @@ import kotlin.OptIn
 import kotlin.String
 import kotlin.collections.Map
 import org.jetbrains.compose.resources.DrawableResource
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.FontResource
 import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-@ExperimentalResourceApi
 internal val Res.allDrawableResources: Map<String, DrawableResource> by lazy {
   val map = mutableMapOf<String, DrawableResource>()
   _collectMainDrawable0Resources(map)
@@ -20,28 +18,24 @@ internal val Res.allDrawableResources: Map<String, DrawableResource> by lazy {
 }
 
 
-@ExperimentalResourceApi
 internal val Res.allStringResources: Map<String, StringResource> by lazy {
   val map = mutableMapOf<String, StringResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 internal val Res.allStringArrayResources: Map<String, StringArrayResource> by lazy {
   val map = mutableMapOf<String, StringArrayResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 internal val Res.allPluralStringResources: Map<String, PluralStringResource> by lazy {
   val map = mutableMapOf<String, PluralStringResource>()
   return@lazy map
 }
 
 
-@ExperimentalResourceApi
 internal val Res.allFontResources: Map<String, FontResource> by lazy {
   val map = mutableMapOf<String, FontResource>()
   return@lazy map

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/src/main/kotlin/App.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/src/main/kotlin/App.kt
@@ -4,7 +4,6 @@ import me.app.jvmonlyresources.generated.resources.Res
 import me.app.jvmonlyresources.generated.resources.vector
 import org.jetbrains.compose.resources.*
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun App() {
     Image(

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/appModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/appModule/build.gradle.kts
@@ -19,12 +19,6 @@ kotlin {
     wasmJs { browser() }
 
     sourceSets {
-        all {
-            languageSettings {
-                optIn("org.jetbrains.compose.resources.ExperimentalResourceApi")
-            }
-        }
-
         commonMain.dependencies {
             implementation(compose.runtime)
             implementation(compose.material3)

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/cmplib/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/cmplib/build.gradle.kts
@@ -28,11 +28,6 @@ kotlin {
     wasmJs { browser() }
 
     sourceSets {
-        all {
-            languageSettings {
-                optIn("org.jetbrains.compose.resources.ExperimentalResourceApi")
-            }
-        }
         commonMain.dependencies {
             implementation(compose.runtime)
             implementation(compose.material3)

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/featureModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/featureModule/build.gradle.kts
@@ -17,11 +17,6 @@ kotlin {
     wasmJs { browser() }
 
     sourceSets {
-        all {
-            languageSettings {
-                optIn("org.jetbrains.compose.resources.ExperimentalResourceApi")
-            }
-        }
         commonMain.dependencies {
             implementation(compose.runtime)
             implementation(compose.material3)

--- a/gradle-plugins/compose/src/test/test-projects/misc/macosResources/src/commonMain/kotlin/App.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/macosResources/src/commonMain/kotlin/App.kt
@@ -12,11 +12,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import iosResources.generated.resources.*
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun App() {
     MaterialTheme {

--- a/gradle-plugins/compose/src/test/test-projects/misc/testResources/src/commonTest/kotlin/CommonUiTest.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/testResources/src/commonTest/kotlin/CommonUiTest.kt
@@ -4,13 +4,12 @@ import app.group.resources_test.generated.resources.Res
 import app.group.resources_test.generated.resources.app_name
 import app.group.resources_test.generated.resources.test_string
 import kotlinx.coroutines.test.runTest
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-@OptIn(ExperimentalTestApi::class, ExperimentalResourceApi::class)
+@OptIn(ExperimentalTestApi::class)
 class CommonUiTest {
 
     @Test

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -15,8 +15,8 @@ compose.tests.kotlin.version=2.1.0
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config
 # minimal and current gradle version
-compose.tests.gradle.versions=7.4, 8.10.2
-compose.tests.agp.versions=8.1.0, 8.5.0, 8.8.0-alpha08
+compose.tests.gradle.versions=7.4, 8.13
+compose.tests.agp.versions=8.6.0, 8.9.0
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.


### PR DESCRIPTION
Delete `ExperimentalResourceApi` annotation from library API available since 1.7

## Release Notes
N/A
