### PR TITLE
Downgrade Kotlin to 2.2.20 in libraries

### DIFF
--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.configuration-cache=true
 android.useAndroidX=true
 
 #Versions
-kotlin.version=2.2.21
+kotlin.version=2.2.20
 agp.version=8.9.0
 compose.version=1.9.0
 deploy.version=9999.0.0-SNAPSHOT

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -11,7 +11,7 @@ dev.junit.parallel=false
 compose.version=1.10.0-alpha02
 compose.material3.version=1.9.0-beta03
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
-compose.tests.kotlin.version=2.2.21
+compose.tests.kotlin.version=2.2.20
 # __SUPPORTED_GRADLE_VERSIONS__
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config

--- a/html/buildSrc/gradle.properties
+++ b/html/buildSrc/gradle.properties
@@ -1,1 +1,1 @@
-kotlin.version=2.2.21
+kotlin.version=2.2.20


### PR DESCRIPTION
[CMP-9273](https://youtrack.jetbrains.com/issue/CMP-9273) Using Kotlin 2.2.20 in user project cause build error

## Release Notes
### Fixes - Resources
- _(prerelease fix)_ Fixed compatibility with Kotlin 2.2.20 on Web
