### PR TITLE
Fix `./gradlew runRelease`, update ProGuard to 7.7.0

### DIFF
--- a/examples/imageviewer/desktopApp/build.gradle.kts
+++ b/examples/imageviewer/desktopApp/build.gradle.kts
@@ -39,5 +39,9 @@ compose.desktop {
                 iconFile.set(iconsRoot.resolve("icon-linux.png"))
             }
         }
+
+        buildTypes.release.proguard {
+            configurationFiles.from(project.file("rules.pro"))
+        }
     }
 }

--- a/examples/imageviewer/desktopApp/rules.pro
+++ b/examples/imageviewer/desktopApp/rules.pro
@@ -2,11 +2,10 @@
 -keep class io.ktor.** { *; }
 -keepclassmembers class io.ktor.** { volatile <fields>; }
 -keep class io.ktor.client.engine.cio.** { *; }
--keep class kotlinx.coroutines.** { *; }
 -dontwarn kotlinx.atomicfu.**
 -dontwarn io.netty.**
 -dontwarn com.typesafe.**
 -dontwarn org.slf4j.**
-
-# Obfuscation breaks coroutines/ktor for some reason
--dontobfuscate
+-dontnote io.ktor.**
+-dontnote org.slf4j.**
+-dontnote kotlinx.serialization.**

--- a/examples/issues/desktop/compose-desktop.pro
+++ b/examples/issues/desktop/compose-desktop.pro
@@ -14,3 +14,6 @@
 -dontwarn org.openjsse.**
 
 -keep class org.ocpsoft.prettytime.i18n**
+
+-dontnote okhttp3.**
+-keep class okio.Okio__JvmOkioKt { *; }

--- a/examples/nav_cupcake/composeApp/build.gradle.kts
+++ b/examples/nav_cupcake/composeApp/build.gradle.kts
@@ -141,6 +141,10 @@ compose.desktop {
             packageName = "org.jetbrains.nav_cupcake"
             packageVersion = "1.0.0"
         }
+
+        buildTypes.release.proguard {
+            configurationFiles.from(project.file("rules.pro"))
+        }
     }
 }
 

--- a/examples/nav_cupcake/composeApp/rules.pro
+++ b/examples/nav_cupcake/composeApp/rules.pro
@@ -1,0 +1,1 @@
+-keep enum org.jetbrains.nav_cupcake.**  { *; }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
@@ -12,7 +12,7 @@ import org.jetbrains.compose.internal.utils.notNullProperty
 import org.jetbrains.compose.internal.utils.nullableProperty
 import javax.inject.Inject
 
-private const val DEFAULT_PROGUARD_VERSION = "7.2.2"
+private const val DEFAULT_PROGUARD_VERSION = "7.7.0"
 
 abstract class ProguardSettings @Inject constructor(
     objects: ObjectFactory,

--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -35,6 +35,9 @@
 -keep,allowshrinking,allowobfuscation class kotlinx.coroutines.Job { *; }
 -dontnote kotlinx.coroutines.**
 
+# org.jetbrains.kotlinx:kotlinx-coroutines-swing
+-keep class kotlinx.coroutines.swing.SwingDispatcherFactory
+
 # Kotlinx Datetime
 #   Material3 depends on it, and it references `kotlinx.serialization`, which is optional
 #   Copied from https://github.com/Kotlin/kotlinx-datetime/blob/v0.6.2/core/jvm/resources/META-INF/proguard/datetime.pro

--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -29,6 +29,12 @@
 -dontwarn java.lang.ClassValue
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
+# https://youtrack.jetbrains.com/issue/CMP-3818/Update-ProGuard-to-version-7.4-to-support-new-Java-versions
+# https://youtrack.jetbrains.com/issue/CMP-7577/Desktop-runRelease-crash-when-upgrade-to-CMP-1.8.0-alpha02
+-keep,allowshrinking,allowobfuscation class kotlinx.coroutines.flow.FlowKt { *; }
+-keep,allowshrinking,allowobfuscation class kotlinx.coroutines.Job { *; }
+-dontnote kotlinx.coroutines.**
+
 # Kotlinx Datetime
 #   Material3 depends on it, and it references `kotlinx.serialization`, which is optional
 #   Copied from https://github.com/Kotlin/kotlinx-datetime/blob/v0.6.2/core/jvm/resources/META-INF/proguard/datetime.pro
@@ -56,4 +62,6 @@
 -dontwarn org.graalvm.compiler.core.aarch64.AArch64NodeMatchRules_MatchStatementSet*
 
 # Androidx
+-keep,allowshrinking,allowobfuscation class androidx.compose.runtime.SnapshotStateKt__DerivedStateKt { *; }
+-keep class androidx.compose.material3.SliderDefaults { *; }
 -dontnote androidx.**


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7577/Desktop-runRelease-crash-when-upgrade-to-CMP-1.8.0-alpha02
Fixes https://youtrack.jetbrains.com/issue/CMP-3818/Update-ProGuard-to-version-7.4-to-support-new-Java-versions
Fixes https://youtrack.jetbrains.com/issue/CMP-4883/Default-Proguard-rules-cause-release-task-failure-when-using-Material-3-instead-of-2-in-Compose-Desktop

Targeting 1.8.0

The rules was added by testing our current examples. The comprehensive rules are only possible if we run [all tests with ProGuard](https://youtrack.jetbrains.com/issue/CMP-3404/Run-all-Compose-tests-with-ProGuard-on).

Also, each rule wasn't investigated thoroughly, in some cases it might a valid rule, in some cases a ProGuard bug.

The auto integration checks on CI will be added in https://youtrack.jetbrains.com/issue/CMP-7970/Add-integration-checks-for-all-libraries.


## Testing
`./gradlew runRelease` works in:
- https://kmp.jetbrains.com
- all examples

## Release Notes
### Features - Desktop
- The default ProGuard version is set to 7.7.0
   - If there are any new errors in the release build, update [the ProGuard rules](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-native-distribution.html#minification-and-obfuscation)
   - A usual workaround is to add `-keep class` for the associated with error class in "Location:"
   - If the error contains `androidx.` package, it might a Compose bug, please report in https://youtrack.jetbrains.com/issues/CMP. The `-keep class` workaround should also work in this case.
- _(prerelease fix)_ `./gradlew runRelease` doesn't crash with `java.lang.VerifyError`