### PR TITLE
Support AGP 9.0.0-alpha01 and improve compatibility handling for AGP < 8.10

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-24.04', 'macos-14', 'windows-2022']
-        gradle: ['8.7', '8.13']
-        agp: ['8.6.0', '8.9.0']
+        gradle: ['8.7', '9.0.0']
+        agp: ['8.6.0', '8.9.0', '9.0.0-alpha01']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -57,8 +57,7 @@ dependencies {
 
     compileOnly(gradleApi())
     compileOnly(localGroovy())
-    //the version supports XCFramework with resources https://youtrack.jetbrains.com/issue/KT-75823
-    compileOnly(kotlin("gradle-plugin", "2.2.0-RC2"))
+    compileOnly(kotlin("gradle-plugin"))
     compileOnly(kotlin("native-utils"))
     compileOnly(libs.plugin.android)
     compileOnly(libs.plugin.android.api)

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -334,11 +334,17 @@ class ResourcesTest : GradlePluginTestBase() {
     @Test
     fun testNewAgpResources() {
         Assumptions.assumeTrue(defaultTestEnvironment.parsedGradleVersion >= GradleVersion.version("8.10.2"))
-        Assumptions.assumeTrue(Version.fromString(defaultTestEnvironment.agpVersion) >= Version.fromString("8.8.0-alpha08"))
+
+        val agpVersion = Version.fromString(defaultTestEnvironment.agpVersion)
+        Assumptions.assumeTrue(agpVersion >= Version.fromString("8.8.0-alpha08"))
 
         with(testProject("misc/newAgpResources", defaultTestEnvironment)) {
             gradle(":appModule:assembleDebug").checks {
-                check.logContains("Configure compose resources with KotlinMultiplatformAndroidComponentsExtension")
+                if (agpVersion >= Version.fromString("8.10")) {
+                    check.logContains("Configure compose resources with KotlinMultiplatformAndroidComponentsExtension")
+                } else {
+                    check.logContains("Configure compose resources with outdated KotlinMultiplatformAndroidComponentsExtension < 8.10")
+                }
 
                 val resourcesFiles = sequenceOf(
                     "composeResources/newagpresources.appmodule.generated.resources/values/strings.commonMain.cvr",

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -670,7 +670,7 @@ class ResourcesTest : GradlePluginTestBase() {
         with(
             testProject(
                 "misc/appleResources",
-                defaultTestEnvironment.copy(kotlinVersion = "2.1.0"))
+                defaultTestEnvironment.copy(kotlinVersion = "2.1.21"))
         ) {
             file("build.gradle.kts").modify { content ->
                 """

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -10,16 +10,16 @@ dev.junit.parallel=false
 # Default version of Compose Libraries used by Gradle plugin
 compose.version=1.9.0-alpha02
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
-compose.tests.kotlin.version=2.2.0-Beta1
+compose.tests.kotlin.version=2.2.0
 # __SUPPORTED_GRADLE_VERSIONS__
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config
 # minimal and current gradle version
-compose.tests.gradle.versions=8.7, 8.13
-compose.tests.agp.versions=8.6.0, 8.9.0
+compose.tests.gradle.versions=8.7, 9.0.0
+compose.tests.agp.versions=8.6.0, 8.9.0, 9.0.0-alpha01
 # gradle and agp versions should be compatible:
 # https://developer.android.com/build/releases/gradle-plugin#updating-plugin
-compose.tests.gradle-agp.exclude=8.7/8.9.0
+compose.tests.gradle-agp.exclude=8.7/8.9.0, 8.7/9.0.0-alpha01
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-kotlin = "2.2.0-RC2"
+kotlin = "2.2.0"
 gradle-download-plugin = "5.5.0"
 kotlin-poet = "2.1.0"
-plugin-android = "8.9.1"
+plugin-android = "8.10.1"
 shadow-jar = "8.1.1"
 publish-plugin = "1.2.1"
 


### PR DESCRIPTION
- Updated Gradle to support version 9.0.0.  
- Improved Compose resource configuration to handle AGP versions below 8.10 with a fallback implementation.
- Bumped Kotlin to 2.2.0 release and updated related dependencies.  
- Adjusted tests to reflect changes in AGP-specific behavior and logging.

Fixes https://youtrack.jetbrains.com/issue/CMP-8771

## Release Notes
### Fixes - Gradle Plugin
- Support `AGP 9.0.0`