### PR TITLE
Bump CHR version to 1.1.0-alpha03

### DIFF
--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ plugin-android = "8.10.1"
 shadow-jar = "8.1.1"
 publish-plugin = "1.2.1"
 # we use "prefer" here for the strategy: "explicitly specified hot reload plugin always wins".
-plugin-hot-reload = { prefer = "1.0.0" }
+plugin-hot-reload = { prefer = "1.1.0-alpha03" }
 
 [libraries]
 download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }


### PR DESCRIPTION
## Release Notes
### Features - Desktop
- _(prerelease fix)_  Compose 1.11 pre-release versions come with pre-release versions of [Compose Hot Reload ](https://github.com/JetBrains/compose-hot-reload) 1.1 now