### PR TITLE
Revert compose in gradle tests

### DIFF
--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -8,7 +8,7 @@ kotlin.code.style=official
 dev.junit.parallel=false
 
 # Default version of Compose Libraries used by Gradle plugin
-compose.version=1.9.0-rc01
+compose.version=1.8.2
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
 compose.tests.kotlin.version=2.2.0
 # __SUPPORTED_GRADLE_VERSIONS__


### PR DESCRIPTION
After combination of #5399 and #5400

Build fails with
```
org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.jetbrains.compose.material3:material3:1.9.0-rc01.
```

It happens because material3 is uncoupled in that version, but if gradle plugin is built from sources with passing compose version as 1.9.0-rc01, and using it as material3 alias - it's just invalid state. Revert to 1.8.2 as hotfix.

## Release Notes
N/A