### PR TITLE
[html][tests] Explicitely set executable flag for gradlew in integrat…

### DIFF
--- a/html/compose-compiler-integration/build.gradle.kts
+++ b/html/compose-compiler-integration/build.gradle.kts
@@ -104,7 +104,7 @@ private fun build(
         throw GradleException("Failed to start Gradle process. Command: ${command.joinToString(" ")}", e)
     }
 
-    val finished = proc.waitFor(5, TimeUnit.MINUTES)
+    val finished = proc.waitFor(10, TimeUnit.MINUTES)
     if (!finished) {
         proc.destroyForcibly()
         throw GradleException("Gradle process timed out for $caseName. Command: ${command.joinToString(" ")}")


### PR DESCRIPTION
This PR is a supposed fix for https://youtrack.jetbrains.com/issue/CMP-8990
Basically the problem is that `copyRecursively` does not guarantee execution flag to be preserved

## Testing
`./gradlew checkComposeCases`

## Release Notes
N/A