### PR TITLE
Fix getSystemEnvironment crash on web when a locale region is undefined

### DIFF
--- a/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.js.kt
+++ b/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.js.kt
@@ -5,7 +5,11 @@ import kotlinx.browser.window
 private external class Intl {
     class Locale(locale: String) {
         val language: String
-        val region: String
+
+        // Intl.Locale.region can be undefined.
+        // For example, new Int.Locale('en') instead of new Int.Locale('en-NL').
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/region
+        val region: String?
     }
 }
 
@@ -16,7 +20,7 @@ internal actual fun getSystemEnvironment(): ResourceEnvironment {
     val dpi: Int = (window.devicePixelRatio * 96).toInt()
     return ResourceEnvironment(
         language = LanguageQualifier(locale.language),
-        region = RegionQualifier(locale.region),
+        region = RegionQualifier(locale.region ?: ""),
         theme = ThemeQualifier.selectByValue(isDarkTheme),
         density = DensityQualifier.selectByValue(dpi)
     )

--- a/components/resources/library/src/wasmJsMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.wasmJs.kt
+++ b/components/resources/library/src/wasmJsMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.wasmJs.kt
@@ -5,7 +5,11 @@ import kotlinx.browser.window
 private external class Intl {
     class Locale(locale: String) {
         val language: String
-        val region: String
+
+        // Intl.Locale.region can be undefined.
+        // For example, new Int.Locale('en') instead of new Int.Locale('en-NL').
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/region
+        val region: String?
     }
 }
 
@@ -16,7 +20,7 @@ internal actual fun getSystemEnvironment(): ResourceEnvironment {
     val dpi: Int = (window.devicePixelRatio * 96).toInt()
     return ResourceEnvironment(
         language = LanguageQualifier(locale.language),
-        region = RegionQualifier(locale.region),
+        region = RegionQualifier(locale.region ?: ""),
         theme = ThemeQualifier.selectByValue(isDarkTheme),
         density = DensityQualifier.selectByValue(dpi)
     )

--- a/components/resources/library/src/webTest/kotlin/org/jetbrains/compose/resources/ResourceEnvironmentTest.wasm.kt
+++ b/components/resources/library/src/webTest/kotlin/org/jetbrains/compose/resources/ResourceEnvironmentTest.wasm.kt
@@ -1,0 +1,50 @@
+package org.jetbrains.compose.resources
+
+import kotlinx.browser.window
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ResourceEnvironmentTest {
+
+    // covers https://youtrack.jetbrains.com/issue/CMP-6930 (also see the comments)
+    @Test
+    fun usingLocaleWithoutRegion() {
+        val originalLanguage = window.navigator.language
+        configureLanguage("en")
+
+        try {
+            val env = getSystemEnvironment()
+            assertEquals("", env.region.region)
+            assertEquals("en", env.language.language)
+        } finally {
+            configureLanguage(originalLanguage)
+        }
+    }
+
+    @Test
+    fun usingLocaleWithRegion() {
+        val originalLanguage = window.navigator.language
+        configureLanguage("en-NL")
+
+        try {
+            val env = getSystemEnvironment()
+            assertEquals("NL", env.region.region)
+            assertEquals("en", env.language.language)
+        } finally {
+            configureLanguage(originalLanguage)
+        }
+
+    }
+}
+
+//language=js
+private fun configureLanguage(language: String) {
+    js("""
+       Object.defineProperty(window.navigator, 'language', {
+            get: function () {
+                return language;
+            },
+            configurable: true
+        });
+    """)
+}


### PR DESCRIPTION
Handle a case when Int.Locale('...') is created without a region - then use an empty string for region.

Fixes https://youtrack.jetbrains.com/issue/CMP-6930

## Testing
- Added a test
- This should be tested by QA

## Release Notes
### Fixes - Resources
- Fix a crash when calling `getString` and the Locale has no region specified
