### PR TITLE
Hardcode Material3 to stable

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -69,8 +69,8 @@ abstract class ComposePlugin : Plugin<Project> {
         val animationGraphics get() = composeDependency("org.jetbrains.compose.animation:animation-graphics")
         val foundation get() = composeDependency("org.jetbrains.compose.foundation:foundation")
         val material get() = composeDependency("org.jetbrains.compose.material:material")
-        val material3 get() = composeDependency("org.jetbrains.compose.material3:material3")
-        val material3AdaptiveNavigationSuite get() = composeDependency("org.jetbrains.compose.material3:material3-adaptive-navigation-suite")
+        val material3 get() = "org.jetbrains.compose.material3:material3:1.8.2"
+        val material3AdaptiveNavigationSuite get() = "org.jetbrains.compose.material3:material3-adaptive-navigation-suite:1.8.2"
         val runtime get() = composeDependency("org.jetbrains.compose.runtime:runtime")
         val runtimeSaveable get() = composeDependency("org.jetbrains.compose.runtime:runtime-saveable")
         val ui get() = composeDependency("org.jetbrains.compose.ui:ui")


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8527/Hardcode-material3-alias-to-the-stable-version

## Release Notes
### Migration Notes - Multiple Platforms
- Material3 versioning is decoupled for the Compose Multiplatform 1.9.* release due the upstream Jetpack Compose Material3 1.4 has not been released as stable yet
- `compose.material3` now points to the latest stable Material3 version, 1.8.2. If the latest Material3 features are needed, please include it this way:
```
implementation("org.jetbrains.compose.material3:material3:1.9.0-beta06")
```