### PR TITLE
Fix GradlePluginTest::skikoWasm test

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -90,19 +90,6 @@ internal fun configureWebApplication(
         dependsOn(unpackRuntime)
         from(unpackedRuntimeDir)
         into(processedRuntimeDir)
-
-        doLast {
-            // TODO: in the next versions we can simply filter skiko.js out for k/wasm target
-            processedRuntimeDir.file("skiko.js").get().apply {
-                asFile.appendText("\n\n// Warn about skiko.js redundancy in case of K/Wasm target:\n")
-                asFile.appendText(
-                    """console.warn("Note: skiko.js is redundant in K/Wasm Compose for Web applications. 
-                        |Consider removing it from index.html, 
-                        |it will be removed from the distribution in next Compose Multiplatform versions");
-                        """.trimMargin().replace("\n", "")
-                )
-            }
-        }
     }
 
     targets.forEach { target ->

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -60,8 +60,7 @@ class GradlePluginTest : GradlePluginTestBase() {
                 assertTrue(isDirectory)
                 val distributionFiles = listFiles()!!.map { it.name }.toList()
                 assertTrue(distributionFiles.contains("skiko.wasm"))
-                assertTrue(distributionFiles.contains("skiko.js"))
-                assertFalse(this.resolve("skiko.js").readText().contains("skiko.js is redundant"))
+                assertTrue(distributionFiles.contains("skiko.mjs"))
             }
         }
     }


### PR DESCRIPTION
This PR corrects test behaviour after skiko stops shipping skiko.js file altogeher

## Testing
regular pipeline test routine

## Release Notes
N/A