### PR TITLE
Allow having k/js target without setting org.jetbrains.compose.experimental.jscanvas.enabled=true

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/checkExperimentalTargets.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/internal/checkExperimentalTargets.kt
@@ -27,7 +27,6 @@ private val TargetType.gradlePropertyName get() = "org.jetbrains.compose.experim
 
 private val EXPERIMENTAL_TARGETS: Set<TargetType> = setOf(
     TargetType("macos", identifiers = listOf("macosX64", "macosArm64")),
-    TargetType("jscanvas", identifiers = listOf("jsIr", "js")),
 )
 
 private sealed interface CheckResult {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -35,17 +35,6 @@ class GradlePluginTest : GradlePluginTestBase() {
             defaultTestEnvironment.copy(useGradleConfigurationCache = false)
         )
     ) {
-        fun jsCanvasEnabled(value: Boolean) {
-            modifyGradleProperties { put("org.jetbrains.compose.experimental.jscanvas.enabled", value.toString()) }
-
-        }
-
-        jsCanvasEnabled(false)
-        gradleFailure(":build").checks {
-            check.logContains("ERROR: Compose targets '[jscanvas]' are experimental and may have bugs!")
-        }
-
-        jsCanvasEnabled(true)
         gradle(":build").checks {
             check.taskSuccessful(":unpackSkikoWasmRuntime")
             check.taskSuccessful(":processSkikoRuntimeForKWasm")


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8425

## Testing
Updated the relevant test

## Release Notes
### Highlights - Web
- Setting `org.jetbrains.compose.experimental.jscanvas.enabled=true` is not required anymore when having a kotlin/js target
