### PR TITLE
Add ui-backhandler dependency shortcut

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -78,6 +78,7 @@ abstract class ComposePlugin : Plugin<Project> {
         val runtime get() = composeDependency("org.jetbrains.compose.runtime:runtime")
         val runtimeSaveable get() = composeDependency("org.jetbrains.compose.runtime:runtime-saveable")
         val ui get() = composeDependency("org.jetbrains.compose.ui:ui")
+        val uiBackHandler get() = composeDependency("org.jetbrains.compose.ui:ui-backhandler")
         @Deprecated("Use desktop.uiTestJUnit4", replaceWith = ReplaceWith("desktop.uiTestJUnit4"))
         @ExperimentalComposeLibrary
         val uiTestJUnit4 get() = composeDependency("org.jetbrains.compose.ui:ui-test-junit4")


### PR DESCRIPTION
In [1.8.0 release](https://github.com/JetBrains/compose-multiplatform/releases/tag/v1.8.0) multiplatform `BackHandler` and `PredictiveBackHandler` were implemented. But shortcut for `ui-backhandler` dependency wasn't. To be able to use 
`BackHandler` you have to manually add `org.jetbrains.compose.ui:ui-backhandler` dependency.

Now you add the dependency like this:
```kotlin
dependencies {
    implementation(compose.uiBackHandler)
}
```