### PR TITLE
Cmp 8760 skip non executables

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/tasks/WebCompatibilityTask.kt
@@ -133,24 +133,20 @@ private fun Project.registerWebCompatibilityTask(mppPlugin: KotlinMultiplatformE
 
         mppPlugin.targets.withType(KotlinJsIrTarget::class.java).configureEach { target ->
             if (target.platformType == KotlinPlatformType.wasm) {
-                wasmOutputName.set(
-                    tasks.named(
-                        "${target.name}BrowserProductionWebpack",
-                        KotlinWebpack::class.java
-                    ).flatMap { it.mainOutputFileName }
-                )
+                tasks.withType(KotlinWebpack::class.java).findByName("${target.name}BrowserProductionWebpack")?.let {
+                    wasmOutputName.set(it.mainOutputFileName)
+                }
+
                 wasmDistFiles.from(
-                    tasks.named("${target.name}BrowserDistribution").map { it.outputs.files }
+                    tasks.matching { it.name == "${target.name}BrowserDistribution" }.map { it.outputs.files }
                 )
             } else if (target.platformType == KotlinPlatformType.js) {
-                jsOutputName.set(
-                    tasks.named(
-                        "${target.name}BrowserProductionWebpack",
-                        KotlinWebpack::class.java
-                    ).flatMap { it.mainOutputFileName }
-                )
+                tasks.withType(KotlinWebpack::class.java).findByName("${target.name}BrowserProductionWebpack")?.let {
+                    jsOutputName.set(it.mainOutputFileName)
+                }
+
                 jsDistFiles.from(
-                    tasks.named("${target.name}BrowserDistribution").map { it.outputs.files }
+                    tasks.matching { it.name == "${target.name}BrowserDistribution" }.map { it.outputs.files }
                 )
             }
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/WebCompatibilityDistributionTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/WebCompatibilityDistributionTest.kt
@@ -41,7 +41,7 @@ class WebCompatibilityDistributionTest : GradlePluginTestBase() {
                 testEnvironment = defaultTestEnvironment.copy()
             )
         ) {
-            gradle(":composeApp:composeCompatibilityBrowserDistribution").checks {
+            gradle(taskName).checks {
                 onExecution(this@with)
             }
         }

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/.yarnrc
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/.yarnrc
@@ -1,0 +1,1 @@
+--install.mutex network

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    // this is necessary to avoid the plugins to be loaded multiple times
+    // in each subproject's classloader
+    id("org.jetbrains.kotlin.multiplatform") apply false
+    id("org.jetbrains.compose") apply false
+    id("org.jetbrains.kotlin.plugin.compose") apply false
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/build.gradle.kts
@@ -8,22 +8,9 @@ plugins {
 }
 
 kotlin {
-    js(name = "webJs", IR) {
+    js(IR) {
         outputModuleName.set("composeApp")
         browser {
-            commonWebpackConfig {
-                outputFileName = "composeApp.js"
-            }
-        }
-        binaries.executable()
-    }
-
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs(name = "webWasm") {
-        outputModuleName.set("composeApp")
-        browser {
-            val rootDirPath = project.rootDir.path
-            val projectDirPath = project.projectDir.path
             commonWebpackConfig {
                 outputFileName = "composeApp.js"
             }
@@ -41,11 +28,7 @@ kotlin {
             dependsOn(commonMain.get())
         }
 
-        val webJsMain by getting {
-            dependsOn(webMain)
-        }
-
-        val webWasmMain by getting {
+        val jsMain by getting {
             dependsOn(webMain)
         }
     }

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/jsMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/jsMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class JsPlatform : Platform {
+    override val name: String = "Web with Kotlin/JS"
+}
+
+actual fun getPlatform(): Platform = JsPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/wasmJsMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/wasmJsMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class WasmPlatform : Platform {
+    override val name: String = "Web with Kotlin/Wasm"
+}
+
+actual fun getPlatform(): Platform = WasmPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/kotlin/Greeting.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/kotlin/Greeting.kt
@@ -1,0 +1,9 @@
+package org.example.project
+
+class Greeting {
+    private val platform = getPlatform()
+
+    fun greet(): String {
+        return "Hello, ${platform.name}!"
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/kotlin/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/kotlin/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+interface Platform {
+    val name: String
+}
+
+expect fun getPlatform(): Platform

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/kotlin/main.kt
@@ -1,0 +1,5 @@
+package org.example.project
+
+fun main() {
+    println(Greeting().greet())
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/resources/index.html
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/resources/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KotlinProject</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+</head>
+<body>
+</body>
+<script type="application/javascript" src="composeApp.js"></script>
+
+</html>

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/resources/styles.css
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/composeApp/src/webMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/gradle/libs.versions.toml
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/gradle/libs.versions.toml
@@ -1,0 +1,6 @@
+[versions]
+androidx-lifecycle = "2.9.1"
+
+[libraries]
+androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsOnly/settings.gradle.kts
@@ -1,0 +1,41 @@
+rootProject.name = "WebJsMain"
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+pluginManagement {
+    plugins {
+        id("org.jetbrains.kotlin.multiplatform") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.kotlin.plugin.compose") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.compose") version "COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER"
+    }
+    repositories {
+        mavenLocal()
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        maven {
+            url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        }
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+}
+
+include(":composeApp")

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasm/composeApp/build.gradle.kts
@@ -31,8 +31,6 @@ kotlin {
         binaries.executable()
     }
 
-    // Simple task that prints "Hello World" to the console
-
     sourceSets {
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/.yarnrc
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/.yarnrc
@@ -1,0 +1,1 @@
+--install.mutex network

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    // this is necessary to avoid the plugins to be loaded multiple times
+    // in each subproject's classloader
+    id("org.jetbrains.kotlin.multiplatform") apply false
+    id("org.jetbrains.compose") apply false
+    id("org.jetbrains.kotlin.plugin.compose") apply false
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/build.gradle.kts
@@ -8,27 +8,15 @@ plugins {
 }
 
 kotlin {
-    js(name = "webJs", IR) {
+    js(IR) {
         outputModuleName.set("composeApp")
-        browser {
-            commonWebpackConfig {
-                outputFileName = "composeApp.js"
-            }
-        }
-        binaries.executable()
+        browser { }
     }
 
     @OptIn(ExperimentalWasmDsl::class)
-    wasmJs(name = "webWasm") {
+    wasmJs {
         outputModuleName.set("composeApp")
-        browser {
-            val rootDirPath = project.rootDir.path
-            val projectDirPath = project.projectDir.path
-            commonWebpackConfig {
-                outputFileName = "composeApp.js"
-            }
-        }
-        binaries.executable()
+        browser { }
     }
 
     sourceSets {
@@ -41,11 +29,11 @@ kotlin {
             dependsOn(commonMain.get())
         }
 
-        val webJsMain by getting {
+        val jsMain by getting {
             dependsOn(webMain)
         }
 
-        val webWasmMain by getting {
+        val wasmJsMain by getting {
             dependsOn(webMain)
         }
     }

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/jsMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/jsMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class JsPlatform : Platform {
+    override val name: String = "Web with Kotlin/JS"
+}
+
+actual fun getPlatform(): Platform = JsPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/wasmJsMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/wasmJsMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class WasmPlatform : Platform {
+    override val name: String = "Web with Kotlin/Wasm"
+}
+
+actual fun getPlatform(): Platform = WasmPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/webMain/kotlin/Greeting.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/webMain/kotlin/Greeting.kt
@@ -1,0 +1,9 @@
+package org.example.project
+
+class Greeting {
+    private val platform = getPlatform()
+
+    fun greet(): String {
+        return "Hello, ${platform.name}!"
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/webMain/kotlin/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/webMain/kotlin/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+interface Platform {
+    val name: String
+}
+
+expect fun getPlatform(): Platform

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/webMain/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/composeApp/src/webMain/kotlin/main.kt
@@ -1,0 +1,5 @@
+package org.example.project
+
+fun main() {
+    println(Greeting().greet())
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/gradle/libs.versions.toml
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/gradle/libs.versions.toml
@@ -1,0 +1,6 @@
+[versions]
+androidx-lifecycle = "2.9.1"
+
+[libraries]
+androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmNonExecutable/settings.gradle.kts
@@ -1,0 +1,41 @@
+rootProject.name = "WebJsMain"
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+pluginManagement {
+    plugins {
+        id("org.jetbrains.kotlin.multiplatform") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.kotlin.plugin.compose") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.compose") version "COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER"
+    }
+    repositories {
+        mavenLocal()
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        maven {
+            url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        }
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+}
+
+include(":composeApp")

--- a/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webJsWasmReconfigured/composeApp/build.gradle.kts
@@ -31,8 +31,6 @@ kotlin {
         binaries.executable()
     }
 
-    // Simple task that prints "Hello World" to the console
-
     sourceSets {
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/.yarnrc
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/.yarnrc
@@ -1,0 +1,1 @@
+--install.mutex network

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    // this is necessary to avoid the plugins to be loaded multiple times
+    // in each subproject's classloader
+    id("org.jetbrains.kotlin.multiplatform") apply false
+    id("org.jetbrains.compose") apply false
+    id("org.jetbrains.kotlin.plugin.compose") apply false
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/build.gradle.kts
@@ -8,18 +8,8 @@ plugins {
 }
 
 kotlin {
-    js(name = "webJs", IR) {
-        outputModuleName.set("composeApp")
-        browser {
-            commonWebpackConfig {
-                outputFileName = "composeApp.js"
-            }
-        }
-        binaries.executable()
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
-    wasmJs(name = "webWasm") {
+    wasmJs {
         outputModuleName.set("composeApp")
         browser {
             val rootDirPath = project.rootDir.path
@@ -41,11 +31,7 @@ kotlin {
             dependsOn(commonMain.get())
         }
 
-        val webJsMain by getting {
-            dependsOn(webMain)
-        }
-
-        val webWasmMain by getting {
+        val wasmJsMain by getting {
             dependsOn(webMain)
         }
     }

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/wasmJsMain/kotlin/org/example/project/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/wasmJsMain/kotlin/org/example/project/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+private class WasmPlatform : Platform {
+    override val name: String = "Web with Kotlin/Wasm"
+}
+
+actual fun getPlatform(): Platform = WasmPlatform()

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/kotlin/Greeting.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/kotlin/Greeting.kt
@@ -1,0 +1,9 @@
+package org.example.project
+
+class Greeting {
+    private val platform = getPlatform()
+
+    fun greet(): String {
+        return "Hello, ${platform.name}!"
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/kotlin/Platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/kotlin/Platform.kt
@@ -1,0 +1,7 @@
+package org.example.project
+
+interface Platform {
+    val name: String
+}
+
+expect fun getPlatform(): Platform

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/kotlin/main.kt
@@ -1,0 +1,5 @@
+package org.example.project
+
+fun main() {
+    println(Greeting().greet())
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/resources/index.html
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/resources/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KotlinProject</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+</head>
+<body>
+</body>
+<script type="application/javascript" src="composeApp.js"></script>
+
+</html>

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/resources/styles.css
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/composeApp/src/webMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/gradle/libs.versions.toml
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/gradle/libs.versions.toml
@@ -1,0 +1,6 @@
+[versions]
+androidx-lifecycle = "2.9.1"
+
+[libraries]
+androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }

--- a/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/webWasmOnly/settings.gradle.kts
@@ -1,0 +1,41 @@
+rootProject.name = "WebJsMain"
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+pluginManagement {
+    plugins {
+        id("org.jetbrains.kotlin.multiplatform") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.kotlin.plugin.compose") version "KOTLIN_VERSION_PLACEHOLDER"
+        id("org.jetbrains.compose") version "COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER"
+    }
+    repositories {
+        mavenLocal()
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        maven {
+            url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        }
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+}
+
+include(":composeApp")


### PR DESCRIPTION
composeCompatibilityBrowserDistribution: Skip web targets where executable is not configures

Fixes https://youtrack.jetbrains.com/issue/CMP-8760/Compatibility-task-breaks-build-of-Compose-library-modules

## Testing
Manual and running `WebCompatibilityDistributionTest`

## Release Notes
N / A