### PR TITLE
Fix task dependency for Android Studio previews

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/AndroidResources.kt
@@ -189,7 +189,7 @@ private fun Project.configureGeneratedAndroidComponentAssets(
     )
     tasks.configureEach { task ->
         //fix agp task dependencies for AndroidStudio preview
-        if (task.name == "compile${camelComponentName}Sources") {
+        if (task.name == "package${camelComponentName}Resources") {
             task.dependsOn(copyComponentAssets)
         }
         //fix linter task dependencies for `build` task

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/appModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/appModule/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("org.jetbrains.compose")
+    kotlin("plugin.compose")
+    id("com.android.application")
+}
+
+android {
+    namespace = "me.sample.app"
+    compileSdk = 35
+    defaultConfig {
+        applicationId = "org.example.project"
+        minSdk = 23
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+    }
+}
+
+dependencies {
+    implementation(project(":featureModule"))
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/appModule/src/main/AndroidManifest.xml
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/appModule/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+    <application/>
+</manifest>

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/appModule/src/main/kotlin/me/sample/app/App.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/appModule/src/main/kotlin/me/sample/app/App.kt
@@ -1,0 +1,17 @@
+package me.sample.app
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import oldagpresources.featuremodule.generated.resources.*
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun App() {
+    Column {
+        val txt = "text: "
+        Text(txt + stringResource(Res.string.str_1))
+        MyFeatureText(txt = txt)
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id("org.jetbrains.compose").apply(false)
+    kotlin("multiplatform").apply(false)
+    kotlin("plugin.compose").apply(false)
+    id("com.android.library").apply(false)
+    id("com.android.application").apply(false)
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/featureModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/featureModule/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("org.jetbrains.compose")
+    kotlin("multiplatform")
+    kotlin("plugin.compose")
+    id("com.android.library")
+}
+
+kotlin {
+    jvm()
+
+    androidTarget()
+
+    sourceSets {
+        commonMain.dependencies {
+            api(compose.runtime)
+            api(compose.material3)
+            api(compose.components.resources)
+        }
+    }
+}
+android {
+    namespace = "me.sample.feature"
+    compileSdk = 35
+}
+
+compose.resources {
+    publicResClass = true
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/featureModule/src/commonMain/composeResources/values/strings.xml
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/featureModule/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="str_1">Feature text str_1</string>
+</resources>

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/featureModule/src/commonMain/kotlin/me/sample/app/Feature.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/featureModule/src/commonMain/kotlin/me/sample/app/Feature.kt
@@ -1,0 +1,12 @@
+package me.sample.app
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.resources.stringResource
+import oldagpresources.featuremodule.generated.resources.*
+
+@Composable
+fun MyFeatureText(modifier: Modifier = Modifier, txt: String) {
+    Text(txt + stringResource(Res.string.str_1), modifier)
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/gradle.properties
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+kotlin.code.style=official
+android.useAndroidX=true

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/settings.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/settings.gradle.kts
@@ -1,0 +1,29 @@
+rootProject.name = "oldAgpResources"
+include(":featureModule")
+include(":appModule")
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
+    }
+    plugins {
+        id("org.jetbrains.kotlin.multiplatform").version("KOTLIN_VERSION_PLACEHOLDER")
+        id("org.jetbrains.kotlin.plugin.compose").version("KOTLIN_VERSION_PLACEHOLDER")
+        id("org.jetbrains.compose").version("COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER")
+        id("com.android.library").version("AGP_VERSION_PLACEHOLDER")
+        id("com.android.application").version("AGP_VERSION_PLACEHOLDER")
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        google()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
+        mavenLocal()
+    }
+}


### PR DESCRIPTION
Fixes [CMP-7170](https://youtrack.jetbrains.com/issue/CMP-7170) Resources / Preview: NullPointerException with Android previews when accessing compose resources from another module

## Testing
Integration test

## Release Notes
### Fixes - Resources
- Fix resource gradle tasks invocation on AGP < 9.0.0 for Android Studio previews
