### PR TITLE
Introduce test for invoking composeCompatibilityBrowserDistribution in heavily reconfigured project

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/CompatibilityDistributionTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/CompatibilityDistributionTest.kt
@@ -1,66 +1,110 @@
 package org.jetbrains.compose.test.tests.integration
 
-import org.gradle.internal.impldep.junit.framework.TestCase.assertTrue
 import org.jetbrains.compose.test.utils.GradlePluginTestBase
+import org.jetbrains.compose.test.utils.TestProject
 import org.jetbrains.compose.test.utils.checkExists
 import org.jetbrains.compose.test.utils.checks
 import org.junit.jupiter.api.Test
-import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class CompatibilityDistributionTest : GradlePluginTestBase() {
-    @Test
-    fun testWebJsWasm() = with(
+    private val defaultDistDir = "./composeApp/build/dist/composeWebCompatibility/productionExecutable"
+
+    private fun TestProject.assertCompatibilityDistribution(
+        dirPath: String,
+        expectedFileNames: Set<String>
+    ) {
+        file(dirPath).apply {
+            checkExists()
+            assertTrue(isDirectory, "Expected $dirPath to be a directory")
+
+            val listed = listFiles()
+                ?: error("Expected to list files in $dirPath but got null")
+            val distributionNames = listed.map { it.name }
+
+            assertTrue(
+                distributionNames.any { it.endsWith(".wasm") },
+                "Expected at least one .wasm file in $dirPath, found: $distributionNames"
+            )
+
+            val actualFiles = distributionNames.filterNot { it.endsWith(".wasm") }.toSet()
+            assertEquals(expectedFileNames, actualFiles, "files mismatch in $dirPath")
+        }
+    }
+
+    private fun runCompatibilityTest(
+        projectPath: String,
+        successfulTasks: List<String>,
+        distDir: String = defaultDistDir,
+        expectedFiles: Set<String>
+    ) = with(
         testProject(
-            "application/webJsWasm",
+            projectPath,
             testEnvironment = defaultTestEnvironment.copy()
         )
     ) {
         gradle(":composeApp:composeCompatibilityBrowserDistribution").checks {
             check.taskSuccessful(":composeApp:composeCompatibilityBrowserDistribution")
-            check.taskSuccessful(":composeApp:jsBrowserDistribution")
-            check.taskSuccessful(":composeApp:wasmJsBrowserDistribution")
-
-            file("./composeApp/build/dist/composeWebCompatibility/productionExecutable").apply {
-                checkExists()
-                assertTrue(isDirectory)
-                val distributionFiles = listFiles()!!.map { it.name }.toList().sorted()
-
-                assertTrue(distributionFiles.any { it.endsWith(".wasm") })
-
-                assertContentEquals(distributionFiles.filter { !it.endsWith(".wasm") }, listOf(
-                    "composeApp.js", "composeResources", "index.html", "originJsComposeApp.js", "originJsComposeApp.js.map", "originWasmComposeApp.js", "originWasmComposeApp.js.map", "styles.css"
-                ))
-            }
+            successfulTasks.forEach { check.taskSuccessful(it) }
+            assertCompatibilityDistribution(dirPath = distDir, expectedFileNames = expectedFiles)
         }
     }
-
 
     @Test
-    fun testWebJsWasmNonStandard() = with(
-        testProject(
-            "application/webJsWasmNonStandard",
-            testEnvironment = defaultTestEnvironment.copy()
+    fun testWebJsWasm() = runCompatibilityTest(
+        projectPath = "application/webJsWasm",
+        successfulTasks = listOf(
+            ":composeApp:jsBrowserDistribution",
+            ":composeApp:wasmJsBrowserDistribution"
+        ),
+        expectedFiles = setOf(
+            "composeApp.js",
+            "composeResources",
+            "index.html",
+            "originJsComposeApp.js",
+            "originJsComposeApp.js.map",
+            "originWasmComposeApp.js",
+            "originWasmComposeApp.js.map",
+            "styles.css"
         )
-    ) {
-        gradle(":composeApp:composeCompatibilityBrowserDistribution").checks {
-            check.taskSuccessful(":composeApp:composeCompatibilityBrowserDistribution")
-            check.taskSuccessful(":composeApp:webJsBrowserDistribution")
-            check.taskSuccessful(":composeApp:webWasmBrowserDistribution")
+    )
 
-            file("./composeApp/build/dist/composeWebCompatibility/productionExecutable").apply {
-                checkExists()
-                assertTrue(isDirectory)
-                val distributionFiles = listFiles()!!.map { it.name }.toList().sorted()
+    @Test
+    fun testWebJsWasmNonStandard() = runCompatibilityTest(
+        projectPath = "application/webJsWasmNonStandard",
+        successfulTasks = listOf(
+            ":composeApp:webJsBrowserDistribution",
+            ":composeApp:webWasmBrowserDistribution"
+        ),
+        expectedFiles = setOf(
+            "composeApp.js",
+            "composeResources",
+            "index.html",
+            "originJsComposeApp.js",
+            "originJsComposeApp.js.map",
+            "originWasmComposeApp.js",
+            "originWasmComposeApp.js.map",
+            "styles.css"
+        )
+    )
 
-                assertTrue(distributionFiles.any { it.endsWith(".wasm") })
-
-                println(distributionFiles.filter { !it.endsWith(".wasm") }.sorted().joinToString(", ") { "\"$it\"" })
-
-                assertContentEquals(distributionFiles.filter { !it.endsWith(".wasm") }, listOf(
-                    "composeApp.js", "composeResources", "index.html", "originJsComposeApp.js", "originJsComposeApp.js.map", "originWasmComposeApp.js", "originWasmComposeApp.js.map", "styles.css"
-                ))
-            }
-        }
-    }
-
+    @Test
+    fun testWebJsWasmReconfigured() = runCompatibilityTest(
+        projectPath = "application/webJsWasmReconfigured",
+        successfulTasks = listOf(
+            ":composeApp:wasmRepack",
+            ":composeApp:jsRepack"
+        ),
+        expectedFiles = setOf(
+            "composeResources",
+            "index.html",
+            "originJsRepackedApp.js",
+            "originJsRepackedApp.js.map",
+            "originWasmRepackedApp.js",
+            "originWasmRepackedApp.js.map",
+            "repackedApp.js",
+            "styles.css"
+        )
+    )
 }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/WebCompatibilityDistributionTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/WebCompatibilityDistributionTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class CompatibilityDistributionTest : GradlePluginTestBase() {
+class WebCompatibilityDistributionTest : GradlePluginTestBase() {
     private val defaultDistDir = "./composeApp/build/dist/composeWebCompatibility/productionExecutable"
 
     private fun TestProject.assertCompatibilityDistribution(

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    // this is necessary to avoid the plugins to be loaded multiple times
+    // in each subproject's classloader
+    id("org.jetbrains.kotlin.multiplatform") apply false
+    id("org.jetbrains.compose") apply false
+    id("org.jetbrains.kotlin.plugin.compose") apply false
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/build.gradle.kts
@@ -1,0 +1,99 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
+
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("org.jetbrains.compose")
+    id("org.jetbrains.kotlin.plugin.compose")
+}
+
+kotlin {
+    js(name = "webJs", IR) {
+        outputModuleName.set("composeApp")
+        browser {
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+            }
+        }
+        binaries.executable()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs(name = "webWasm") {
+        outputModuleName.set("composeApp")
+        browser {
+            val rootDirPath = project.rootDir.path
+            val projectDirPath = project.projectDir.path
+            commonWebpackConfig {
+                outputFileName = "composeApp.js"
+            }
+        }
+        binaries.executable()
+    }
+
+    // Simple task that prints "Hello World" to the console
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(compose.runtime)
+        }
+
+        val webMain by creating {
+            resources.setSrcDirs(resources.srcDirs)
+            dependsOn(commonMain.get())
+        }
+
+        val webJsMain by getting {
+            dependsOn(webMain)
+        }
+
+        val webWasmMain by getting {
+            dependsOn(webMain)
+        }
+    }
+}
+
+
+val wasmRepack = tasks.register<RepackTask>("wasmRepack") {
+    sourceFiles.from(project.tasks.named("webWasmBrowserDistribution").map { it.outputs.files })
+    outputDir.set(project.layout.buildDirectory.dir("dist/repackedWasm"))
+}
+
+val jsRepack = tasks.register<RepackTask>("jsRepack") {
+    sourceFiles.from(project.tasks.named("webJsBrowserDistribution").map { it.outputs.files })
+    outputDir.set(project.layout.buildDirectory.dir("dist/repackedJs"))
+}
+
+project.tasks.withType<org.jetbrains.compose.web.tasks.WebCompatibilityTask>().configureEach {
+    jsOutputName.set("repackedApp.js")
+    wasmOutputName.set("repackedApp.js")
+    jsDistFiles.setFrom(jsRepack)
+    wasmDistFiles.setFrom(wasmRepack)
+}
+
+abstract class RepackTask : DefaultTask() {
+    @get:Inject
+    internal abstract val fileOperations: FileSystemOperations
+
+    @get:InputFiles
+    abstract val sourceFiles: ConfigurableFileCollection
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun run() {
+        fileOperations.copy {
+            from(sourceFiles) {
+                this.rename { name ->
+                    when (name) {
+                        "composeApp.js" -> "repackedApp.js"
+                        "composeApp.js.map" -> "repackedApp.js.map"
+                        else -> name
+                    }
+                }
+            }
+            into(outputDir)
+        }
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webJsMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webJsMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class JsPlatform : Platform {
+    override val name: String = "Web with Kotlin/JS"
+}
+
+actual fun getPlatform(): Platform = JsPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/kotlin/Greeting.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/kotlin/Greeting.kt
@@ -1,0 +1,9 @@
+package org.example.project
+
+class Greeting {
+    private val platform = getPlatform()
+
+    fun greet(): String {
+        return "Hello, ${platform.name}!"
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/kotlin/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/kotlin/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+interface Platform {
+    val name: String
+}
+
+expect fun getPlatform(): Platform

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/kotlin/main.kt
@@ -1,0 +1,5 @@
+package org.example.project
+
+fun main() {
+    println(Greeting().greet())
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/resources/index.html
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/resources/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KotlinProject</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+</head>
+<body>
+</body>
+<script type="application/javascript" src="composeApp.js"></script>
+
+</html>

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/resources/styles.css
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webWasmMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/src/webWasmMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class WasmPlatform : Platform {
+    override val name: String = "Web with Kotlin/Wasm"
+}
+
+actual fun getPlatform(): Platform = WasmPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/gradle/libs.versions.toml
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/gradle/libs.versions.toml
@@ -1,0 +1,6 @@
+[versions]
+androidx-lifecycle = "2.9.1"
+
+[libraries]
+androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/settings.gradle.kts
@@ -1,0 +1,41 @@
+rootProject.name = "WebJsMain"
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+pluginManagement {
+    plugins {
+        id("org.jetbrains.kotlin.multiplatform") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.kotlin.plugin.compose") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.compose") version "COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER"
+    }
+    repositories {
+        mavenLocal()
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        maven {
+            url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        }
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+}
+
+include(":composeApp")


### PR DESCRIPTION
CompatibilityDistributionTest::testWebJsWasmReconfigured makes sure that composeCompatibilityBrowserDistribution task can be reconfigured to be used with arbitrary set of input tasks

## Testing
Pipeline

## Release Notes
N/A