### PR TITLE
Refactor resource path resolution for iOS resources to be able to use XCFramework resources

### DIFF
--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -9,8 +9,8 @@ android.useAndroidX=true
 #Versions
 kotlin.version=2.1.0
 agp.version=8.2.2
-compose.version=1.8.0+dev2188
-deploy.version=0.1.0-SNAPSHOT
+compose.version=1.8.10+dev2347
+deploy.version=9999.0.0-SNAPSHOT
 
 #Compose
 org.jetbrains.compose.experimental.jscanvas.enabled=true

--- a/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceReader.ios.kt
+++ b/components/resources/library/src/iosMain/kotlin/org/jetbrains/compose/resources/ResourceReader.ios.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.compose.resources
 
 import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.BooleanVar
 import kotlinx.cinterop.ObjCObjectVar
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.alloc
@@ -13,6 +14,7 @@ import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.available
 import platform.Foundation.NSBundle
 import platform.Foundation.NSData
+import platform.Foundation.NSDirectoryEnumerationSkipsHiddenFiles
 import platform.Foundation.NSError
 import platform.Foundation.NSFileHandle
 import platform.Foundation.NSFileManager
@@ -25,6 +27,8 @@ import platform.posix.memcpy
 
 @OptIn(BetaInteropApi::class)
 internal actual fun getPlatformResourceReader(): ResourceReader = object : ResourceReader {
+    private val composeResourcesDir: String by lazy { findComposeResourcesPath() }
+
     override suspend fun read(path: String): ByteArray {
         val data = readData(getPathInBundle(path))
         return ByteArray(data.length.toInt()).apply {
@@ -64,7 +68,41 @@ internal actual fun getPlatformResourceReader(): ResourceReader = object : Resou
     }
 
     private fun getPathInBundle(path: String): String {
-        // todo: support fallback path at bundle root?
-        return NSBundle.mainBundle.resourcePath + "/compose-resources/" + path
+        return "$composeResourcesDir/$path"
+    }
+
+    /**
+     * Determines the path to the compose resources directory.
+     * It first searches for a "/Frameworks/'*'.framework/composeResources" directory in the main bundle directory.
+     * If no such directory exists, it defaults to a directory named "compose-resources" in the main bundle directory.
+     *
+     * @return The path to the compose resources directory as a string.
+     */
+    private fun findComposeResourcesPath(): String {
+        val mainBundle = NSBundle.mainBundle
+        val fm = NSFileManager.defaultManager()
+        val frameworkDirs = fm.findSubDirs(mainBundle.resourcePath + "/Frameworks") { it.endsWith(".framework") }
+        val frameworkResourcesDir = frameworkDirs.firstOrNull { frameworkDir ->
+            fm.findSubDirs(frameworkDir) { it.endsWith("composeResources") }.isNotEmpty()
+        }
+        val defaultDir = mainBundle.resourcePath + "/compose-resources"
+        return frameworkResourcesDir ?: defaultDir
+    }
+
+    private fun NSFileManager.findSubDirs(parentDir: String, filter: (String) -> Boolean): List<String> = memScoped {
+        if (!fileExistsAtPath(parentDir)) return emptyList()
+        val contents = contentsOfDirectoryAtURL(
+            url = NSURL(fileURLWithPath = parentDir),
+            includingPropertiesForKeys = null,
+            options = NSDirectoryEnumerationSkipsHiddenFiles,
+            error = null
+        ) ?: return emptyList()
+
+        contents.mapNotNull { url ->
+            val path = (url as? NSURL)?.path ?: return@mapNotNull null
+            val isDir = alloc<BooleanVar>()
+            val exist = fileExistsAtPath(path, isDir.ptr)
+            if (exist && isDir.value && filter(path)) path else null
+        }
     }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7736

## Testing
This should be tested by QA

## Release Notes
### Features - Resources
- Now a compose library with resources may be built and used as XCFramework (it requires Kotlin Gradle plugin 2.2 or higher).
