### PR TITLE
Temporally disable hot reload tests 

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/HotReloadTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/HotReloadTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 import kotlin.concurrent.thread
 
 class HotReloadTest : GradlePluginTestBase() {
-    @Disabled
+    @Disabled("TODO: install JBR on CI for the test to pass")
     @Test
     fun testHotReloadTaskRegisteredInJvmProject() = with(testProject("application/jvm")) {
         gradle("hotRun", "--dry-run").checks {
@@ -20,7 +20,7 @@ class HotReloadTest : GradlePluginTestBase() {
         }
     }
 
-    @Disabled
+    @Disabled("TODO: install JBR on CI for the test to pass")
     @Test
     fun testHotReloadTaskRegisteredInKmpProject() = with(testProject("application/mpp")) {
         gradle("hotRunJvm", "--dry-run").checks {
@@ -49,7 +49,7 @@ class HotReloadTest : GradlePluginTestBase() {
         Thread.sleep(1000)
     }
 
-    @Disabled
+    @Disabled("TODO: install JBR on CI for the test to pass")
     @Test
     fun testHotReload() = with(testProject("application/hotReload")) {
         var result: BuildResult? = null
@@ -95,7 +95,7 @@ class HotReloadTest : GradlePluginTestBase() {
         gradleRunnerWorkaround()
     }
 
-    @Disabled
+    @Disabled("TODO: install JBR on CI for the test to pass")
     @Test
     fun testExternalHotReload() = with(testProject("application/mpp")) {
         val externalHotReloadVersion = "1.0.0-rc01"


### PR DESCRIPTION
Temporally disable hot reload tests  until JBR is installed in docker container for the tests on CI

## Release Notes
N/A