### PR TITLE
Suppress "redundant visibility modifier" diagnostics in the Res class

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GeneratedResClassSpec.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GeneratedResClassSpec.kt
@@ -137,6 +137,12 @@ internal fun getResFileSpec(
                 .addMember("org.jetbrains.compose.resources.InternalResourceApi::class")
                 .build()
         )
+        file.addAnnotation(
+            AnnotationSpec.builder(ClassName("kotlin", "Suppress"))
+                .addMember("%S","RedundantVisibilityModifier")
+                .addMember("%S","REDUNDANT_VISIBILITY_MODIFIER")
+                .build()
+        )
         file.addType(TypeSpec.objectBuilder("Res").also { resObject ->
             resObject.addModifiers(resModifier)
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonResClass/my/lib/res/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonResClass/my/lib/res/Res.kt
@@ -1,10 +1,15 @@
 @file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+@file:Suppress(
+  "RedundantVisibilityModifier",
+  "REDUNDANT_VISIBILITY_MODIFIER",
+)
 
 package my.lib.res
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
+import kotlin.Suppress
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/commonResClass/app/group/resources_test/generated/resources/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected/commonResClass/app/group/resources_test/generated/resources/Res.kt
@@ -1,10 +1,15 @@
 @file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+@file:Suppress(
+  "RedundantVisibilityModifier",
+  "REDUNDANT_VISIBILITY_MODIFIER",
+)
 
 package app.group.resources_test.generated.resources
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
+import kotlin.Suppress
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/commonResClass/app/group/empty_res/generated/resources/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/emptyResources/expected/commonResClass/app/group/empty_res/generated/resources/Res.kt
@@ -1,10 +1,15 @@
 @file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+@file:Suppress(
+  "RedundantVisibilityModifier",
+  "REDUNDANT_VISIBILITY_MODIFIER",
+)
 
 package app.group.empty_res.generated.resources
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
+import kotlin.Suppress
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/commonResClass/me/app/jvmonlyresources/generated/resources/Res.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jvmOnlyResources/expected/commonResClass/me/app/jvmonlyresources/generated/resources/Res.kt
@@ -1,10 +1,15 @@
 @file:OptIn(org.jetbrains.compose.resources.InternalResourceApi::class)
+@file:Suppress(
+  "RedundantVisibilityModifier",
+  "REDUNDANT_VISIBILITY_MODIFIER",
+)
 
 package me.app.jvmonlyresources.generated.resources
 
 import kotlin.ByteArray
 import kotlin.OptIn
 import kotlin.String
+import kotlin.Suppress
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 


### PR DESCRIPTION
Suppress "redundant visibility modifier" diagnostics so Res is compatible with `-Werror`, `-Wextra`, and IntelliJ inspections

Fixes [CMP-7193](https://youtrack.jetbrains.com/issue/CMP-7193) Generated resource accessors contain redundant visibility modifiers, causing build to fail

## Release Notes
N/A