### PR TITLE
Changelog fixes for 1.8

### DIFF
--- a/tools/changelog/changelog.main.kts
+++ b/tools/changelog/changelog.main.kts
@@ -584,7 +584,7 @@ fun requestPlain(url: String): String = exponentialRetry {
     val connection = URL(url).openConnection()
     connection.setRequestProperty("User-Agent", "Compose-Multiplatform-Script")
     if (token != null) {
-        connection.setRequestProperty("Authorization", "Bearer $token")
+        connection.setRequestProperty("Authorization", if (token.startsWith("github_pat")) token else "Bearer $token")
     }
     connection.getInputStream().use {
         it.bufferedReader().readText()

--- a/tools/changelog/changelog.main.kts
+++ b/tools/changelog/changelog.main.kts
@@ -468,7 +468,7 @@ fun spaceContentOf(repoUrl: String, path: String, tagName: String): String {
  */
 fun gitLogShas(folder: File, firstCommit: String, lastCommit: String, additionalArgs: String): List<String> {
     val absolutePath = folder.absolutePath
-    val commits = pipeProcess("git -C $absolutePath log --oneline --format=\"%H\" $additionalArgs $firstCommit...$lastCommit").
+    val commits = pipeProcess("git -C $absolutePath log --oneline --format=%H $additionalArgs $firstCommit...$lastCommit").
             readText()
     return commits.split("\n")
 }

--- a/tools/changelog/changelog.main.kts
+++ b/tools/changelog/changelog.main.kts
@@ -334,6 +334,7 @@ fun extractReleaseNotes(body: String?, prNumber: Int, prLink: String): ReleaseNo
     var section: String? = null
     var subsection: String? = null
     var isFirstLine = true
+    var isPrerelease = false
 
     for (line in relNoteBody.split("\n")) {
         // parse "## Section - Subsection"
@@ -342,6 +343,7 @@ fun extractReleaseNotes(body: String?, prNumber: Int, prLink: String): ReleaseNo
             section = s.substringBefore("-", "").trim().normalizeSectionName().ifEmpty { null }
             subsection = s.substringAfter("-", "").trim().normalizeSubsectionName().ifEmpty { null }
             isFirstLine = true
+            isPrerelease = false
         } else if (section != null && line.isNotBlank()) {
             var lineFixed = line
 
@@ -354,7 +356,9 @@ fun extractReleaseNotes(body: String?, prNumber: Int, prLink: String): ReleaseNo
             lineFixed = lineFixed.trimEnd().removeSuffix(".")
 
             val isTopLevel = lineFixed.startsWith("-")
-            val isPrerelease = isTopLevel && lineFixed.contains("(prerelease fix)")
+            if (isTopLevel) {
+                isPrerelease = lineFixed.contains("(prerelease fix)")
+            }
             list.add(
                 ChangelogEntry(
                     lineFixed,

--- a/tools/changelog/changelog.main.kts
+++ b/tools/changelog/changelog.main.kts
@@ -184,7 +184,11 @@ fun generateChangelog() {
                             appendLine("### $subsection")
                             appendLine()
                             subsectionEntries.forEach {
-                                appendLine(it.run { "$message [#$prNumber]($link)" })
+                                if (it.link != null) {
+                                    appendLine(it.run { "$message [#$prNumber]($link)" })
+                                } else {
+                                    appendLine(it.message)
+                                }
                             }
                             appendLine()
                         }
@@ -327,7 +331,6 @@ fun extractReleaseNotes(body: String?, prNumber: Int, prLink: String): ReleaseNo
     var section: String? = null
     var subsection: String? = null
     var isFirstLine = true
-    var shouldPadLines = false
 
     for (line in relNoteBody.split("\n")) {
         // parse "## Section - Subsection"
@@ -336,15 +339,13 @@ fun extractReleaseNotes(body: String?, prNumber: Int, prLink: String): ReleaseNo
             section = s.substringBefore("-", "").trim().normalizeSectionName().ifEmpty { null }
             subsection = s.substringAfter("-", "").trim().normalizeSubsectionName().ifEmpty { null }
             isFirstLine = true
-            shouldPadLines = false
         } else if (section != null && line.isNotBlank()) {
             var lineFixed = line
 
             if (isFirstLine && !lineFixed.startsWith("-")) {
                 lineFixed = "- $lineFixed"
-                shouldPadLines = true
             }
-            if (!isFirstLine && shouldPadLines) {
+            if (!isFirstLine && !lineFixed.startsWithAny("  ", "-")) {
                 lineFixed = "  $lineFixed"
             }
             lineFixed = lineFixed.trimEnd().removeSuffix(".")

--- a/tools/changelog/changelog.main.kts
+++ b/tools/changelog/changelog.main.kts
@@ -447,7 +447,7 @@ fun androidxLibToVersion(commit: String): Map<String, String> {
     val libraryKt = spaceContentOf(repo, file, commit)
 
     return if (libraryKt.isBlank()) {
-        println("Can't clone $repo to know library versions. Please register your ssh key in https://jetbrains.team/m/me/authentication?tab=GitKeys")
+        println("Can't find library versions in $repo for $commit. Either the format is changed, or you need to register your ssh key in https://jetbrains.team/m/me/authentication?tab=GitKeys")
         emptyMap()
     } else {
         val regex = Regex("Library\\.(.*)\\s*->\\s*\"(.*)\"")


### PR DESCRIPTION
- identify cherry-picks
  - via "git log --cherry-pick" (we have to clone repos for that)
  - in case it doesn't work, additionally identified via "cherry-picked from" in PR descriptions
 - fix multiline changes formatting
 - exclude prerelease fixes

## Release Notes
N/A