### PR TITLE
KMT-599: Expose some of the preview parameters from androidx's Preview annotation

### DIFF
--- a/components/ui-tooling-preview/library/src/commonMain/kotlin/org/jetbrains/compose/ui/tooling/preview/Preview.kt
+++ b/components/ui-tooling-preview/library/src/commonMain/kotlin/org/jetbrains/compose/ui/tooling/preview/Preview.kt
@@ -18,16 +18,32 @@ package org.jetbrains.compose.ui.tooling.preview
 
 /**
  * [Preview] can be applied to either of the following:
- * - @[Composable] methods with no parameters to show them in the IDE preview.
+ * - @[Composable] methods with no parameters to show them in the Android Studio preview.
  * - Annotation classes, that could then be used to annotate @[Composable] methods or other
- * annotation classes, which will then be considered as indirectly annotated with that [Preview].
+ *   annotation classes, which will then be considered as indirectly annotated with that [Preview].
+ *
+ * The annotation contains a number of parameters that allow to define the way the @[Composable]
+ * will be rendered within the preview.
+ *
+ * The passed parameters are only read by Studio when rendering the preview.
+ *
+ * @param name Display name of this preview allowing to identify it in the panel.
+ * @param group Group name for this @[Preview]. This allows grouping them in the UI and display only
+ *   one or more of them.
+ * @param widthDp Max width in DP the annotated @[Composable] will be rendered in. Use this to
+ *   restrict the size of the rendering viewport.
+ * @param heightDp Max height in DP the annotated @[Composable] will be rendered in. Use this to
+ *   restrict the size of the rendering viewport.
+ * @param locale Current user preference for the locale, corresponding to
+ *   [locale](https://d.android.com/guide/topics/resources/providing-resources.html#LocaleQualifier)
+ *   resource qualifier. By default, the `default` folder will be used. To preview an RTL layout use
+ *   a locale that uses right to left script, such as `ar` (or the `ar-rXB` pseudo locale).
+ * @param showBackground If true, the @[Composable] will use a default background color.
+ * @param backgroundColor The 32-bit ARGB color int for the background or 0 if not set
  */
 @MustBeDocumented
 @Retention(AnnotationRetention.BINARY)
-@Target(
-    AnnotationTarget.ANNOTATION_CLASS,
-    AnnotationTarget.FUNCTION
-)
+@Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FUNCTION)
 @Repeatable
 annotation class Preview(
     val name: String = "",


### PR DESCRIPTION
Exposed the following Preview annotation parameters:
- name
- group
- widthDp
- heightDp
- locale
- showBackground
- backgroundColor

## Testing
Tested the local artifact in IJ: new parameters are exposed and picked up. No additional changes on the IDE end are required.

But this should be tested by QA, of course.

## Release Notes
### Features - Multiple Platforms
- Extended the `@Preview` (`org.jetbrains.compose.ui.tooling.preview`) annotation with the following parameters: name, group, widthDp, heightDp, locale, showBackground, backgroundColor. IDE (IJ or AS) will pick up these parameters in the same way it works for `androidx` Preview annotations.