### PR TITLE
Docker vs2022

### DIFF
--- a/ci/docker/windows/Dockerfile
+++ b/ci/docker/windows/Dockerfile
@@ -30,6 +30,10 @@ RUN `
 
 RUN setx /M SKIKO_VSBT_PATH "C:\BuildTools"
 
+ADD https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.7/LLVM-20.1.7-win64.exe C:\Temp\llvm.exe
+RUN powershell C:\Temp\llvm.exe -ArgumentList /S -Wait
+RUN setx /M PATH "C:\Program Files\LLVM\bin;%PATH%"
+
 # Install Java
 COPY install_jdk.ps1 C:\TEMP\install_jdk.ps1
 RUN powershell C:\TEMP\install_jdk.ps1 -url https://corretto.aws/downloads/latest/amazon-corretto-11-x64-windows-jdk.zip -targetDir C:\jdk11

--- a/ci/docker/windows/Dockerfile
+++ b/ci/docker/windows/Dockerfile
@@ -31,7 +31,7 @@ RUN `
 RUN setx /M SKIKO_VSBT_PATH "C:\BuildTools"
 
 ADD https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.7/LLVM-20.1.7-win64.exe C:\Temp\llvm.exe
-RUN powershell C:\Temp\llvm.exe -ArgumentList /S -Wait
+RUN powershell Start-Process -Wait C:\Temp\llvm.exe -ArgumentList /S
 RUN setx /M PATH "C:\Program Files\LLVM\bin;%PATH%"
 
 # Install Java

--- a/ci/docker/windows/Dockerfile
+++ b/ci/docker/windows/Dockerfile
@@ -1,22 +1,32 @@
 # escape=`
 
-# Use the latest Windows Server Core image with .NET Framework 4.8.
-FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+# Use the latest Windows Server Core 2022 image.
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 # Restore the default Windows shell for correct batch processing.
 SHELL ["cmd", "/S", "/C"]
 
+# Download BuildTools installer
+
+ADD https://aka.ms/vs/17/release/vs_buildtools.exe C:\Temp\vs_buildtools.exe
+
+# Download channel for fixed install.
+ADD https://aka.ms/vs/17/release/channel C:\Temp\VisualStudio.chman
+
 # Install MSVC C++ compiler, CMake, and MSBuild.
-ADD https://aka.ms/vs/16/release/vs_buildtools.exe C:\Temp\vs_buildtools.exe
-ADD https://aka.ms/vs/16/release/channel C:\Temp\VisualStudio.chman
-RUN C:\Temp\vs_buildtools.exe `
-    --quiet --wait --norestart --nocache `
-    --installPath C:\BuildTools `
+RUN `
+    # Install Build Tools excluding workloads and components with known issues.
+    start /w C:\Temp\vs_buildtools.exe --quiet --wait --norestart --nocache `
+    --installPath "C:\BuildTools" `
     --channelUri C:\Temp\VisualStudio.chman `
     --installChannelUri C:\Temp\VisualStudio.chman `
     --add Microsoft.VisualStudio.Workload.VCTools;includeRecommended `
     --add Microsoft.Component.MSBuild `
- || IF "%ERRORLEVEL%"=="3010" EXIT 0
+    --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 `
+    --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 `
+    --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 `
+    --remove Microsoft.VisualStudio.Component.Windows81SDK `
+  || IF "%ERRORLEVEL%"=="3010" EXIT 0
 
 RUN setx /M SKIKO_VSBT_PATH "C:\BuildTools"
 
@@ -30,10 +40,6 @@ ENV PYTHON_VERSION=2.7.18
 ENV PYTHON_RELEASE=2.7.18
 ADD install_python.ps1 C:\TEMP\install_python.ps1
 RUN powershell C:\TEMP\install_python.ps1
-
-ADD https://bintray.com/jetbrains/skija/download_file?file_path=zip.zip C:\TEMP\zip.zip
-RUN tar -xf C:\TEMP\zip.zip
-RUN setx /M PATH "C:\zip;%PATH%"
 
 COPY install_git.ps1 C:\TEMP\install_git.ps1
 RUN powershell C:\TEMP\install_git.ps1

--- a/ci/docker/windows/README.md
+++ b/ci/docker/windows/README.md
@@ -1,13 +1,13 @@
 ### Build image
 
 ```
-docker build -t skiko-build-windows-ltsc2019-amd64:latest -m 2G .
+docker build -t skiko-build-windows-ltsc2022-amd64:latest -m 2G .
 ```
 
 ### Run container
 
 ```
-docker run -it skiko-build-windows-ltsc2019-amd64:latest 
+docker run -it skiko-build-windows-ltsc2022-amd64:latest 
 ```
 
 * To customize memory constraints, use `-m` argument (e.g. `-m 2G`)
@@ -17,6 +17,6 @@ docker run -it skiko-build-windows-ltsc2019-amd64:latest
 
 ```
 docker login public.registry.jetbrains.space
-docker tag skiko-build-windows-ltsc2019-amd64:latest public.registry.jetbrains.space/p/compose/docker/skiko-build-windows-ltsc2019-amd64:latest
-docker push public.registry.jetbrains.space/p/compose/docker/skiko-build-windows-ltsc2019-amd64:latest
+docker tag skiko-build-windows-ltsc2019-amd64:latest public.registry.jetbrains.space/p/compose/docker/skiko-build-windows-ltsc2022-amd64:latest
+docker push public.registry.jetbrains.space/p/compose/docker/skiko-build-windows-ltsc2022-amd64:latest
 ```


### PR DESCRIPTION
Update Docker image for Skiko Windows build to the latest Windows Server 2022 and Visual Studio 2022

Also add LLVM to the image and avoid downloading it on every build

## Testing
Latest Skiko compiles successfully on CI

This should be tested by QA

## Release Notes
N/A