### PR TITLE
Bump kotlin version in compose gradle plugin to 2.1.20

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -34,8 +34,8 @@ subprojects {
             compilerOptions {
                 // must be set to a language version of the kotlin compiler & runtime,
                 // which is bundled to the oldest supported Gradle
-                languageVersion.set(KotlinVersion.KOTLIN_1_5)
-                apiVersion.set(KotlinVersion.KOTLIN_1_5)
+                languageVersion.set(KotlinVersion.KOTLIN_1_6)
+                apiVersion.set(KotlinVersion.KOTLIN_1_6)
                 jvmTarget.set(JvmTarget.JVM_11)
             }
         }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/checkExperimentalTargets.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/checkExperimentalTargets.kt
@@ -20,14 +20,14 @@ private const val SKIKO_ARTIFACT_PREFIX = "org.jetbrains.skiko:skiko"
 
 private class TargetType(
     val id: String,
-    val presets: List<String>
+    val identifiers: List<String>
 )
 
 private val TargetType.gradlePropertyName get() = "org.jetbrains.compose.experimental.$id.enabled"
 
 private val EXPERIMENTAL_TARGETS: Set<TargetType> = setOf(
-    TargetType("macos", presets = listOf("macosX64", "macosArm64")),
-    TargetType("jscanvas", presets = listOf("jsIr", "js")),
+    TargetType("macos", identifiers = listOf("macosX64", "macosArm64")),
+    TargetType("jscanvas", identifiers = listOf("jsIr", "js")),
 )
 
 private sealed interface CheckResult {
@@ -59,10 +59,10 @@ private fun checkExperimentalTargetsWithSkikoIsEnabled(
 }
 
 private fun checkTarget(project: Project, target: KotlinTarget): CheckResult {
-    val presetName = target.preset?.name ?: return CheckResult.Success
+    val targetIdentifier = target.disambiguationClassifier ?: return CheckResult.Success
 
     val targetType = EXPERIMENTAL_TARGETS.firstOrNull {
-        it.presets.contains(presetName)
+        it.identifiers.contains(targetIdentifier)
     } ?: return CheckResult.Success
 
     val targetConfigurationNames = target.compilations.map { compilation ->

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.0"
+kotlin = "2.1.20"
 gradle-download-plugin = "5.5.0"
 kotlin-poet = "1.16.0"
 plugin-android = "8.8.0-alpha08"


### PR DESCRIPTION
New Kotlin version 2.2.0 is going to remove a deprecated Presets API. To make our gradle plugin (1.8.x) compatible with Kotlin 2.2.x, we need to replace those API usages: https://youtrack.jetbrains.com/issue/CMP-7891/Compose-Gradle-plugin-is-using-deprecated-Presets-API



## Testing
N/A (automated tests are enough)

## Release Notes
N/A
