### PR TITLE
Fix runRelease FlowKt__MergeKt crash

### DIFF
--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -31,7 +31,7 @@
 
 # https://youtrack.jetbrains.com/issue/CMP-3818/Update-ProGuard-to-version-7.4-to-support-new-Java-versions
 # https://youtrack.jetbrains.com/issue/CMP-7577/Desktop-runRelease-crash-when-upgrade-to-CMP-1.8.0-alpha02
--keep,allowshrinking,allowobfuscation class kotlinx.coroutines.flow.FlowKt { *; }
+-keep,allowshrinking,allowobfuscation class kotlinx.coroutines.flow.FlowKt** { *; }
 -keep,allowshrinking,allowobfuscation class kotlinx.coroutines.Job { *; }
 -dontnote kotlinx.coroutines.**
 


### PR DESCRIPTION
Continuation of https://github.com/JetBrains/compose-multiplatform/pull/5279

```
> Task :composeApp:runRelease
Exception in thread "AWT-EventQueue-0" java.lang.VerifyError: Bad return type
Exception Details:
  Location:
    kotlinx/coroutines/flow/FlowKt__MergeKt.transformLatest$21dee7bd(Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/internal/ChannelFlowTransformLatest; @17: areturn
  Reason:
    Type 'kotlinx/coroutines/flow/Flow' (current frame, stack[0]) is not assignable to 'kotlinx/coroutines/flow/internal/ChannelFlowTransformLatest' (from method signature)
  Current Frame:
    bci: @17
    flags: { }
    locals: { 'kotlinx/coroutines/flow/Flow', 'kotlin/jvm/functions/Function3' }
    stack: { 'kotlinx/coroutines/flow/Flow' }
  Bytecode:
    0000000: bb00 0e59 2b2a 0103 0110 1cb7 0012 c000
    0000010: 0ab0

        at kotlinx.coroutines.flow.FlowKt.mapLatest(Unknown Source)
        at kotlinx.coroutines.flow.FlowKt.collectLatest(Unknown Source)
        at androidx.compose.foundation.text.SecureTextFieldController.observeHideEvents(BasicSecureTextField.kt:241)
        at androidx.compose.foundation.text.BasicSecureTextFieldKt$BasicSecureTextField$1$1.invokeSuspend(BasicSecureTextField.kt:139)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at androidx.compose.ui.platform.FlushCoroutineDispatcher.flush$lambda$4(FlushCoroutineDispatcher.skiko.kt:96)
        at androidx.compose.ui.platform.FlushCoroutineDispatcher.performRun(FlushCoroutineDispatcher.skiko.kt:105)
        at androidx.compose.ui.platform.FlushCoroutineDispatcher.flush(FlushCoroutineDispatcher.skiko.kt:83)
        at androidx.compose.ui.scene.ComposeSceneRecomposer.performScheduledEffects(ComposeSceneRecomposer.skiko.kt:91)
        at androidx.compose.ui.scene.BaseComposeScene.render(BaseComposeScene.skiko.kt:171)
        at androidx.compose.ui.scene.ComposeSceneMediator.onRender$lambda$20$lambda$19(ComposeSceneMediator.desktop.kt:600)
        at androidx.compose.ui.viewinterop.SwingInteropContainer.postponingExecutingScheduledUpdates(SwingInteropContainer.desktop.kt:251)
        at androidx.compose.ui.scene.ComposeSceneMediator.onRender(ComposeSceneMediator.desktop.kt:598)
        at org.jetbrains.skiko.SkiaLayer.update$skiko(SkiaLayer.awt.kt:558)
        at org.jetbrains.skiko.redrawer.AWTRedrawer.update(AWTRedrawer.kt:54)
        at org.jetbrains.skiko.redrawer.Direct3DRedrawer.redrawImmediately(Direct3DRedrawer.kt:74)
        at org.jetbrains.skiko.SkiaLayer.tryRedrawImmediately(SkiaLayer.awt.kt:394)
        at org.jetbrains.skiko.SkiaLayer.paint(SkiaLayer.awt.kt:367)
        at androidx.compose.ui.scene.skia.WindowSkiaLayerComponent$contentComponent$1.paint(WindowSkiaLayerComponent.desktop.kt:64)
        at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:961)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1137)
        at java.desktop/javax.swing.JLayeredPane.paint(JLayeredPane.java:586)
        at androidx.compose.ui.awt.JLayeredPaneWithTransparencyHack.paint(Utils.desktop.kt:121)
        at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:961)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1137)
        at androidx.compose.ui.window.Window_desktopKt.Window$lambda$40$lambda$39(Window.desktop.kt:629)
        at androidx.compose.ui.window.AwtWindow_desktopKt.AwtWindow$lambda$7$lambda$6(AwtWindow.desktop.kt:78)
        at androidx.compose.ui.util.UpdateEffect_desktopKt.UpdateEffect$lambda$8$lambda$7$performUpdate$lambda$4(UpdateEffect.desktop.kt:59)
        at androidx.compose.runtime.snapshots.Snapshot$Companion.observe(Snapshot.kt:2496)
        at androidx.compose.runtime.snapshots.SnapshotStateObserver$ObservedScopeMap.observe(SnapshotStateObserver.kt:460)
        at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads(SnapshotStateObserver.kt:244)
        at androidx.compose.ui.util.UpdateEffect_desktopKt.UpdateEffect$lambda$8$lambda$7$performUpdate(UpdateEffect.desktop.kt:55)
        at androidx.compose.ui.util.UpdateEffect_desktopKt.UpdateEffect$lambda$8$lambda$7(UpdateEffect.desktop.kt:64)
        at androidx.compose.runtime.DisposableEffectImpl.onRemembered(Effects.kt:83)
        at androidx.compose.runtime.internal.RememberEventDispatcher.dispatchRememberObservers(RememberEventDispatcher.kt:1182)
        at androidx.compose.runtime.CompositionImpl.applyChangesInLocked(Composition.kt:1044)
        at androidx.compose.runtime.CompositionImpl.applyChanges(Composition.kt:1067)
        at androidx.compose.runtime.Recomposer.composeInitial$runtime(Recomposer.kt:1159)
        at androidx.compose.runtime.CompositionImpl.setContent(Composition.kt:2677)
        at androidx.compose.ui.window.Application_desktopKt$awaitApplication$2$1$2.invokeSuspend(Application.desktop.kt:221)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
        Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [androidx.compose.ui.scene.ComposeContainer$DesktopCoroutineExceptionHandler@5bbe2373, androidx.compose.runtime.BroadcastFrameClock@3c45d5c5, StandaloneCoroutine{Cancelling}@7b8a1fc6, FlushCoroutineDispatcher@1850cb73]
```

## Release Notes
N/A