### PR TITLE
use maven local artifacts for teamcity test runs

### DIFF
--- a/compose/integrations/composable-test-cases/README.MD
+++ b/compose/integrations/composable-test-cases/README.MD
@@ -1,10 +1,10 @@
 ## Run:
 
-`./gradlew build -Pkotlin_version=2.1.21`
+`./gradlew build -Pkotlin.version=2.1.21`
 to build and run the tests,
 
 or
-`./gradlew allTests -Pkotlin_version=2.1.21`
+`./gradlew allTests -Pkotlin.version=2.1.21`
 to only run the tests.
 
 It will build and run the tests for all available targets (depends on a host machine).

--- a/compose/integrations/composable-test-cases/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/build.gradle.kts
@@ -20,8 +20,8 @@ allprojects {
 
         maven("https://packages.jetbrains.team/maven/p/kt/dev")
         maven("https://redirector.kotlinlang.org/maven/dev")
-        if (providers.gradleProperty("kotlin_version").orNull == "true") {
-            mavenLocal()
+        maven {
+            url = uri("${rootDir}/build/maven-project")
         }
     }
 

--- a/compose/integrations/composable-test-cases/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/build.gradle.kts
@@ -1,6 +1,4 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 //group "com.example"
 //version "1.0-SNAPSHOT"
@@ -22,7 +20,9 @@ allprojects {
 
         maven("https://packages.jetbrains.team/maven/p/kt/dev")
         maven("https://redirector.kotlinlang.org/maven/dev")
-//        mavenLocal()
+        if (System.getenv("TEAMCITY_VERSION") != null) {
+            mavenLocal()
+        }
     }
 
     disableYarnLockMismatchReport()

--- a/compose/integrations/composable-test-cases/build.gradle.kts
+++ b/compose/integrations/composable-test-cases/build.gradle.kts
@@ -20,7 +20,7 @@ allprojects {
 
         maven("https://packages.jetbrains.team/maven/p/kt/dev")
         maven("https://redirector.kotlinlang.org/maven/dev")
-        if (System.getenv("TEAMCITY_VERSION") != null) {
+        if (providers.gradleProperty("kotlin_version").orNull == "true") {
             mavenLocal()
         }
     }

--- a/compose/integrations/composable-test-cases/gradle/libs.versions.toml
+++ b/compose/integrations/composable-test-cases/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin="2.1.21" # should be provided via `-Pkotlin_version=<kotlin version to test with>`
+kotlin="2.1.21" # should be provided via `-Pkotlin.version=<kotlin version to test with>`
 kotlinx-coroutines = "1.8.0"
 compose = "1.8.1"
 

--- a/compose/integrations/composable-test-cases/settings.gradle.kts
+++ b/compose/integrations/composable-test-cases/settings.gradle.kts
@@ -7,8 +7,8 @@ pluginManagement {
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         maven("https://packages.jetbrains.team/maven/p/kt/dev")
         maven("https://redirector.kotlinlang.org/maven/dev")
-        if (providers.gradleProperty("kotlin_version").orNull == "true") {
-            mavenLocal()
+        maven {
+            url = uri("${rootDir}/build/maven-project")
         }
     }
 }

--- a/compose/integrations/composable-test-cases/settings.gradle.kts
+++ b/compose/integrations/composable-test-cases/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         maven("https://packages.jetbrains.team/maven/p/kt/dev")
         maven("https://redirector.kotlinlang.org/maven/dev")
-        if (System.getenv("TEAMCITY_VERSION") != null) {
+        if (providers.gradleProperty("kotlin_version").orNull == "true") {
             mavenLocal()
         }
     }

--- a/compose/integrations/composable-test-cases/settings.gradle.kts
+++ b/compose/integrations/composable-test-cases/settings.gradle.kts
@@ -16,7 +16,7 @@ pluginManagement {
 dependencyResolutionManagement {
     versionCatalogs {
         register("libs").configure {
-            val kotlinVersion = providers.gradleProperty("kotlin_version").orNull
+            val kotlinVersion = providers.gradleProperty("kotlin.version").orNull
             if (kotlinVersion != null) {
                 version("kotlin", kotlinVersion)
 //                println("kotlin version applied: $kotlinVersion")

--- a/compose/integrations/composable-test-cases/settings.gradle.kts
+++ b/compose/integrations/composable-test-cases/settings.gradle.kts
@@ -7,21 +7,13 @@ pluginManagement {
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
         maven("https://packages.jetbrains.team/maven/p/kt/dev")
         maven("https://redirector.kotlinlang.org/maven/dev")
-//        mavenLocal()
+        if (System.getenv("TEAMCITY_VERSION") != null) {
+            mavenLocal()
+        }
     }
 }
 
 dependencyResolutionManagement {
-    repositories {
-        google()
-        mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
-        maven("https://packages.jetbrains.team/maven/p/kt/dev")
-        maven("https://redirector.kotlinlang.org/maven/dev")
-//        mavenLocal()
-    }
-
     versionCatalogs {
         register("libs").configure {
             val kotlinVersion = providers.gradleProperty("kotlin_version").orNull


### PR DESCRIPTION
instead of relying on maven publications for compose compiler test runs, rely on kotlin builds via "artifact" dependency
artifacts from those kotlin builds should be placed in maven local (done on teamcity config side)

## Release Notes
N/A