### PR TITLE
[cherry-pick]  Bump Compose Hot Reload to 1.0.0 Stable in Compose Gradle plugin (#5491)

### DIFF
--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ plugin-android = "8.10.1"
 shadow-jar = "8.1.1"
 publish-plugin = "1.2.1"
 # we use "prefer" here for the strategy: "explicitly specified hot reload plugin always wins".
-plugin-hot-reload = { prefer = "1.0.0-rc03" }
+plugin-hot-reload = { prefer = "1.0.0" }
 
 [libraries]
 download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }


### PR DESCRIPTION
Cherry pick of https://github.com/JetBrains/compose-multiplatform/pull/5491

## Release Notes
N/A