### PR TITLE
Allow major version to be 0 on macOS

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/validatePackageVersions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/validatePackageVersions.kt
@@ -169,7 +169,7 @@ private object WindowsVersionChecker : VersionChecker {
 
 private object MacVersionChecker : VersionChecker {
     override val correctFormat = """|'MAJOR[.MINOR][.PATCH]', where:
-        |    * MAJOR is an integer > 0;
+        |    * MAJOR is a non-negative integer;
         |    * MINOR is an optional non-negative integer;
         |    * PATCH is an optional non-negative integer;
     """.trimMargin()
@@ -180,6 +180,5 @@ private object MacVersionChecker : VersionChecker {
         return parts.isNotEmpty()
                 && parts.size <= 3
                 && parts.all { it != null && it >= 0 }
-                && (parts.first() ?: 0) > 0
     }
 }


### PR DESCRIPTION
MacOS .dmg and .pkg files used to require that major versions of CFBundleVersion were greater than 0. See [here](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364).

This is no longer the case. See [here](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion)

Fixes https://youtrack.jetbrains.com/issue/CMP-2360

Adapted from https://github.com/JetBrains/compose-multiplatform/pull/4874

## Release Notes
### Fixes - Gradle Plugin
- Corrected version validation for MacOS `CFBundleVersion`. The major version may now be 0.