### PR TITLE
Gradle Plugin DSL to change the generated Res class name

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResourcesGeneration.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ComposeResourcesGeneration.kt
@@ -44,6 +44,7 @@ internal fun Project.configureComposeResourcesGeneration(
         }
     }
     val packageName = config.getResourcePackage(project)
+    val resClassName = config.map { it.nameOfResClass }
     val makeAccessorsPublic = config.map { it.publicResClass }
     val packagingDir = config.getModuleResourcesDir(project)
 
@@ -53,6 +54,7 @@ internal fun Project.configureComposeResourcesGeneration(
                 sourceSet,
                 shouldGenerateCode,
                 packageName,
+                resClassName,
                 makeAccessorsPublic,
                 packagingDir,
                 generateModulePath
@@ -67,13 +69,20 @@ internal fun Project.configureComposeResourcesGeneration(
             preparedResources,
             shouldGenerateCode,
             packageName,
+            resClassName,
             makeAccessorsPublic,
             packagingDir,
             generateModulePath
         )
     }
 
-    configureResourceCollectorsGeneration(kotlinExtension, shouldGenerateCode, packageName, makeAccessorsPublic)
+    configureResourceCollectorsGeneration(
+        kotlinExtension,
+        shouldGenerateCode,
+        packageName,
+        resClassName,
+        makeAccessorsPublic
+    )
 
     //setup task execution during IDE import
     tasks.configureEach { importTask ->
@@ -87,6 +96,7 @@ private fun Project.configureResClassGeneration(
     resClassSourceSet: KotlinSourceSet,
     shouldGenerateCode: Provider<Boolean>,
     packageName: Provider<String>,
+    resClassName: Provider<String>,
     makeAccessorsPublic: Provider<Boolean>,
     packagingDir: Provider<File>,
     generateModulePath: Boolean
@@ -98,6 +108,7 @@ private fun Project.configureResClassGeneration(
         GenerateResClassTask::class.java
     ) { task ->
         task.packageName.set(packageName)
+        task.resClassName.set(resClassName)
         task.makeAccessorsPublic.set(makeAccessorsPublic)
         task.codeDir.set(layout.buildDirectory.dir("$RES_GEN_DIR/kotlin/commonResClass"))
 
@@ -120,6 +131,7 @@ private fun Project.configureResourceAccessorsGeneration(
     resourcesDir: Provider<File>,
     shouldGenerateCode: Provider<Boolean>,
     packageName: Provider<String>,
+    resClassName: Provider<String>,
     makeAccessorsPublic: Provider<Boolean>,
     packagingDir: Provider<File>,
     generateModulePath: Boolean
@@ -131,6 +143,7 @@ private fun Project.configureResourceAccessorsGeneration(
         GenerateResourceAccessorsTask::class.java
     ) { task ->
         task.packageName.set(packageName)
+        task.resClassName.set(resClassName)
         task.sourceSetName.set(sourceSet.name)
         task.makeAccessorsPublic.set(makeAccessorsPublic)
         task.resDir.set(resourcesDir)
@@ -159,6 +172,7 @@ private fun Project.configureResourceCollectorsGeneration(
     kotlinExtension: KotlinProjectExtension,
     shouldGenerateCode: Provider<Boolean>,
     packageName: Provider<String>,
+    resClassName: Provider<String>,
     makeAccessorsPublic: Provider<Boolean>
 ) {
     if (kotlinExtension is KotlinMultiplatformExtension) {
@@ -169,6 +183,7 @@ private fun Project.configureResourceCollectorsGeneration(
                     commonMainSourceSet,
                     shouldGenerateCode,
                     packageName,
+                    resClassName,
                     makeAccessorsPublic
                 )
             }
@@ -180,6 +195,7 @@ private fun Project.configureResourceCollectorsGeneration(
                         androidMain,
                         shouldGenerateCode,
                         packageName,
+                        resClassName,
                         makeAccessorsPublic,
                         true
                     )
@@ -190,6 +206,7 @@ private fun Project.configureResourceCollectorsGeneration(
                         compilation.defaultSourceSet,
                         shouldGenerateCode,
                         packageName,
+                        resClassName,
                         makeAccessorsPublic,
                         true
                     )
@@ -205,6 +222,7 @@ private fun Project.configureResourceCollectorsGeneration(
                     compilation.defaultSourceSet,
                     shouldGenerateCode,
                     packageName,
+                    resClassName,
                     makeAccessorsPublic,
                     false
                 )
@@ -217,6 +235,7 @@ private fun Project.configureExpectResourceCollectorsGeneration(
     sourceSet: KotlinSourceSet,
     shouldGenerateCode: Provider<Boolean>,
     packageName: Provider<String>,
+    resClassName: Provider<String>,
     makeAccessorsPublic: Provider<Boolean>
 ) {
     logger.info("Configure expect resource collectors generation for ${sourceSet.name}")
@@ -227,6 +246,7 @@ private fun Project.configureExpectResourceCollectorsGeneration(
         GenerateExpectResourceCollectorsTask::class.java
     ) { task ->
         task.packageName.set(packageName)
+        task.resClassName.set(resClassName)
         task.makeAccessorsPublic.set(makeAccessorsPublic)
         task.codeDir.set(layout.buildDirectory.dir("$RES_GEN_DIR/kotlin/${sourceSet.name}ResourceCollectors"))
         task.onlyIf { shouldGenerateCode.get() }
@@ -244,6 +264,7 @@ private fun Project.configureActualResourceCollectorsGeneration(
     sourceSet: KotlinSourceSet,
     shouldGenerateCode: Provider<Boolean>,
     packageName: Provider<String>,
+    resClassName: Provider<String>,
     makeAccessorsPublic: Provider<Boolean>,
     useActualModifier: Boolean
 ) {
@@ -269,6 +290,7 @@ private fun Project.configureActualResourceCollectorsGeneration(
         GenerateActualResourceCollectorsTask::class.java
     ) { task ->
         task.packageName.set(packageName)
+        task.resClassName.set(resClassName)
         task.makeAccessorsPublic.set(makeAccessorsPublic)
         task.useActualModifier.set(useActualModifier)
         task.resourceAccessorDirs.from(accessorDirs)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResClassTask.kt
@@ -9,12 +9,11 @@ import org.jetbrains.compose.internal.IdeaImportTask
 import java.io.File
 
 internal abstract class GenerateResClassTask : IdeaImportTask() {
-    companion object {
-        private const val RES_FILE_NAME = "Res"
-    }
-
     @get:Input
     abstract val packageName: Property<String>
+
+    @get:Input
+    abstract val resClassName: Property<String>
 
     @get:Input
     @get:Optional
@@ -31,11 +30,12 @@ internal abstract class GenerateResClassTask : IdeaImportTask() {
         dir.deleteRecursively()
         dir.mkdirs()
 
-        logger.info("Generate $RES_FILE_NAME.kt")
+        val resClassName = resClassName.get()
+        logger.info("Generate $resClassName.kt")
 
         val pkgName = packageName.get()
         val moduleDirectory = packagingDir.getOrNull()?.let { it.invariantSeparatorsPath + "/" } ?: ""
         val isPublic = makeAccessorsPublic.get()
-        getResFileSpec(pkgName, RES_FILE_NAME, moduleDirectory, isPublic).writeTo(dir)
+        getResFileSpec(pkgName, resClassName, moduleDirectory, isPublic).writeTo(dir)
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResourceAccessorsTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResourceAccessorsTask.kt
@@ -19,6 +19,9 @@ internal abstract class GenerateResourceAccessorsTask : IdeaImportTask() {
     abstract val packageName: Property<String>
 
     @get:Input
+    abstract val resClassName: Property<String>
+
+    @get:Input
     abstract val sourceSetName: Property<String>
 
     @get:Input
@@ -68,9 +71,15 @@ internal abstract class GenerateResourceAccessorsTask : IdeaImportTask() {
 
         val pkgName = packageName.get()
         val moduleDirectory = packagingDir.getOrNull()?.let { it.invariantSeparatorsPath + "/" } ?: ""
+        val resClassName = resClassName.get()
         val isPublic = makeAccessorsPublic.get()
         getAccessorsSpecs(
-            resources, pkgName, sourceSet, moduleDirectory, isPublic
+            resources,
+            pkgName,
+            sourceSet,
+            moduleDirectory,
+            resClassName,
+            isPublic
         ).forEach { it.writeTo(kotlinDir) }
     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResourceCollectorsTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/GenerateResourceCollectorsTask.kt
@@ -16,6 +16,9 @@ internal abstract class GenerateExpectResourceCollectorsTask : IdeaImportTask() 
     abstract val packageName: Property<String>
 
     @get:Input
+    abstract val resClassName: Property<String>
+
+    @get:Input
     abstract val makeAccessorsPublic: Property<Boolean>
 
     @get:OutputDirectory
@@ -31,8 +34,14 @@ internal abstract class GenerateExpectResourceCollectorsTask : IdeaImportTask() 
         logger.info("Generate expect ResourceCollectors for $kotlinDir")
 
         val pkgName = packageName.get()
+        val resClassName = resClassName.get()
         val isPublic = makeAccessorsPublic.get()
-        val spec = getExpectResourceCollectorsFileSpec(pkgName, "ExpectResourceCollectors", isPublic)
+        val spec = getExpectResourceCollectorsFileSpec(
+            packageName = pkgName,
+            fileName = "ExpectResourceCollectors",
+            resClassName = resClassName,
+            isPublic = isPublic
+        )
         spec.writeTo(kotlinDir)
     }
 }
@@ -40,6 +49,9 @@ internal abstract class GenerateExpectResourceCollectorsTask : IdeaImportTask() 
 internal abstract class GenerateActualResourceCollectorsTask : IdeaImportTask() {
     @get:Input
     abstract val packageName: Property<String>
+
+    @get:Input
+    abstract val resClassName: Property<String>
 
     @get:Input
     abstract val makeAccessorsPublic: Property<Boolean>
@@ -89,14 +101,16 @@ internal abstract class GenerateActualResourceCollectorsTask : IdeaImportTask() 
         }.groupBy({ it.first }, { it.second })
 
         val pkgName = packageName.get()
+        val resClassName = resClassName.get()
         val isPublic = makeAccessorsPublic.get()
         val useActual = useActualModifier.get()
         val spec = getActualResourceCollectorsFileSpec(
-            pkgName,
-            "ActualResourceCollectors",
-            isPublic,
-            useActual,
-            funNames
+            packageName = pkgName,
+            fileName = "ActualResourceCollectors",
+            resClassName = resClassName,
+            isPublic = isPublic,
+            useActualModifier = useActual,
+            typeToCollectorFunctions = funNames
         )
         spec.writeTo(kotlinDir)
     }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesDSL.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/ResourcesDSL.kt
@@ -22,6 +22,13 @@ abstract class ResourcesExtension {
      */
     var packageOfResClass: String = ""
 
+    /**
+     * The name of the generated resources accessors class.
+     *
+     * The default is "Res".
+     */
+    var nameOfResClass: String = "Res"
+
     enum class ResourceClassGeneration { Auto, Always, Never }
 
     //to support groovy DSL

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -229,6 +229,7 @@ class ResourcesTest : GradlePluginTestBase() {
                 compose.resources {
                     publicResClass = true
                     packageOfResClass = "my.lib.res"
+                    nameOfResClass = "MyRes"
                 }
             """.trimIndent()
         }

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/androidMainResourceAccessors/my/lib/res/String0.androidMain.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/androidMainResourceAccessors/my/lib/res/String0.androidMain.kt
@@ -11,7 +11,7 @@ import org.jetbrains.compose.resources.StringResource
 
 private const val MD: String = "composeResources/my.lib.res/"
 
-public val Res.string.android_str: StringResource by lazy {
+public val MyRes.string.android_str: StringResource by lazy {
       StringResource("string:android_str", "android_str", setOf(
         ResourceItem(setOf(), "${MD}values/strings.androidMain.cvr", 10, 39),
       ))

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/androidMainResourceCollectors/my/lib/res/ActualResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/androidMainResourceCollectors/my/lib/res/ActualResourceCollectors.kt
@@ -11,31 +11,31 @@ import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-public actual val Res.allDrawableResources: Map<String, DrawableResource> by lazy {
+public actual val MyRes.allDrawableResources: Map<String, DrawableResource> by lazy {
   val map = mutableMapOf<String, DrawableResource>()
   _collectCommonMainDrawable0Resources(map)
   return@lazy map
 }
 
-public actual val Res.allStringResources: Map<String, StringResource> by lazy {
+public actual val MyRes.allStringResources: Map<String, StringResource> by lazy {
   val map = mutableMapOf<String, StringResource>()
   _collectAndroidMainString0Resources(map)
   _collectCommonMainString0Resources(map)
   return@lazy map
 }
 
-public actual val Res.allStringArrayResources: Map<String, StringArrayResource> by lazy {
+public actual val MyRes.allStringArrayResources: Map<String, StringArrayResource> by lazy {
   val map = mutableMapOf<String, StringArrayResource>()
   return@lazy map
 }
 
-public actual val Res.allPluralStringResources: Map<String, PluralStringResource> by lazy {
+public actual val MyRes.allPluralStringResources: Map<String, PluralStringResource> by lazy {
   val map = mutableMapOf<String, PluralStringResource>()
   _collectCommonMainPlurals0Resources(map)
   return@lazy map
 }
 
-public actual val Res.allFontResources: Map<String, FontResource> by lazy {
+public actual val MyRes.allFontResources: Map<String, FontResource> by lazy {
   val map = mutableMapOf<String, FontResource>()
   _collectCommonMainFont0Resources(map)
   return@lazy map

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceAccessors/my/lib/res/Drawable0.commonMain.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceAccessors/my/lib/res/Drawable0.commonMain.kt
@@ -14,25 +14,25 @@ import org.jetbrains.compose.resources.ThemeQualifier
 
 private const val MD: String = "composeResources/my.lib.res/"
 
-public val Res.drawable._3_strange_name: DrawableResource by lazy {
+public val MyRes.drawable._3_strange_name: DrawableResource by lazy {
       DrawableResource("drawable:_3_strange_name", setOf(
         ResourceItem(setOf(), "${MD}drawable/3-strange-name.xml", -1, -1),
       ))
     }
 
-public val Res.drawable.camelCaseName: DrawableResource by lazy {
+public val MyRes.drawable.camelCaseName: DrawableResource by lazy {
       DrawableResource("drawable:camelCaseName", setOf(
         ResourceItem(setOf(), "${MD}drawable/camelCaseName.xml", -1, -1),
       ))
     }
 
-public val Res.drawable.`is`: DrawableResource by lazy {
+public val MyRes.drawable.`is`: DrawableResource by lazy {
       DrawableResource("drawable:is", setOf(
         ResourceItem(setOf(), "${MD}drawable/is.xml", -1, -1),
       ))
     }
 
-public val Res.drawable.vector: DrawableResource by lazy {
+public val MyRes.drawable.vector: DrawableResource by lazy {
       DrawableResource("drawable:vector", setOf(
         ResourceItem(setOf(LanguageQualifier("ast"), ), "${MD}drawable-ast/vector.xml", -1, -1),
         ResourceItem(setOf(LanguageQualifier("au"), RegionQualifier("US"), ), "${MD}drawable-au-rUS/vector.xml", -1, -1),
@@ -42,7 +42,7 @@ public val Res.drawable.vector: DrawableResource by lazy {
       ))
     }
 
-public val Res.drawable.vector_2: DrawableResource by lazy {
+public val MyRes.drawable.vector_2: DrawableResource by lazy {
       DrawableResource("drawable:vector_2", setOf(
         ResourceItem(setOf(), "${MD}drawable/vector_2.xml", -1, -1),
       ))

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceAccessors/my/lib/res/Font0.commonMain.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceAccessors/my/lib/res/Font0.commonMain.kt
@@ -12,7 +12,7 @@ import org.jetbrains.compose.resources.ResourceItem
 
 private const val MD: String = "composeResources/my.lib.res/"
 
-public val Res.font.emptyFont: FontResource by lazy {
+public val MyRes.font.emptyFont: FontResource by lazy {
       FontResource("font:emptyFont", setOf(
         ResourceItem(setOf(LanguageQualifier("en"), ), "${MD}font-en/emptyFont.otf", -1, -1),
         ResourceItem(setOf(), "${MD}font/emptyFont.otf", -1, -1),

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceAccessors/my/lib/res/Plurals0.commonMain.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceAccessors/my/lib/res/Plurals0.commonMain.kt
@@ -11,7 +11,7 @@ import org.jetbrains.compose.resources.ResourceItem
 
 private const val MD: String = "composeResources/my.lib.res/"
 
-public val Res.plurals.numberOfSongsAvailable: PluralStringResource by lazy {
+public val MyRes.plurals.numberOfSongsAvailable: PluralStringResource by lazy {
       PluralStringResource("plurals:numberOfSongsAvailable", "numberOfSongsAvailable", setOf(
         ResourceItem(setOf(), "${MD}values/strings.commonMain.cvr", 10, 124),
       ))

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceAccessors/my/lib/res/String0.commonMain.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceAccessors/my/lib/res/String0.commonMain.kt
@@ -11,49 +11,49 @@ import org.jetbrains.compose.resources.StringResource
 
 private const val MD: String = "composeResources/my.lib.res/"
 
-public val Res.string.PascalCase: StringResource by lazy {
+public val MyRes.string.PascalCase: StringResource by lazy {
       StringResource("string:PascalCase", "PascalCase", setOf(
         ResourceItem(setOf(), "${MD}values/strings.commonMain.cvr", 172, 34),
       ))
     }
 
-public val Res.string._1_kebab_case: StringResource by lazy {
+public val MyRes.string._1_kebab_case: StringResource by lazy {
       StringResource("string:_1_kebab_case", "_1_kebab_case", setOf(
         ResourceItem(setOf(), "${MD}values/strings.commonMain.cvr", 135, 36),
       ))
     }
 
-public val Res.string.app_name: StringResource by lazy {
+public val MyRes.string.app_name: StringResource by lazy {
       StringResource("string:app_name", "app_name", setOf(
         ResourceItem(setOf(), "${MD}values/strings.commonMain.cvr", 207, 44),
       ))
     }
 
-public val Res.string.camelCase: StringResource by lazy {
+public val MyRes.string.camelCase: StringResource by lazy {
       StringResource("string:camelCase", "camelCase", setOf(
         ResourceItem(setOf(), "${MD}values/strings.commonMain.cvr", 252, 29),
       ))
     }
 
-public val Res.string.hello: StringResource by lazy {
+public val MyRes.string.hello: StringResource by lazy {
       StringResource("string:hello", "hello", setOf(
         ResourceItem(setOf(), "${MD}values/strings.commonMain.cvr", 282, 37),
       ))
     }
 
-public val Res.string.`info_using_release_$x`: StringResource by lazy {
+public val MyRes.string.`info_using_release_$x`: StringResource by lazy {
       StringResource("string:info_using_release_${'$'}x", "info_using_release_${'$'}x", setOf(
         ResourceItem(setOf(), "${MD}values/strings.commonMain.cvr", 320, 57),
       ))
     }
 
-public val Res.string.multi_line: StringResource by lazy {
+public val MyRes.string.multi_line: StringResource by lazy {
       StringResource("string:multi_line", "multi_line", setOf(
         ResourceItem(setOf(), "${MD}values/strings.commonMain.cvr", 378, 178),
       ))
     }
 
-public val Res.string.str_template: StringResource by lazy {
+public val MyRes.string.str_template: StringResource by lazy {
       StringResource("string:str_template", "str_template", setOf(
         ResourceItem(setOf(), "${MD}values/strings.commonMain.cvr", 557, 76),
       ))

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceCollectors/my/lib/res/ExpectResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonMainResourceCollectors/my/lib/res/ExpectResourceCollectors.kt
@@ -8,12 +8,12 @@ import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-public expect val Res.allDrawableResources: Map<String, DrawableResource>
+public expect val MyRes.allDrawableResources: Map<String, DrawableResource>
 
-public expect val Res.allStringResources: Map<String, StringResource>
+public expect val MyRes.allStringResources: Map<String, StringResource>
 
-public expect val Res.allStringArrayResources: Map<String, StringArrayResource>
+public expect val MyRes.allStringArrayResources: Map<String, StringArrayResource>
 
-public expect val Res.allPluralStringResources: Map<String, PluralStringResource>
+public expect val MyRes.allPluralStringResources: Map<String, PluralStringResource>
 
-public expect val Res.allFontResources: Map<String, FontResource>
+public expect val MyRes.allFontResources: Map<String, FontResource>

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonResClass/my/lib/res/MyRes.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/commonResClass/my/lib/res/MyRes.kt
@@ -14,11 +14,11 @@ import org.jetbrains.compose.resources.InternalResourceApi
 import org.jetbrains.compose.resources.getResourceUri
 import org.jetbrains.compose.resources.readResourceBytes
 
-public object Res {
+public object MyRes {
   /**
    * Reads the content of the resource file at the specified path and returns it as a byte array.
    *
-   * Example: `val bytes = Res.readBytes("files/key.bin")`
+   * Example: `val bytes = MyRes.readBytes("files/key.bin")`
    *
    * @param path The path of the file to read in the compose resource's directory.
    * @return The content of the file as a byte array.
@@ -28,7 +28,7 @@ public object Res {
   /**
    * Returns the URI string of the resource file at the specified path.
    *
-   * Example: `val uri = Res.getUri("files/key.bin")`
+   * Example: `val uri = MyRes.getUri("files/key.bin")`
    *
    * @param path The path of the file in the compose resource's directory.
    * @return The URI string of the file.

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/desktopMainResourceAccessors/my/lib/res/String0.desktopMain.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/desktopMainResourceAccessors/my/lib/res/String0.desktopMain.kt
@@ -11,7 +11,7 @@ import org.jetbrains.compose.resources.StringResource
 
 private const val MD: String = "composeResources/my.lib.res/"
 
-public val Res.string.desktop_str: StringResource by lazy {
+public val MyRes.string.desktop_str: StringResource by lazy {
       StringResource("string:desktop_str", "desktop_str", setOf(
         ResourceItem(setOf(), "${MD}values/desktop_strings.desktopMain.cvr", 10, 39),
       ))

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/desktopMainResourceCollectors/my/lib/res/ActualResourceCollectors.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/expected-open-res/desktopMainResourceCollectors/my/lib/res/ActualResourceCollectors.kt
@@ -11,31 +11,31 @@ import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringArrayResource
 import org.jetbrains.compose.resources.StringResource
 
-public actual val Res.allDrawableResources: Map<String, DrawableResource> by lazy {
+public actual val MyRes.allDrawableResources: Map<String, DrawableResource> by lazy {
   val map = mutableMapOf<String, DrawableResource>()
   _collectCommonMainDrawable0Resources(map)
   return@lazy map
 }
 
-public actual val Res.allStringResources: Map<String, StringResource> by lazy {
+public actual val MyRes.allStringResources: Map<String, StringResource> by lazy {
   val map = mutableMapOf<String, StringResource>()
   _collectDesktopMainString0Resources(map)
   _collectCommonMainString0Resources(map)
   return@lazy map
 }
 
-public actual val Res.allStringArrayResources: Map<String, StringArrayResource> by lazy {
+public actual val MyRes.allStringArrayResources: Map<String, StringArrayResource> by lazy {
   val map = mutableMapOf<String, StringArrayResource>()
   return@lazy map
 }
 
-public actual val Res.allPluralStringResources: Map<String, PluralStringResource> by lazy {
+public actual val MyRes.allPluralStringResources: Map<String, PluralStringResource> by lazy {
   val map = mutableMapOf<String, PluralStringResource>()
   _collectCommonMainPlurals0Resources(map)
   return@lazy map
 }
 
-public actual val Res.allFontResources: Map<String, FontResource> by lazy {
+public actual val MyRes.allFontResources: Map<String, FontResource> by lazy {
   val map = mutableMapOf<String, FontResource>()
   _collectCommonMainFont0Resources(map)
   return@lazy map


### PR DESCRIPTION
Gradle Plugin DSL to change the generated Res class name:

```kotlin
compose.resources {
    nameOfResClass = "MyRes"
}
```

Fixes [CMP-7341](https://youtrack.jetbrains.com/issue/CMP-7341) Support generating custom resource class name
## Testing
Integration tests.

## Release Notes
### Features - Resources
- Gradle Plugin DSL to change the generated Res class name
