### PR TITLE
CMP-8068 Fix crash in `getSystemEnvironment` on headless desktop

### DIFF
--- a/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.desktop.kt
+++ b/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceEnvironment.desktop.kt
@@ -2,6 +2,7 @@ package org.jetbrains.compose.resources
 
 import org.jetbrains.skiko.SystemTheme
 import org.jetbrains.skiko.currentSystemTheme
+import java.awt.GraphicsEnvironment
 import java.awt.Toolkit
 import java.util.*
 
@@ -9,7 +10,12 @@ internal actual fun getSystemEnvironment(): ResourceEnvironment {
     val locale = Locale.getDefault()
     //FIXME: don't use skiko internals
     val isDarkTheme = currentSystemTheme == SystemTheme.DARK
-    val dpi = Toolkit.getDefaultToolkit().screenResolution
+    val dpi = if (GraphicsEnvironment.isHeadless()) {
+        // Default to 1x ("unscaled") resources when DPI info not available
+        DensityQualifier.MDPI.dpi
+    } else {
+        Toolkit.getDefaultToolkit().screenResolution
+    }
     return ResourceEnvironment(
         language = LanguageQualifier(locale.language),
         region = RegionQualifier(locale.country),


### PR DESCRIPTION
Fixes a crash in `getSystemEnvironment` on desktop when running in a headless environment (such as most CI runners) by providing a default density qualifier. In the future that might be something that's nice to make configurable, but since both our use case and the linked issue encountered it when calling `getString` I didn't worry about it too hard.

Fixes [CMP-8068](https://youtrack.jetbrains.com/issue/CMP-8068)

## Testing

Made a local build and used it to run some tests in another project that were failing on calls to `getString`

## Release Notes
### Fixes - Resources
- Fix crash in `getSystemEnvironment` on headless desktop
