### PR TITLE
update maven template to use embedded variant of compose compiler

### DIFF
--- a/ci/templates/maven-test-project/pom.xml
+++ b/ci/templates/maven-test-project/pom.xml
@@ -58,7 +58,7 @@
                 </executions>
                 <configuration>
                     <args>
-                        <arg>-Xplugin=${user.home}/.m2/repository/org/jetbrains/kotlin/kotlin-compose-compiler-plugin/${kotlin.version}/kotlin-compose-compiler-plugin-${kotlin.version}.jar</arg>
+                        <arg>-Xplugin=${user.home}/.m2/repository/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/${kotlin.version}/kotlin-compose-compiler-plugin-embeddable-${kotlin.version}.jar</arg>
                     </args>
                 </configuration>
             </plugin>
@@ -187,7 +187,7 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-compose-compiler-plugin</artifactId>
+            <artifactId>kotlin-compose-compiler-plugin-embeddable</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Maven template updated to use embedded variant of compose compiler plugin
Fixes [[CMP-8859]](https://youtrack.jetbrains.com/issue/CMP-8859)

## Testing
manual testing

## Release Notes
N/A