### PR TITLE
Maven Test Project. Remove accidental configuration

### DIFF
--- a/ci/templates/maven-test-project/pom.xml
+++ b/ci/templates/maven-test-project/pom.xml
@@ -57,7 +57,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <args>org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable
+                    <args>
                         <arg>-Xplugin=${user.home}/.m2/repository/org/jetbrains/kotlin/kotlin-compose-compiler-plugin/${kotlin.version}/kotlin-compose-compiler-plugin-${kotlin.version}.jar</arg>
                     </args>
                 </configuration>


### PR DESCRIPTION
This value isn't used, as it is inside non-read xml tag

## Release Notes
N/A
