### PR TITLE
Don't throw an error if a context is null in the DefaultAndroidResourceReader

### DIFF
--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceReader.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceReader.kt
@@ -4,7 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 
-class MissingResourceException(path: String) : Exception("Missing resource with path: $path")
+class MissingResourceException(path: String) : Exception("Missing resource with path: $path") {
+    internal constructor(path: String, message: String) : this("$path. $message")
+}
 
 /**
  * Reads the content of the resource file at the specified path and returns it as a byte array.


### PR DESCRIPTION
It fixes Robolectric tests where a context is available through InstrumentationRegistry

Fixes https://youtrack.jetbrains.com/issue/CMP-6612

## Release Notes
### Fixes - Resources
- Fix resource access in a Robolectric test environment.
