### PR TITLE
Make ResourceEnvironment public

### DIFF
--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.kt
@@ -5,11 +5,12 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.intl.Locale
 
-class ResourceEnvironment internal constructor(
-    internal val language: LanguageQualifier,
-    internal val region: RegionQualifier,
-    internal val theme: ThemeQualifier,
-    internal val density: DensityQualifier
+@ExperimentalResourceApi
+class ResourceEnvironment(
+   val language: LanguageQualifier,
+   val region: RegionQualifier,
+   val theme: ThemeQualifier,
+   val density: DensityQualifier
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -32,6 +33,18 @@ class ResourceEnvironment internal constructor(
         result = 31 * result + density.hashCode()
         return result
     }
+
+    fun copy(
+        language: LanguageQualifier = this.language,
+        region: RegionQualifier = this.region,
+        theme: ThemeQualifier = this.theme,
+        density: DensityQualifier = this.density
+    ) = ResourceEnvironment(
+        language = language,
+        region = region,
+        theme = theme,
+        density = density
+    )
 }
 
 internal interface ComposeEnvironment {

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/StringResources.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/StringResources.kt
@@ -38,8 +38,14 @@ fun stringResource(resource: StringResource): String {
  *
  * @throws IllegalArgumentException If the provided ID is not found in the resource file.
  */
-suspend fun getString(resource: StringResource): String =
-    loadString(resource, DefaultResourceReader, getSystemResourceEnvironment())
+suspend fun getString(
+    resource: StringResource,
+    reader: ResourceReader = DefaultResourceReader
+): String = loadString(
+    resource = resource,
+    resourceReader = reader,
+    environment = getSystemResourceEnvironment()
+)
 
 /**
  * Loads a string using the specified string resource.
@@ -50,8 +56,15 @@ suspend fun getString(resource: StringResource): String =
  *
  * @throws IllegalArgumentException If the provided ID is not found in the resource file.
  */
-suspend fun getString(environment: ResourceEnvironment, resource: StringResource): String =
-    loadString(resource, DefaultResourceReader, environment)
+suspend fun getString(
+    environment: ResourceEnvironment,
+    resource: StringResource,
+    reader: ResourceReader = DefaultResourceReader
+): String = loadString(
+    resource = resource,
+    resourceReader = reader,
+    environment = environment
+)
 
 private suspend fun loadString(
     resource: StringResource,
@@ -91,11 +104,15 @@ fun stringResource(resource: StringResource, vararg formatArgs: Any): String {
  *
  * @throws IllegalArgumentException If the provided ID is not found in the resource file.
  */
-suspend fun getString(resource: StringResource, vararg formatArgs: Any): String = loadString(
-    resource,
-    formatArgs.map { it.toString() },
-    DefaultResourceReader,
-    getSystemResourceEnvironment()
+suspend fun getString(
+    resource: StringResource,
+    reader: ResourceReader = DefaultResourceReader,
+    vararg formatArgs: Any
+): String = loadString(
+    resource = resource,
+    args = formatArgs.map { it.toString() },
+    resourceReader = reader,
+    environment = getSystemResourceEnvironment()
 )
 
 /**
@@ -111,12 +128,13 @@ suspend fun getString(resource: StringResource, vararg formatArgs: Any): String 
 suspend fun getString(
     environment: ResourceEnvironment,
     resource: StringResource,
+    reader: ResourceReader = DefaultResourceReader,
     vararg formatArgs: Any
 ): String = loadString(
-    resource,
-    formatArgs.map { it.toString() },
-    DefaultResourceReader,
-    environment
+    resource = resource,
+    args = formatArgs.map { it.toString() },
+    resourceReader = reader,
+    environment = environment
 )
 
 private suspend fun loadString(


### PR DESCRIPTION
# Problem
Currently, `StringResources.getString(...)` and `ResourceEnvironment` are only convenient to use inside a composition. For **server-side rendering (SSR)** with Kotlin/WasmJS, we need to serve html pages that are SEO-friendly and localized. This requires access to string resources **outside composition** and the ability to configure a `ResourceEnvironment` manually.

# Proposed Changes
1. **ResourceEnvironment**
   - Made public (`language`, `region`, `theme`, `density` now public `val`s).
   - Added a `copy(...)` helper to allow modification without exposing a `data class`.

2. **StringResources**
   - Added overloads of `getString(...)` that accept a `ResourceReader` parameter (default: `DefaultResourceReader`).
   - This enables reading localized strings outside of composition while keeping composition-aware behavior unchanged.

# Motivation
- SSR requires rendering UI to HTML on the server, not just in the browser.
- Without these changes, we cannot reliably access localized strings during SSR, leading to incomplete or incorrect rendering.
- The ability to override `ResourceEnvironment` is crucial for generating pages in multiple locales programmatically.

# Open Questions
- The current PR only adds support for **strings**. Should we extend a similar pattern to other resource types (images, fonts, etc.) for consistency?
- Binary compatibility: do we need to preserve exact overloads of the old `getString` signatures to avoid breaking precompiled binaries?This change allows to access resources outside the composition while also allowing configuring ResourceEnvironment.

The reason behind this change is to simplify the generation of SSR pages for Kotlin/WasmJs while also respecting localization.
