### PR TITLE
Benchmarks k/wasm d8: Add a polyfill for window.isSecureContext 

### DIFF
--- a/benchmarks/multiplatform/benchmarks/src/wasmJsMain/resources/polyfills.mjs
+++ b/benchmarks/multiplatform/benchmarks/src/wasmJsMain/resources/polyfills.mjs
@@ -11,6 +11,9 @@ if (!globalThis.navigator.languages) {
     globalThis.navigator.platform = "MacIntel";
 }
 
+// Compose reads `window.isSecureContext` in its Clipboard feature:
+globalThis.isSecureContext = false;
+
 if (!globalThis.gc) {
     // No GC control in D8
     globalThis.gc = () => {

--- a/benchmarks/multiplatform/gradle/libs.versions.toml
+++ b/benchmarks/multiplatform/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-compose-multiplatform = "1.8.0-beta01"
+compose-multiplatform = "1.8.1"
 kotlin = "2.1.20"
 kotlinx-coroutines = "1.8.0"
 kotlinx-serialization = "1.8.0"


### PR DESCRIPTION
CMP 1.8.0 started using one more Web API, and D8 environment doesn't have it, so we polyfill it.

## Testing
N/A

## Release Notes
N/A
