### PR TITLE
Introduce wasmJsBrowserDistribution task

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -27,6 +27,7 @@ import org.jetbrains.compose.resources.ResourcesExtension
 import org.jetbrains.compose.resources.configureComposeResources
 import org.jetbrains.compose.web.WebExtension
 import org.jetbrains.compose.web.internal.configureWeb
+import org.jetbrains.compose.web.tasks.configureWebCompatibility
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
 
 internal val composeVersion get() = ComposeBuildConfig.composeVersion
@@ -51,6 +52,8 @@ abstract class ComposePlugin : Plugin<Project> {
         project.checkComposeCompilerPlugin()
 
         project.configureComposeResources(resourcesExtension)
+
+        project.configureWebCompatibility()
 
         project.afterEvaluate {
             configureDesktop(project, desktopExtension)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -59,12 +59,12 @@ internal fun Project.configureWeb(
 }
 
 private fun Project.introduceComposeWebCompatibilityTask(targets: Collection<KotlinJsIrTarget>) {
-    val webProductionDist = project.layout.buildDirectory.dir("dist/web/productionExecutable")
+    val webProductionDist = layout.buildDirectory.dir("dist/web/productionExecutable")
 
     val jsAppRenamed = "__jsApp.js"
     val wasmAppRenamed = "__wasmApp.js"
 
-    project.registerTask<Copy>("composeWebCompatibilityDist") {
+    registerTask<Copy>("composeWebCompatibilityDist") {
         val jsTarget = targets.firstOrNull { it.name == "js" }?.outputModuleName
         val wasmTarget = targets.firstOrNull { it.name == "wasmJs" }?.outputModuleName
 
@@ -74,10 +74,10 @@ private fun Project.introduceComposeWebCompatibilityTask(targets: Collection<Kot
         }
 
         into(webProductionDist)
-        with(project.copySpec { spec ->
+        with(copySpec { spec ->
             val jsTarget = targets.firstOrNull { it.name == "js" }?.outputModuleName
             spec.apply {
-                from( project.tasks.named("jsBrowserDistribution")) {
+                from( tasks.named("jsBrowserDistribution")) {
                     rename { name ->
                         val moduleName = jsTarget?.get()
                         when (name) {
@@ -88,10 +88,10 @@ private fun Project.introduceComposeWebCompatibilityTask(targets: Collection<Kot
                     }
                 }
             }
-        }, project.copySpec { spec ->
+        }, copySpec { spec ->
             val wasmTarget = targets.firstOrNull { it.name == "wasmJs" }?.outputModuleName
             spec.apply {
-                from( project.tasks.named("wasmJsBrowserDistribution")) {
+                from( tasks.named("wasmJsBrowserDistribution")) {
                     rename { name ->
                         val moduleName = wasmTarget?.get()
                         when (name) {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -64,13 +64,16 @@ private fun Project.introduceComposeWebCompatibilityTask(targets: Collection<Kot
     val jsAppRenamed = "__jsApp.js"
     val wasmAppRenamed = "__wasmApp.js"
 
+    val jsDistTask = targets.firstOrNull { it.name == "js" } ?: return
+    val wasmDistTask = targets.firstOrNull { it.name == "wasmJs" } ?: return
+
     registerTask<Copy>("composeWebCompatibilityDist") {
-        val jsTarget = targets.firstOrNull { it.name == "js" }?.outputModuleName
-        val wasmTarget = targets.firstOrNull { it.name == "wasmJs" }?.outputModuleName
+        val jsTargetModuleName = jsDistTask.outputModuleName
+        val wasmTargetModuleName = wasmDistTask.outputModuleName
 
         duplicatesStrategy = DuplicatesStrategy.WARN
         onlyIf {
-            jsTarget != null && wasmTarget != null
+            jsTargetModuleName != null && wasmTargetModuleName != null
         }
 
         into(webProductionDist)
@@ -89,7 +92,7 @@ private fun Project.introduceComposeWebCompatibilityTask(targets: Collection<Kot
                 }
             }
         }, copySpec { spec ->
-            val wasmTarget = targets.firstOrNull { it.name == "wasmJs" }?.outputModuleName
+            val wasmTarget = wasmDistTask?.outputModuleName
             spec.apply {
                 from( tasks.named("wasmJsBrowserDistribution")) {
                     rename { name ->
@@ -137,11 +140,11 @@ private fun Project.introduceComposeWebCompatibilityTask(targets: Collection<Kot
             
             """.trimIndent()
 
-            webProductionDist.file("${jsTarget!!.get()}.js").get().asFile.writeText(
+            webProductionDist.file("${jsTargetModuleName!!.get()}.js").get().asFile.writeText(
                 fallbackResolverCode
             )
 
-            webProductionDist.file("${wasmTarget!!.get()}.js").get().asFile.writeText(
+            webProductionDist.file("${wasmTargetModuleName!!.get()}.js").get().asFile.writeText(
                 fallbackResolverCode
             )
         }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.TaskAction
 import org.jetbrains.compose.internal.KOTLIN_MPP_PLUGIN_ID
 import org.jetbrains.compose.internal.mppExt
 import org.jetbrains.compose.internal.utils.clearDirs
+import org.jetbrains.compose.internal.utils.joinLowerCamelCase
 import org.jetbrains.compose.internal.utils.registerTask
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
@@ -45,8 +46,11 @@ abstract class WebCompatibilityTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        val jsAppRenamed = "__jsApp.js"
-        val wasmAppRenamed = "__wasmApp.js"
+        val prefix = "origin"
+        val jsAppFileName = jsOutputName.get()
+        val jsAppRenamed = joinLowerCamelCase(prefix, "js", jsAppFileName)
+        val wasmAppFileName = wasmOutputName.get()
+        val wasmAppRenamed = joinLowerCamelCase(prefix, "wasm", wasmAppFileName)
 
         fileOperations.clearDirs(outputDir)
 
@@ -55,20 +59,18 @@ abstract class WebCompatibilityTask : DefaultTask() {
 
             copySpec.from(jsDistFiles) {
                 it.rename { name ->
-                    val moduleName = jsOutputName.get()
                     when (name) {
-                        "${moduleName}" -> jsAppRenamed
-                        "${moduleName}.map" -> "${jsAppRenamed}.map"
+                        jsAppFileName -> jsAppRenamed
+                        "${jsAppFileName}.map" -> "${jsAppRenamed}.map"
                         else -> name
                     }
                 }
             }
             copySpec.from(wasmDistFiles) {
                 it.rename { name ->
-                    val moduleName = wasmOutputName.get()
                     when (name) {
-                        "${moduleName}" -> wasmAppRenamed
-                        "${moduleName}.map" -> "${wasmAppRenamed}.map"
+                        wasmAppFileName -> wasmAppRenamed
+                        "${wasmAppFileName}.map" -> "${wasmAppRenamed}.map"
                         else -> name
                     }
                 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
@@ -128,13 +128,12 @@ private fun Project.registerWebCompatibilityTask(mppPlugin: KotlinMultiplatformE
     val webProductionDist = layout.buildDirectory.dir("dist/web/productionExecutable")
 
     mppPlugin.targets.matching { it is KotlinJsIrTarget }.all { target ->
-        if (target.name ==  "js") {
-            jsOutputName.set((target as KotlinJsIrTarget).outputModuleName)
+        val outputName = when {
+            (target as KotlinJsIrTarget).wasmTargetType == null -> wasmOutputName
+            else -> jsOutputName
         }
 
-        if (target.name ==  "wasmJs") {
-            wasmOutputName.set((target as KotlinJsIrTarget).outputModuleName)
-        }
+        outputName.set(target.outputModuleName)
     }
 
     onlyIf {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
@@ -127,6 +127,9 @@ abstract class WebCompatibilityTask : DefaultTask() {
 }
 
 private fun Project.registerWebCompatibilityTask(mppPlugin: KotlinMultiplatformExtension)  =  registerTask<WebCompatibilityTask>("composeWebCompatibilityDist") {
+    group = "compose"
+    description = "This task combines both js and wasm distributions into one so that wasm application fallback to js target if modern wasm feature are not supported"
+
     val webProductionDist = layout.buildDirectory.dir("dist/web/productionExecutable")
     outputDir.set(webProductionDist)
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
@@ -5,7 +5,6 @@ import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -16,11 +15,14 @@ import org.gradle.api.tasks.TaskAction
 import org.jetbrains.compose.internal.KOTLIN_MPP_PLUGIN_ID
 import org.jetbrains.compose.internal.mppExt
 import org.jetbrains.compose.internal.utils.clearDirs
+import org.jetbrains.compose.internal.utils.joinLowerCamelCase
 import org.jetbrains.compose.internal.utils.registerTask
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
+import java.io.File
 import javax.inject.Inject
-import kotlin.math.log
 
 abstract class WebCompatibilityTask : DefaultTask() {
     @get:Inject
@@ -45,8 +47,11 @@ abstract class WebCompatibilityTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        val jsAppRenamed = "__jsApp.js"
-        val wasmAppRenamed = "__wasmApp.js"
+        val prefix = "origin"
+        val jsAppFileName = jsOutputName.get()
+        val jsAppRenamed = joinLowerCamelCase(prefix, "js", jsAppFileName)
+        val wasmAppFileName = wasmOutputName.get()
+        val wasmAppRenamed = joinLowerCamelCase(prefix, "wasm", wasmAppFileName)
 
         fileOperations.clearDirs(outputDir)
 
@@ -54,28 +59,20 @@ abstract class WebCompatibilityTask : DefaultTask() {
             copySpec.duplicatesStrategy = DuplicatesStrategy.WARN
 
             copySpec.from(jsDistFiles) {
-                copySpec.rename { name ->
-                    val moduleName = jsOutputName.get()
+                it.rename { name ->
                     when (name) {
-                        "${moduleName}.js" -> jsAppRenamed
-                        "${moduleName}.js.map" -> "${jsAppRenamed}.map"
+                        jsAppFileName -> jsAppRenamed
+                        "${jsAppFileName}.map" -> "${jsAppRenamed}.map"
                         else -> name
                     }
                 }
             }
 
-            copySpec.into(outputDir)
-        }
-
-        fileOperations.copy { copySpec ->
-            copySpec.duplicatesStrategy = DuplicatesStrategy.WARN
-
             copySpec.from(wasmDistFiles) {
-                copySpec.rename { name ->
-                    val moduleName = wasmOutputName.get()
+                it.rename { name ->
                     when (name) {
-                        "${moduleName}.js" -> wasmAppRenamed
-                        "${moduleName}.js.map" -> "${wasmAppRenamed}.map"
+                        wasmAppFileName -> wasmAppRenamed
+                        "${wasmAppFileName}.map" -> "${wasmAppRenamed}.map"
                         else -> name
                     }
                 }
@@ -116,30 +113,44 @@ abstract class WebCompatibilityTask : DefaultTask() {
             
             """.trimIndent()
 
-        outputDir.file("${jsOutputName.get()}.js").get().asFile.writeText(
-            fallbackResolverCode
-        )
-
-        outputDir.file("${wasmOutputName.get()}.js").get().asFile.writeText(
-            fallbackResolverCode
-        )
+        val outputDir = outputDir.get().asFile
+        File(outputDir, jsAppFileName).writeText(fallbackResolverCode)
+        File(outputDir, wasmAppFileName).writeText(fallbackResolverCode)
     }
 }
 
-private fun Project.registerWebCompatibilityTask(mppPlugin: KotlinMultiplatformExtension)  =  registerTask<WebCompatibilityTask>("composeWebCompatibilityDist") {
+private fun Project.registerWebCompatibilityTask(
+    mppPlugin: KotlinMultiplatformExtension
+) = registerTask<WebCompatibilityTask>("composeWebCompatibilityDist") {
     group = "compose"
-    description = "This task combines both js and wasm distributions into one so that wasm application fallback to js target if modern wasm feature are not supported"
+    description = "This task combines both js and wasm distributions into one " +
+            "so that wasm application fallback to js target if modern wasm feature are not supported"
 
     val webProductionDist = layout.buildDirectory.dir("dist/composeWebCompatibility/productionExecutable")
     outputDir.set(webProductionDist)
 
-    mppPlugin.targets.matching { it is KotlinJsIrTarget }.all { target ->
-        val outputName = when {
-            (target as KotlinJsIrTarget).wasmTargetType != null -> wasmOutputName
-            else -> jsOutputName
+    mppPlugin.targets.withType(KotlinJsIrTarget::class.java).configureEach { target ->
+        if (target.platformType == KotlinPlatformType.wasm) {
+            wasmOutputName.set(
+                tasks.named(
+                    "${target.name}BrowserProductionWebpack",
+                    KotlinWebpack::class.java
+                ).flatMap { it.mainOutputFileName }
+            )
+            wasmDistFiles.from(
+                tasks.named("${target.name}BrowserDistribution").map { it.outputs.files }
+            )
+        } else if (target.platformType == KotlinPlatformType.js) {
+            jsOutputName.set(
+                tasks.named(
+                    "${target.name}BrowserProductionWebpack",
+                    KotlinWebpack::class.java
+                ).flatMap { it.mainOutputFileName }
+            )
+            jsDistFiles.from(
+                tasks.named("${target.name}BrowserDistribution").map { it.outputs.files }
+            )
         }
-
-        outputName.set(target.outputModuleName)
     }
 
     onlyIf {
@@ -153,18 +164,10 @@ private fun Project.registerWebCompatibilityTask(mppPlugin: KotlinMultiplatformE
         }
         hasBothDistributions && hasBothOutputs
     }
-
-    jsDistFiles.from(project.provider {
-        project.tasks.findByName("jsBrowserDistribution")?.outputs?.files ?: project.files()
-    })
-
-    wasmDistFiles.from(project.provider {
-        project.tasks.findByName("wasmJsBrowserDistribution")?.outputs?.files ?: project.files()
-    })
 }
 
 internal fun Project.configureWebCompatibility() {
     plugins.withId(KOTLIN_MPP_PLUGIN_ID) {
-            project.registerWebCompatibilityTask(mppExt)
+        project.registerWebCompatibilityTask(mppExt)
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
@@ -126,7 +126,7 @@ abstract class WebCompatibilityTask : DefaultTask() {
     }
 }
 
-private fun Project.registerWebCompatibilityTask(mppPlugin: KotlinMultiplatformExtension)  =  registerTask<WebCompatibilityTask>("composeWebCompatibilityDist") {
+private fun Project.registerWebCompatibilityTask(mppPlugin: KotlinMultiplatformExtension)  =  registerTask<WebCompatibilityTask>("composeCompatibilityBrowserDistribution") {
     group = "compose"
     description = "This task combines both js and wasm distributions into one so that wasm application fallback to js target if modern wasm feature are not supported"
 
@@ -138,6 +138,7 @@ private fun Project.registerWebCompatibilityTask(mppPlugin: KotlinMultiplatformE
             (target as KotlinJsIrTarget).wasmTargetType != null -> wasmOutputName
             else -> jsOutputName
         }
+
 
         outputName.set(target.outputModuleName)
     }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
+import java.io.File
 import javax.inject.Inject
 
 abstract class WebCompatibilityTask : DefaultTask() {
@@ -111,13 +112,10 @@ abstract class WebCompatibilityTask : DefaultTask() {
             
             """.trimIndent()
 
-        outputDir.file("${jsOutputName.get()}").get().asFile.writeText(
-            fallbackResolverCode
-        )
 
-        outputDir.file("${wasmOutputName.get()}").get().asFile.writeText(
-            fallbackResolverCode
-        )
+        val outputDir = outputDir.get().asFile
+        File(outputDir, jsAppFileName).writeText(fallbackResolverCode)
+        File(outputDir, wasmAppFileName).writeText(fallbackResolverCode)
     }
 }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
@@ -130,7 +130,7 @@ private fun Project.registerWebCompatibilityTask(mppPlugin: KotlinMultiplatformE
     group = "compose"
     description = "This task combines both js and wasm distributions into one so that wasm application fallback to js target if modern wasm feature are not supported"
 
-    val webProductionDist = layout.buildDirectory.dir("dist/web/productionExecutable")
+    val webProductionDist = layout.buildDirectory.dir("dist/composeWebCompatibility/productionExecutable")
     outputDir.set(webProductionDist)
 
     mppPlugin.targets.matching { it is KotlinJsIrTarget }.all { target ->

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/CompatibilityDistributionTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/CompatibilityDistributionTest.kt
@@ -1,0 +1,64 @@
+package org.jetbrains.compose.test.tests.integration
+
+import org.gradle.internal.impldep.junit.framework.TestCase.assertTrue
+import org.jetbrains.compose.test.utils.GradlePluginTestBase
+import org.jetbrains.compose.test.utils.checkExists
+import org.jetbrains.compose.test.utils.checks
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+
+class CompatibilityDistributionTest : GradlePluginTestBase() {
+    @Test
+    fun testWebJsWasm() = with(
+        testProject(
+            "application/webJsWasm",
+            testEnvironment = defaultTestEnvironment.copy()
+        )
+    ) {
+        gradle(":composeApp:composeCompatibilityBrowserDistribution").checks {
+            check.taskSuccessful(":composeApp:composeCompatibilityBrowserDistribution")
+            check.taskSuccessful(":composeApp:jsBrowserDistribution")
+            check.taskSuccessful(":composeApp:wasmJsBrowserDistribution")
+
+            file("./composeApp/build/dist/composeWebCompatibility/productionExecutable").apply {
+                checkExists()
+                assertTrue(isDirectory)
+                val distributionFiles = listFiles()!!.map { it.name }.toList().sorted()
+
+                assertTrue(distributionFiles.any { it.endsWith(".wasm") })
+
+                assertContentEquals(distributionFiles.filter { !it.endsWith(".wasm") }, listOf(
+                    "__jsApp.js", "__jsApp.js.map", "__wasmApp.js", "__wasmApp.js.map", "composeApp.js", "composeResources", "index.html", "styles.css"
+                ))
+            }
+        }
+    }
+
+
+    @Test
+    fun testWebJsWasmNonStandard() = with(
+        testProject(
+            "application/webJsWasmNonStandard",
+            testEnvironment = defaultTestEnvironment.copy()
+        )
+    ) {
+        gradle(":composeApp:composeCompatibilityBrowserDistribution").checks {
+            check.taskSuccessful(":composeApp:composeCompatibilityBrowserDistribution")
+            check.taskSuccessful(":composeApp:webJsBrowserDistribution")
+            check.taskSuccessful(":composeApp:webWasmBrowserDistribution")
+
+            file("./composeApp/build/dist/composeWebCompatibility/productionExecutable").apply {
+                checkExists()
+                assertTrue(isDirectory)
+                val distributionFiles = listFiles()!!.map { it.name }.toList().sorted()
+
+                assertTrue(distributionFiles.any { it.endsWith(".wasm") })
+
+                assertContentEquals(distributionFiles.filter { !it.endsWith(".wasm") }, listOf(
+                    "__jsApp.js", "__jsApp.js.map", "__wasmApp.js", "__wasmApp.js.map", "composeApp.js", "composeResources", "index.html", "styles.css"
+                ))
+            }
+        }
+    }
+
+}

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/CompatibilityDistributionTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/CompatibilityDistributionTest.kt
@@ -28,7 +28,7 @@ class CompatibilityDistributionTest : GradlePluginTestBase() {
                 assertTrue(distributionFiles.any { it.endsWith(".wasm") })
 
                 assertContentEquals(distributionFiles.filter { !it.endsWith(".wasm") }, listOf(
-                    "__jsApp.js", "__jsApp.js.map", "__wasmApp.js", "__wasmApp.js.map", "composeApp.js", "composeResources", "index.html", "styles.css"
+                    "composeApp.js", "composeResources", "index.html", "originJsComposeApp.js", "originJsComposeApp.js.map", "originWasmComposeApp.js", "originWasmComposeApp.js.map", "styles.css"
                 ))
             }
         }
@@ -54,8 +54,10 @@ class CompatibilityDistributionTest : GradlePluginTestBase() {
 
                 assertTrue(distributionFiles.any { it.endsWith(".wasm") })
 
+                println(distributionFiles.filter { !it.endsWith(".wasm") }.sorted().joinToString(", ") { "\"$it\"" })
+
                 assertContentEquals(distributionFiles.filter { !it.endsWith(".wasm") }, listOf(
-                    "__jsApp.js", "__jsApp.js.map", "__wasmApp.js", "__wasmApp.js.map", "composeApp.js", "composeResources", "index.html", "styles.css"
+                    "composeApp.js", "composeResources", "index.html", "originJsComposeApp.js", "originJsComposeApp.js.map", "originWasmComposeApp.js", "originWasmComposeApp.js.map", "styles.css"
                 ))
             }
         }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -87,7 +87,7 @@ class GradlePluginTest : GradlePluginTestBase() {
             }
         }
 
-    // Note: we can"t test non-jvm targets with Kotlin older than 2.1.0, because of klib abi version bump in 2.1.0
+    // Note: we can't test non-jvm targets with Kotlin older than 2.1.0, because of klib abi version bump in 2.1.0
     private val oldestSupportedKotlinVersion = "2.1.0"
     @Test
     fun testOldestKotlinMpp() = with(

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -122,8 +122,8 @@ class GradlePluginTest : GradlePluginTestBase() {
             testEnvironment = defaultTestEnvironment.copy()
         )
     ) {
-        gradle(":composeApp:composeWebCompatibilityDist").checks {
-            check.taskSuccessful(":composeApp:composeWebCompatibilityDist")
+        gradle(":composeApp:composeCompatibilityBrowserDistribution").checks {
+            check.taskSuccessful(":composeApp:composeCompatibilityBrowserDistribution")
             check.taskSuccessful(":composeApp:jsBrowserDistribution")
             check.taskSuccessful(":composeApp:wasmJsBrowserDistribution")
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -116,32 +116,6 @@ class GradlePluginTest : GradlePluginTestBase() {
     }
 
     @Test
-    fun testWebJsWasm() = with(
-        testProject(
-            "application/webJsWasm",
-            testEnvironment = defaultTestEnvironment.copy()
-        )
-    ) {
-        gradle(":composeApp:composeCompatibilityBrowserDistribution").checks {
-            check.taskSuccessful(":composeApp:composeCompatibilityBrowserDistribution")
-            check.taskSuccessful(":composeApp:jsBrowserDistribution")
-            check.taskSuccessful(":composeApp:wasmJsBrowserDistribution")
-
-            file("./composeApp/build/dist/composeWebCompatibility/productionExecutable").apply {
-                checkExists()
-                assertTrue(isDirectory)
-                val distributionFiles = listFiles()!!.map { it.name }.toList().sorted()
-
-                assertTrue(distributionFiles.any { it.endsWith(".wasm") })
-
-                assertContentEquals(distributionFiles.filter { !it.endsWith(".wasm") }, listOf(
-                    "__jsApp.js", "__jsApp.js.map", "__wasmApp.js", "__wasmApp.js.map", "composeApp.js", "composeResources", "index.html", "styles.css"
-                ))
-            }
-        }
-    }
-
-    @Test
     fun testOldComposePluginError() = with(testProject("misc/oldComposePlugin")) {
         gradleFailure("tasks").checks {
             check.logContains(newComposeCompilerError)

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -127,7 +127,7 @@ class GradlePluginTest : GradlePluginTestBase() {
             check.taskSuccessful(":composeApp:jsBrowserDistribution")
             check.taskSuccessful(":composeApp:wasmJsBrowserDistribution")
 
-            file("./composeApp/build/dist/web/productionExecutable").apply {
+            file("./composeApp/build/dist/composeWebCompatibility/productionExecutable").apply {
                 checkExists()
                 assertTrue(isDirectory)
                 val distributionFiles = listFiles()!!.map { it.name }.toList().sorted()

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -124,6 +124,8 @@ class GradlePluginTest : GradlePluginTestBase() {
     ) {
         gradle(":composeApp:composeWebCompatibilityDist").checks {
             check.taskSuccessful(":composeApp:composeWebCompatibilityDist")
+            check.taskSuccessful(":composeApp:jsBrowserDistribution")
+            check.taskSuccessful(":composeApp:wasmJsBrowserDistribution")
 
             file("./composeApp/build/dist/web/productionExecutable").apply {
                 checkExists()

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -128,15 +128,13 @@ class GradlePluginTest : GradlePluginTestBase() {
             file("./composeApp/build/dist/web/productionExecutable").apply {
                 checkExists()
                 assertTrue(isDirectory)
-                val distributionFiles = listFiles()!!.map { it.name }.toSet()
+                val distributionFiles = listFiles()!!.map { it.name }.toList().sorted()
 
                 assertTrue(distributionFiles.any { it.endsWith(".wasm") })
 
-                assertContentEquals(distributionFiles.filter { !it.endsWith(".wasm") }, setOf(
-                    "composeResources", "index.html",
-                    "__jsApp.js.map", "styles.css", "composeApp.js", "__jsApp.js",
-                    "__wasmApp.js.map", "__wasmApp.js")
-                )
+                assertContentEquals(distributionFiles.filter { !it.endsWith(".wasm") }, listOf(
+                    "__jsApp.js", "__jsApp.js.map", "__wasmApp.js", "__wasmApp.js.map", "composeApp.js", "composeResources", "index.html", "styles.css"
+                ))
             }
         }
     }

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/.yarnrc
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/.yarnrc
@@ -1,0 +1,1 @@
+--install.mutex network

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    // this is necessary to avoid the plugins to be loaded multiple times
+    // in each subproject's classloader
+    id("org.jetbrains.kotlin.multiplatform") apply false
+    id("org.jetbrains.compose") apply false
+    id("org.jetbrains.kotlin.plugin.compose") apply false
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/build.gradle.kts
@@ -5,9 +5,3 @@ plugins {
     id("org.jetbrains.compose") apply false
     id("org.jetbrains.kotlin.plugin.compose") apply false
 }
-
-allprojects {
-    tasks.configureEach {
-        if (name == "kotlinStoreYarnLock") enabled = false
-    }
-}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/build.gradle.kts
@@ -5,3 +5,9 @@ plugins {
     id("org.jetbrains.compose") apply false
     id("org.jetbrains.kotlin.plugin.compose") apply false
 }
+
+allprojects {
+    tasks.configureEach {
+        if (name == "kotlinStoreYarnLock") enabled = false
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/build.gradle.kts
@@ -1,0 +1,56 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
+
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("org.jetbrains.compose")
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
+kotlin {
+    js(IR) {
+        outputModuleName.set("composeApp")
+        browser {
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+            }
+        }
+        binaries.executable()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        outputModuleName.set("composeApp")
+        browser {
+            val rootDirPath = project.rootDir.path
+            val projectDirPath = project.projectDir.path
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+            }
+        }
+        binaries.executable()
+    }
+
+    // Simple task that prints "Hello World" to the console
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.runtime)
+        }
+
+        val webMain by creating {
+            resources.setSrcDirs(resources.srcDirs)
+            dependsOn(commonMain.get())
+        }
+
+        val jsMain by getting {
+            dependsOn(webMain)
+        }
+
+        val wasmJsMain by getting {
+            dependsOn(webMain)
+        }
+    }
+}
+
+

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/jsMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/jsMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class JsPlatform : Platform {
+    override val name: String = "Web with Kotlin/JS"
+}
+
+actual fun getPlatform(): Platform = JsPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/wasmJsMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/wasmJsMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class WasmPlatform : Platform {
+    override val name: String = "Web with Kotlin/Wasm"
+}
+
+actual fun getPlatform(): Platform = WasmPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/kotlin/Greeting.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/kotlin/Greeting.kt
@@ -1,0 +1,9 @@
+package org.example.project
+
+class Greeting {
+    private val platform = getPlatform()
+
+    fun greet(): String {
+        return "Hello, ${platform.name}!"
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/kotlin/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/kotlin/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+interface Platform {
+    val name: String
+}
+
+expect fun getPlatform(): Platform

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/kotlin/main.kt
@@ -1,0 +1,5 @@
+package org.example.project
+
+fun main() {
+    println(Greeting().greet())
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/resources/index.html
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/resources/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KotlinProject</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+</head>
+<body>
+</body>
+<script type="application/javascript" src="composeApp.js"></script>
+
+</html>

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/resources/styles.css
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/src/webMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/gradle/libs.versions.toml
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/gradle/libs.versions.toml
@@ -1,0 +1,6 @@
+[versions]
+androidx-lifecycle = "2.9.1"
+
+[libraries]
+androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/settings.gradle.kts
@@ -1,0 +1,41 @@
+rootProject.name = "WebJsMain"
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+pluginManagement {
+    plugins {
+        id("org.jetbrains.kotlin.multiplatform") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.kotlin.plugin.compose") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.compose") version "COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER"
+    }
+    repositories {
+        mavenLocal()
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        maven {
+            url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        }
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+}
+
+include(":composeApp")

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    // this is necessary to avoid the plugins to be loaded multiple times
+    // in each subproject's classloader
+    id("org.jetbrains.kotlin.multiplatform") apply false
+    id("org.jetbrains.compose") apply false
+    id("org.jetbrains.kotlin.plugin.compose") apply false
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/build.gradle.kts
@@ -1,0 +1,56 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
+
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("org.jetbrains.compose")
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
+kotlin {
+    js(name = "webJs", IR) {
+        outputModuleName.set("composeApp")
+        browser {
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+            }
+        }
+        binaries.executable()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs(name = "webWasm") {
+        outputModuleName.set("composeApp")
+        browser {
+            val rootDirPath = project.rootDir.path
+            val projectDirPath = project.projectDir.path
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+            }
+        }
+        binaries.executable()
+    }
+
+    // Simple task that prints "Hello World" to the console
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.runtime)
+        }
+
+        val webMain by creating {
+            resources.setSrcDirs(resources.srcDirs)
+            dependsOn(commonMain.get())
+        }
+
+        val webJsMain by getting {
+            dependsOn(webMain)
+        }
+
+        val webWasmMain by getting {
+            dependsOn(webMain)
+        }
+    }
+}
+
+

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webJsMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webJsMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class JsPlatform : Platform {
+    override val name: String = "Web with Kotlin/JS"
+}
+
+actual fun getPlatform(): Platform = JsPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/kotlin/Greeting.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/kotlin/Greeting.kt
@@ -1,0 +1,9 @@
+package org.example.project
+
+class Greeting {
+    private val platform = getPlatform()
+
+    fun greet(): String {
+        return "Hello, ${platform.name}!"
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/kotlin/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/kotlin/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+interface Platform {
+    val name: String
+}
+
+expect fun getPlatform(): Platform

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/kotlin/main.kt
@@ -1,0 +1,5 @@
+package org.example.project
+
+fun main() {
+    println(Greeting().greet())
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/resources/index.html
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/resources/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KotlinProject</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+</head>
+<body>
+</body>
+<script type="application/javascript" src="composeApp.js"></script>
+
+</html>

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/resources/styles.css
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webWasmMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/composeApp/src/webWasmMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class WasmPlatform : Platform {
+    override val name: String = "Web with Kotlin/Wasm"
+}
+
+actual fun getPlatform(): Platform = WasmPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/gradle/libs.versions.toml
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/gradle/libs.versions.toml
@@ -1,0 +1,6 @@
+[versions]
+androidx-lifecycle = "2.9.1"
+
+[libraries]
+androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonStandard/settings.gradle.kts
@@ -1,0 +1,41 @@
+rootProject.name = "WebJsMain"
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+pluginManagement {
+    plugins {
+        id("org.jetbrains.kotlin.multiplatform") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.kotlin.plugin.compose") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.compose") version "COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER"
+    }
+    repositories {
+        mavenLocal()
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        maven {
+            url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        }
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+}
+
+include(":composeApp")


### PR DESCRIPTION

## Testing
Clone https://github.com/Schahen/ComposeWebApp and run 
```
 ./gradlew  :composeApp: composeCompatibilityBrowserDistribution
```

## Release Notes
### Features - Web
- Introduce composeCompatibilityBrowserDistribution  task. This task combines two prod distributions - for js and for wasm in such way so that if modern require features are not supported by the consumer browser, application switch to js mode. 