### PR TITLE
[Cherry-pick] Add `material-icons-core` to one more example (#5290)

### DIFF
--- a/examples/todoapp-lite/shared/build.gradle.kts
+++ b/examples/todoapp-lite/shared/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
                 implementation(compose.runtime)
                 implementation(compose.foundation)
                 implementation(compose.material)
+                implementation("org.jetbrains.compose.material:material-icons-core:1.6.11")
             }
         }
         val androidMain by getting {


### PR DESCRIPTION
Same as #5284 and #5288

## Release Notes
N/A
