### PR TITLE
Fix com.jetbrains.JBR: can't find referenced method

### DIFF
--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -68,3 +68,6 @@
 -keep,allowshrinking,allowobfuscation class androidx.compose.runtime.SnapshotStateKt__DerivedStateKt { *; }
 -keep class androidx.compose.material3.SliderDefaults { *; }
 -dontnote androidx.**
+
+# org.jetbrains.runtime:jbr-api
+-dontwarn com.jetbrains.JBR


### PR DESCRIPTION
After https://github.com/JetBrains/compose-multiplatform-core/pull/2097 is merged, CI fails with:
```
Warning: com.jetbrains.JBR: can't find referenced method 'java.lang.Object invokeExact(java.lang.Class,java.lang.Class,java.lang.Class,java.lang.Class,java.util.Map,java.util.function.Function)' in library class java.lang.invoke.MethodHandle
Warning: com.jetbrains.JBR: can't find referenced method 'java.lang.Object invokeExact(java.lang.invoke.MethodHandles$Lookup)' in library class java.lang.invoke.MethodHandle
<============-> 96% EXECUTING [3s]                                           Warning: there were 2 unresolved references to library class members.aseJars
         You probably need to update the library versions.-crash-in-the-field
         (https://www.guardsquare.com/proguard/manual/troubleshooting#unresolvedlibraryclassmember)
Unexpected error
java.io.IOException: Please correct the above warnings first.
```

During Gradle tests.

## Testing
Tests for Gradle plugin pass

## Release Notes
### Fixes - Desktop
N/A