### PR TITLE
Fix macOs "could not find certificate"

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/MacSigner.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/MacSigner.kt
@@ -75,8 +75,10 @@ internal class MacSignerImpl(
                     "find-certificate",
                     "-a",
                     "-c",
-                    settings.fullDeveloperID,
-                    settings.keychain?.absolutePath
+                    "\"${settings.fullDeveloperID}\"",
+                    settings.keychain?.absolutePath?.let { 
+                        "\"$it\""
+                    }
                 ),
                 processStdout = { signKeyValue = matchCertificates(it) }
             )


### PR DESCRIPTION
surround commandline arguments with quotes
see https://youtrack.jetbrains.com/issue/CMP-4272/createDistributable-signing-failing-on-macOs-with-Could-not-find-certificate#focus=Comments-27-12309226.0-0

Describe proposed changes and the issue being fixed

Fixes https://youtrack.jetbrains.com/issue/CMP-4272/createDistributable-signing-failing-on-macOs-with-Could-not-find-certificate

## Release Notes
### Fixes - Desktop
- Surround commandline arguments of macOs' "find-certificate" with double quotes
