### PR TITLE
Bump kotlin in gradle tests

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -86,8 +86,8 @@ class GradlePluginTest : GradlePluginTestBase() {
             }
         }
 
-    // Note: we can't test non-jvm targets with Kotlin older than 2.1.0, because of klib abi version bump in 2.1.0
-    private val oldestSupportedKotlinVersion = "2.1.0"
+    // Note: we can't test non-jvm targets with Kotlin older than 2.2.0, because of klib abi version bump in 2.2.0
+    private val oldestSupportedKotlinVersion = "2.2.0"
     @Test
     fun testOldestKotlinMpp() = with(
         testProject(

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -10,7 +10,7 @@ dev.junit.parallel=false
 # Default version of Compose Libraries used by Gradle plugin
 compose.version=1.9.0-rc01
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
-compose.tests.kotlin.version=2.2.20-RC
+compose.tests.kotlin.version=2.2.0
 # __SUPPORTED_GRADLE_VERSIONS__
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -10,7 +10,7 @@ dev.junit.parallel=false
 # Default version of Compose Libraries used by Gradle plugin
 compose.version=1.9.0-rc01
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
-compose.tests.kotlin.version=2.2.0
+compose.tests.kotlin.version=2.2.20-RC
 # __SUPPORTED_GRADLE_VERSIONS__
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config


### PR DESCRIPTION
Compose now uses Kotlin 2.2 with incompatiable ABI

## Release Notes
N/A