### PR TITLE
Fix iOS resource sync task with cocoapods integration to properly register output directory.

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResources.kt
@@ -93,6 +93,7 @@ internal fun Project.configureSyncIosComposeResources(
                 val projectPath = project.path
                 specAttributes["resources"] = specAttr
                 project.tasks.named("podspec").configure {
+                    it.outputs.dir(syncDir)
                     it.doFirst {
                         if (specAttributes["resources"] != specAttr) error(
                             """
@@ -101,7 +102,6 @@ internal fun Project.configureSyncIosComposeResources(
                                 |  * Alternative action: turn off Compose Multiplatform's resources management for iOS by adding '${ComposeProperties.SYNC_RESOURCES_PROPERTY}=false' to your gradle.properties;
                             """.trimMargin()
                         )
-                        syncDir.mkdirs()
                     }
                 }
             }


### PR DESCRIPTION
Fix iOS resource sync task with cocoapods integration to properly register output directory.

Fixes https://youtrack.jetbrains.com/issue/CMP-8575

## Release Notes
N/A