### PR TITLE
Increase Maven Upload socket timeout

### DIFF
--- a/ci/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/DownloadFromSpaceTask.kt
+++ b/ci/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/DownloadFromSpaceTask.kt
@@ -34,7 +34,9 @@ abstract class DownloadFromSpaceMavenRepoTask : DefaultTask() {
         val groupUrl = module.groupId.replace(".", "/")
 
         val filesListingDocument =
-            Jsoup.connect("${spaceRepoUrl.get()}/$groupUrl/${module.artifactId}/${module.version}/").get()
+            Jsoup.connect("${spaceRepoUrl.get()}/$groupUrl/${module.artifactId}/${module.version}/")
+                .timeout(180_000)
+                .get()
         val downloadableFiles = HashMap<String, URL>()
         for (a in filesListingDocument.select("#contents > a")) {
             val href = a.attributes().get("href")

--- a/ci/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/utils/SpaceApiClient.kt
+++ b/ci/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/utils/SpaceApiClient.kt
@@ -57,7 +57,7 @@ internal class SpaceApiClient(
             HttpClient(OkHttp) {
                 configureKtorClientForSpace()
                 install(HttpTimeout) {
-                    socketTimeoutMillis = 120_000
+                    socketTimeoutMillis = 180_000
                 }
             }.use { client ->
                 val space = SpaceClient(


### PR DESCRIPTION
Continuation of https://github.com/JetBrains/compose-multiplatform/pull/5486

Attempt to fix:
```
  Caused by: java.net.SocketTimeoutException: Read timed out
13:45:18    at org.jsoup.helper.HttpConnection$Response.execute(HttpConnection.java:867)
13:45:18    at org.jsoup.helper.HttpConnection$Response.execute(HttpConnection.java:829)
13:45:18    at org.jsoup.helper.HttpConnection.execute(HttpConnection.java:366)
13:45:18    at org.jsoup.helper.HttpConnection.get(HttpConnection.java:353)
13:45:18    at org.jetbrains.compose.internal.publishing.DownloadFromSpaceMavenRepoTask.downloadArtifactsFromComposeDev(DownloadFromSpaceTask.kt:37)
13:45:18    at org.jetbrains.compose.internal.publishing.DownloadFromSpaceMavenRepoTask.run(DownloadFromSpaceTask.kt:28)
13:45:18    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
13:45:18    at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:125)
13:45:18    ... 117 more
```

happened at [20-11-2025](https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Task5UploadToMavenCentral/5680809?showLog=5680809_16241_16045&logView=flowAware)

The default socket timeout is 30 seconds according JSoup docs

## Testing
1. create a Space client key
2. set env. vars: COMPOSE_REPO_USERNAME, COMPOSE_DEV_REPO_PROJECT_ID, COMPOSE_REPO_KEY, COMPOSE_DEV_REPO_REPO_ID
3. run
```
./gradlew -p=cli downloadArtifactsFromComposeDev --info --stacktrace "-Pmaven.central.coordinates=org.jetbrains.androidx.lifecycle:*:2.10.0-alpha05,org.jetbrains.androidx.navigation3:*:1.0.0-alpha05,org.jetbrains.androidx.navigationevent:*:1.0.0-beta02,org.jetbrains.androidx.savedstate:*:1.4.0-rc01,org.jetbrains.androidx.window:*:1.5.0" "-Pmaven.central.deployName=CMP 1.10.0-beta02 (org.jetbrains.androidx)" --rerun-tasks
```

## Release Notes
N/A