### PR TITLE
Fix Maven Project test template (add -Dcompose.material3.version=)

### DIFF
--- a/ci/templates/maven-test-project/README.md
+++ b/ci/templates/maven-test-project/README.md
@@ -1,5 +1,5 @@
 The purpose of this test project is to check if Compose Multiplatform is resolvable via pom files, which are used by JPS, which is used by IntelliJ
 
 ```
-./check.sh -Dkotlin.version=2.1.0 -Dcompose.version=1.8.0-alpha02
+./check.sh -Dkotlin.version=2.1.0 -Dcompose.version=1.8.0-alpha02 -Dcompose.material3.version=1.8.0-alpha02
 ```

--- a/ci/templates/maven-test-project/pom.xml
+++ b/ci/templates/maven-test-project/pom.xml
@@ -14,6 +14,7 @@
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
         <kotlin.version>2.1.20</kotlin.version>
         <compose.version>1.8.2</compose.version>
+        <compose.material3.version>1.8.2</compose.material3.version>
     </properties>
 
     <repositories>
@@ -99,9 +100,14 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.compose.foundation</groupId>
+            <artifactId>foundation-desktop</artifactId>
+            <version>${compose.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.compose.material3</groupId>
             <artifactId>material3-desktop</artifactId>
-            <version>${compose.version}</version>
+            <version>${compose.material3.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
After decoupling Material3 from Compose, we need to pass their versions separately

[CI fix](https://jetbrains.team/p/ui/repositories/compose-teamcity-config/revision/df83b9cf9acff67a45f799e0de7559bc04d7c516)

## Testing
```
./check.sh
./check.sh -Dcompose.version=1.9.0-alpha02
./check.sh -Dcompose.version=1.9.0-alpha01 -Dcompose.material3.version=1.9.0-alpha03
```

## Release Notes
N/A