### PR TITLE
Fix maven example - explicitly add `ui` dependency to align version

### DIFF
--- a/ci/templates/maven-test-project/pom.xml
+++ b/ci/templates/maven-test-project/pom.xml
@@ -12,9 +12,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
-        <kotlin.version>2.1.21</kotlin.version>
-        <compose.version>1.9.1</compose.version>
-        <compose.material3.version>1.9.0-beta04</compose.material3.version>
+        <kotlin.version>2.2.21</kotlin.version>
+        <compose.version>1.9.3</compose.version>
+        <compose.material3.version>1.9.0</compose.material3.version>
     </properties>
 
     <repositories>
@@ -98,6 +98,11 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.compose.ui</groupId>
+            <artifactId>ui-desktop</artifactId>
+            <version>${compose.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.compose.foundation</groupId>


### PR DESCRIPTION
Fix possible un-sync between `compose.ui` and `compose.foundation` in `ci/templates/maven-test-project`.

## Release Notes
N/A