### PR TITLE
CMP-7607: drop CMP-4848 workaround

### DIFF
--- a/examples/jetsnack/common/src/nonAndroidMain/kotlin/com/example/jetsnack/ui/MppJetsnackAppState.kt
+++ b/examples/jetsnack/common/src/nonAndroidMain/kotlin/com/example/jetsnack/ui/MppJetsnackAppState.kt
@@ -6,11 +6,8 @@ import androidx.compose.runtime.*
 import com.example.jetsnack.model.SnackbarManager
 import com.example.jetsnack.ui.home.HomeSections
 import kotlinx.coroutines.CoroutineScope
-import kotlin.native.HiddenFromObjC
 
 @Stable
-@OptIn(kotlin.experimental.ExperimentalObjCRefinement::class)
-@HiddenFromObjC // Remove after the bug is fixed: https://github.com/JetBrains/compose-multiplatform/issues/4848
 actual class MppJetsnackAppState(
     actual val scaffoldState: ScaffoldState,
     actual val snackbarManager: SnackbarManager,

--- a/examples/jetsnack/common/src/nonAndroidMain/kotlin/com/example/jetsnack/ui/home/cart/CartViewModel.nonAndroid.kt
+++ b/examples/jetsnack/common/src/nonAndroidMain/kotlin/com/example/jetsnack/ui/home/cart/CartViewModel.nonAndroid.kt
@@ -5,10 +5,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import com.example.jetsnack.model.OrderLine
 import kotlinx.coroutines.flow.StateFlow
-import kotlin.native.HiddenFromObjC
 
-@OptIn(kotlin.experimental.ExperimentalObjCRefinement::class)
-@HiddenFromObjC // Remove after the bug is fixed: https://github.com/JetBrains/compose-multiplatform/issues/4848
 actual abstract class JetSnackCartViewModel actual constructor()  {
 
     @Composable

--- a/examples/jetsnack/gradle.properties
+++ b/examples/jetsnack/gradle.properties
@@ -2,5 +2,5 @@ org.gradle.jvmargs=-Xmx8g
 kotlin.code.style=official
 android.useAndroidX=true
 agp.version=8.5.0
-kotlin.version=2.1.0
+kotlin.version=2.1.20
 compose.version=1.7.3


### PR DESCRIPTION
also update kotlin version (gradle.properties)

dropped [CMP-4848](https://youtrack.jetbrains.com/issue/CMP-4848) workaround, updated kotlin version for jetsnack example project

Fixes [CMP-7607]

## Testing
build jetsnack project

## Release Notes
N/A
