### PR TITLE
Fix AGP 9.0.0-alpha01 compatibility for compose resources

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
@@ -97,7 +97,7 @@ private fun Project.configureAndroidComposeResources(
     moduleResourceDir: Provider<File>?
 ) {
     logger.info("Configure compose resources with KotlinMultiplatformAndroidComponentsExtension")
-    androidComponents.onVariant { variant ->
+    androidComponents.onVariants { variant ->
         val variantAssets = getAndroidKmpComponentComposeResources(kotlinExtension, variant.name)
         configureGeneratedAndroidComponentAssets(
             variant.name,

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.2.0-RC2"
 gradle-download-plugin = "5.5.0"
 kotlin-poet = "2.1.0"
-plugin-android = "8.9.1"
+plugin-android = "8.10.1"
 shadow-jar = "8.1.1"
 publish-plugin = "1.2.1"
 


### PR DESCRIPTION
AGP 9.0.0-alpha01 removed onVariant{} API from KMP Variant extension. (https://cs.android.com/android-studio/platform/tools/base/+/1d00038ec037fb04b4c83e0e0612ba6f0d35cc8b)

Replacement is the plural onVariants{} API