### PR TITLE
Fix Maven Central API uploading

### DIFF
--- a/ci/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/UploadToSonatypeTask.kt
+++ b/ci/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/UploadToSonatypeTask.kt
@@ -79,13 +79,15 @@ abstract class UploadToSonatypeTask : DefaultTask() {
 
         ZipOutputStream(FileOutputStream(zipFile)).use { zipOut ->
             val sourcesToDestinations = modules.map { it.localDir to it.mavenDirectory() }
+            val addedEntries = mutableSetOf<String>()
 
             for ((sourceDir, destDir) in sourcesToDestinations) {
                 val files = sourceDir.listFiles() ?: continue
 
                 for (file in files) {
-                    if (file.isFile) {
-                        val entryPath = "$destDir/${file.name}"
+                    val entryPath = "$destDir/${file.name}"
+                    if (file.isFile && !addedEntries.contains(entryPath)) {
+                        addedEntries.add(entryPath)
                         val entry = ZipEntry(entryPath)
                         zipOut.putNextEntry(entry)
                         file.inputStream().use { input ->


### PR DESCRIPTION
Fix Maven Central API uploading

Fixes
```
java.util.zip.ZipException: duplicate entry: org/jetbrains/compose/material/material-navigation/1.9.0-alpha03/material-navigation-1.9.0-alpha03.module.sha512
16:53:22    at org.jetbrains.compose.internal.publishing.UploadToSonatypeTask.createDeploymentBundle(UploadToSonatypeTask.kt:90)
```

It happened because we call `-Pmaven.central.coordinates=org.jetbrains.compose*:*:1.9.0-alpha03,org.jetbrains.compose.material:material-navigation*:1.9.0-alpha03`

which points to intersected artifacts. When we add `org.jetbrains.compose.material:material-navigation*` into the bundle, we already added it by `org.jetbrains.compose*:*`. This is [a known issue](https://youtrack.jetbrains.com/issue/CMP-8504/Maven-Central-uploading.-Intersection-of-version-groups)

## Testing
```
./gradlew -p=cli reuploadArtifactsToMavenCentral --info --stacktrace -Pmaven.central.sign=true -Pmaven.central.coordinates=org.jetbrains.compose*:*:1.9.0-alpha03,org.jetbrains.compose.material:material-navigation*:1.9.0-alpha03,org.jetbrains.compose.material3.adaptive:*:1.2.0-alpha03,org.jetbrains.androidx.graphics:graphics-shape*:1.0.0-alpha09,org.jetbrains.androidx.window:*:1.4.0-alpha08 -Pmaven.central.deployName="Compose 1.9.0-alpha03 and associated libs" --rerun-tasks
```
with disabled signing and uploading to Maven no longer produces the error

## Release Notes
N/A