### PR TITLE
Bump hot reload version to 1.0.0-rc03

### DIFF
--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ plugin-android = "8.10.1"
 shadow-jar = "8.1.1"
 publish-plugin = "1.2.1"
 # we use "prefer" here for the strategy: "explicitly specified hot reload plugin always wins".
-plugin-hot-reload = { prefer = "1.0.0-rc02" }
+plugin-hot-reload = { prefer = "1.0.0-rc03" }
 
 [libraries]
 download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }


### PR DESCRIPTION
Bump hot reload version to 1.0.0-rc03

Fixes: https://github.com/JetBrains/compose-hot-reload/issues/96, [CMP-9248](https://youtrack.jetbrains.com/issue/CMP-9248)

## Release Notes
### Fixes - Desktop
- _(prerelease fix)_ Fixed issue where it's unable to create run task 'jvmDesktopRun'
- _(prerelease fix)_ Fixed issue where the Java installation could not be found.

