### PR TITLE
Bundle kotlinx serialization ProGuard rules into the Compose plugin

### DIFF
--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -13,7 +13,6 @@
 
 # Kotlinx Coroutines Rules
 # https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
-
 -keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
 -keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
 -keepclassmembers class kotlinx.coroutines.** {
@@ -68,3 +67,43 @@
 -keep,allowshrinking,allowobfuscation class androidx.compose.runtime.SnapshotStateKt__DerivedStateKt { *; }
 -keep class androidx.compose.material3.SliderDefaults { *; }
 -dontnote androidx.**
+
+# Kotlinx serialization, included by androidx.navigation
+# https://github.com/Kotlin/kotlinx.serialization/blob/master/rules/common.pro
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$* Companion;
+}
+-keepnames @kotlinx.serialization.internal.NamedCompanion class *
+-if @kotlinx.serialization.internal.NamedCompanion class *
+-keepclassmembernames class * {
+    static <1> *;
+}
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+# Keep `INSTANCE.serializer()` of serializable objects.
+-if @kotlinx.serialization.Serializable class ** {
+    public static ** INSTANCE;
+}
+-keepclassmembers class <1> {
+    public static <1> INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+-dontnote kotlinx.serialization.**
+-dontwarn kotlinx.serialization.internal.ClassValueReferences
+-keepclassmembers public class **$$serializer {
+    private ** descriptor;
+}
+
+# Kotlinx serialization, additional rules
+# Fixes:
+#   Exception in thread "main" kotlinx.serialization.SerializationException: Serializer for class 'SomeClass' is not found.
+#   Please ensure that class is marked as '@Serializable' and that the serialization compiler plugin is applied.
+-keep class **$$serializer {
+    *;
+}


### PR DESCRIPTION
When users use `androidx.navigation`, they see `@Serialization` annotation they can use, without explictly adding `kotlinx.serialization`. They see, because it is added as an `api` dependency.

The Compose Gradle plugin on the other hand provide `./gradlew runRelease` task that uses ProGuard to minify binaries. Because the plugin should support not only Compose, but also all support libraries (androidx, components), we should bundle serialization ProGuard rules into it.

Fixes https://youtrack.jetbrains.com/issue/CMP-8050

## Testing
```
import androidx.compose.ui.window.singleWindowApplication
import androidx.navigation.compose.NavHost
import androidx.navigation.compose.composable
import androidx.navigation.compose.rememberNavController

fun main() = singleWindowApplication {
    NavHost(
        navController = rememberNavController(),
        startDestination = LoginRoute()
    ) {
        composable<LoginRoute> {}
    }
}

sealed interface Route

@kotlinx.serialization.Serializable
data class LoginRoute(val id: Long? = null) : Route
```
Doesn't crash when run `./gradlew runRelease`

## Release Notes
### Fixes - Desktop
- Fix "Serializer for class is not found" using `androidx.navigation` and running `./gradlew runRelease`
- `kotlinx.serialization` ProGuard rules are bundled in the Compose Gradle plugin