### PR TITLE
[Cherry-pick] Fix `runRelease` task when navigation and `obfuscate.set(true)` are used

### DIFF
--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -101,11 +101,21 @@
 }
 
 # Kotlinx serialization, additional rules
+
 # Fixes:
 #   Exception in thread "main" kotlinx.serialization.SerializationException: Serializer for class 'SomeClass' is not found.
 #   Please ensure that class is marked as '@Serializable' and that the serialization compiler plugin is applied.
 -keep class **$$serializer {
     *;
+}
+-dontnote **$$serializer
+
+# Fixes:
+#   Exception in thread "main" kotlinx.a.g: Serializer for class 'MyClass' is not found
+# When `@InternalSerializationApi kotlinx.serialization.serializer` is used with obfuscation enabled
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1>$** {
+    kotlinx.serialization.KSerializer serializer(...);
 }
 
 # org.jetbrains.runtime:jbr-api

--- a/gradle-plugins/compose/src/test/test-projects/application/proguard/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/proguard/build.gradle
@@ -5,10 +5,12 @@ plugins {
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.plugin.compose"
     id "org.jetbrains.compose"
+    id "org.jetbrains.kotlin.plugin.serialization"
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:1.9.0"
     implementation compose.desktop.currentOs
     implementation compose.material3
 }
@@ -17,6 +19,9 @@ compose.desktop {
     application {
         mainClass = "Main"
         nativeDistributions {
+            windows {
+                console = true
+            }
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
         }
 

--- a/gradle-plugins/compose/src/test/test-projects/application/proguard/settings.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/proguard/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
     plugins {
         id 'org.jetbrains.kotlin.jvm' version 'KOTLIN_VERSION_PLACEHOLDER'
         id 'org.jetbrains.kotlin.plugin.compose' version 'KOTLIN_VERSION_PLACEHOLDER'
+        id 'org.jetbrains.kotlin.plugin.serialization' version 'KOTLIN_VERSION_PLACEHOLDER'
         id 'org.jetbrains.compose' version 'COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER'
     }
     repositories {

--- a/gradle-plugins/compose/src/test/test-projects/application/proguard/src/main/kotlin/Main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/proguard/src/main/kotlin/Main.kt
@@ -10,6 +10,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.renderComposeScene
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
 import org.jetbrains.skia.EncodedImageFormat
 import java.io.File
 import java.util.*
@@ -34,6 +37,8 @@ object Main {
             .mapTo(TreeSet()) { it.name }
             .joinToString("\n")
         workingDir.resolve("main-methods.actual.txt").writeText(mainMethods)
+
+        serializer()
     }
 
     @Composable
@@ -55,6 +60,13 @@ object Main {
     fun keptByKeepRule() {
         fillShape(Color.Blue, CircleShape)
     }
+
+    // https://youtrack.jetbrains.com/issue/CMP-8050/Desktop-runRelease-crash-when-upgrade-to-CMP-1.8.0-rc01#focus=Comments-27-11963863.0-0
+    @OptIn(InternalSerializationApi::class)
+    fun serializer() {
+        LoginRoute::class.serializer()
+        LoginRoute.serializer()
+    }
 }
 
 @Composable
@@ -74,3 +86,6 @@ fun fillShape(color: Color, shape: Shape){
         )
     }
 }
+
+@Serializable
+data class LoginRoute(val id: Long? = null)


### PR DESCRIPTION
## Release Notes
https://github.com/JetBrains/compose-multiplatform/pull/5384