### PR TITLE
Replace `KotlinPlatformType` check with `KotlinJvmTarget` in JVM target configuration.

### DIFF
--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     compileOnly(gradleApi())
     compileOnly(localGroovy())
     //the version supports XCFramework with resources https://youtrack.jetbrains.com/issue/KT-75823
-    compileOnly(kotlin("gradle-plugin", "2.2.0-Beta2-1"))
+    compileOnly(kotlin("gradle-plugin", "2.2.0-RC2"))
     compileOnly(kotlin("native-utils"))
     compileOnly(libs.plugin.android)
     compileOnly(libs.plugin.android.api)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/JvmApplicationContext.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/JvmApplicationContext.kt
@@ -13,9 +13,9 @@ import org.jetbrains.compose.desktop.application.dsl.JvmApplicationBuildType
 import org.jetbrains.compose.internal.KOTLIN_JVM_PLUGIN_ID
 import org.jetbrains.compose.internal.KOTLIN_MPP_PLUGIN_ID
 import org.jetbrains.compose.internal.javaSourceSets
-import org.jetbrains.compose.internal.utils.joinDashLowercaseNonEmpty
 import org.jetbrains.compose.internal.mppExt
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.compose.internal.utils.joinDashLowercaseNonEmpty
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 internal data class JvmApplicationContext(
     val project: Project,
@@ -56,7 +56,7 @@ internal data class JvmApplicationContext(
         if (project.plugins.hasPlugin(KOTLIN_MPP_PLUGIN_ID)) {
             var isJvmTargetConfigured = false
             project.mppExt.targets.all { target ->
-                if (target.platformType == KotlinPlatformType.jvm) {
+                if (target is KotlinJvmTarget) {
                     if (!isJvmTargetConfigured) {
                         appInternal.from(target)
                         isJvmTargetConfigured = true

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.compose.resources
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidTarget
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.HasAndroidTest
 import com.android.build.api.variant.KotlinMultiplatformAndroidComponentsExtension
@@ -123,15 +123,16 @@ private fun Project.getAndroidKmpComponentComposeResources(
     kotlinExtension: KotlinMultiplatformExtension,
     componentName: String
 ): FileCollection = project.files({
-    kotlinExtension.targets.withType(KotlinMultiplatformAndroidTarget::class.java).flatMap { androidTarget ->
-        androidTarget.compilations.flatMap { compilation ->
-            if (compilation.componentName == componentName) {
-                compilation.allKotlinSourceSets.map { kotlinSourceSet ->
-                    getPreparedComposeResourcesDir(kotlinSourceSet)
-                }
-            } else emptyList()
+    kotlinExtension.targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java)
+        .flatMap { androidTarget ->
+            androidTarget.compilations.flatMap { compilation ->
+                if (compilation.componentName == componentName) {
+                    compilation.allKotlinSourceSets.map { kotlinSourceSet ->
+                        getPreparedComposeResourcesDir(kotlinSourceSet)
+                    }
+                } else emptyList()
+            }
         }
-    }
 })
 
 private fun Project.configureGeneratedAndroidComponentAssets(

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -718,7 +718,7 @@ class ResourcesTest : GradlePluginTestBase() {
         with(
             testProject(
                 "misc/appleResources",
-                defaultTestEnvironment.copy(kotlinVersion = "2.2.0-Beta2-1"))
+                defaultTestEnvironment.copy(kotlinVersion = "2.2.0-RC2"))
         ) {
             file("build.gradle.kts").modify { content ->
                 """
@@ -871,7 +871,7 @@ class ResourcesTest : GradlePluginTestBase() {
         with(
             testProject(
                 "misc/appleResources",
-                defaultTestEnvironment.copy(kotlinVersion = "2.2.0-Beta2-1"))
+                defaultTestEnvironment.copy(kotlinVersion = "2.2.0-RC2"))
         ) {
             gradle(":podPublishDebugXCFramework").checks {
                 assertDirectoriesContentEquals(

--- a/gradle-plugins/compose/src/test/test-projects/misc/newAgpResources/featureModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/newAgpResources/featureModule/build.gradle.kts
@@ -24,3 +24,8 @@ kotlin {
         }
     }
 }
+
+//https://youtrack.jetbrains.com/issue/CMP-8325
+compose.desktop {
+    application { }
+}

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.0-Beta1"
+kotlin = "2.2.0-RC2"
 gradle-download-plugin = "5.5.0"
 kotlin-poet = "2.1.0"
 plugin-android = "8.9.1"


### PR DESCRIPTION
Problem is the new AGP androidLibrary target has `platformType == KotlinPlatformType.jvm` as well.

Fixes https://youtrack.jetbrains.com/issue/CMP-8325 

## Testing
Unit tests

## Release Notes
N/A