### PR TITLE
Don't fail gradle sync if TargetFormat.AppImage is used on macOS

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -181,10 +181,6 @@ private fun JvmApplicationContext.configurePackagingTasks(
         }
 
         if (targetFormat.isCompatibleWith(OS.MacOS)) {
-            check(targetFormat == TargetFormat.Dmg || targetFormat == TargetFormat.Pkg) {
-                "Unexpected target format for MacOS: $targetFormat"
-            }
-
             tasks.register<AbstractNotarizationTask>(
                 taskNameAction = "notarize",
                 taskNameObject = targetFormat.name,


### PR DESCRIPTION
Currently, gradle sync fails on macOS if `TargetFormat.AppImage` is present in `targetFormats`.
Note that this PR removes the check entirely, as the list of target formats should not be validated at gradle sync.
There is no corresponding check for e.g. `TargetFormat.Dmg` on Windows.

## Testing
No testing needed.

## Release Notes
### Fixes - Gradle Plugin
- Don't fail gradle sync if TargetFormat.AppImage is specified in `targetFormats` on macOS.
