### PR TITLE
Add tvOS support in Compose Gradle plugin

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResources.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResources.kt
@@ -29,7 +29,7 @@ internal fun Project.configureSyncIosComposeResources(
 ) {
     if (ComposeProperties.dontSyncResources(project).get()) {
         logger.info(
-            "Compose Multiplatform resource management for iOS is disabled: " +
+            "Compose Multiplatform resource management for Apple platforms (iOS, tvOS, macOS) is disabled: " +
                     "'${ComposeProperties.SYNC_RESOURCES_PROPERTY}' value is 'false'"
         )
         return
@@ -110,9 +110,9 @@ internal fun Project.configureSyncIosComposeResources(
                     it.doFirst {
                         if (specAttributes["resources"] != specAttr) error(
                             """
-                                |Kotlin.cocoapods.extraSpecAttributes["resources"] is not compatible with Compose Multiplatform's resources management for iOS.
+                                |Kotlin.cocoapods.extraSpecAttributes["resources"] is not compatible with Compose Multiplatform's resources management for Apple platforms.
                                 |  * Recommended action: remove extraSpecAttributes["resources"] from '$buildFile' and run '$projectPath:podspec' once;
-                                |  * Alternative action: turn off Compose Multiplatform's resources management for iOS by adding '${ComposeProperties.SYNC_RESOURCES_PROPERTY}=false' to your gradle.properties;
+                                |  * Alternative action: turn off Compose Multiplatform's resources management for Apple platforms by adding '${ComposeProperties.SYNC_RESOURCES_PROPERTY}=false' to your gradle.properties;
                             """.trimMargin()
                         )
                     }
@@ -159,8 +159,18 @@ private fun KotlinNativeTarget.isIosDeviceTarget(): Boolean =
 private fun KotlinNativeTarget.isIosTarget(): Boolean =
     isIosSimulatorTarget() || isIosDeviceTarget()
 
+private fun KotlinNativeTarget.isTvosSimulatorTarget(): Boolean =
+    konanTarget === KonanTarget.TVOS_X64 || konanTarget === KonanTarget.TVOS_SIMULATOR_ARM64
+
+private fun KotlinNativeTarget.isTvosDeviceTarget(): Boolean =
+    konanTarget === KonanTarget.TVOS_ARM64
+
+private fun KotlinNativeTarget.isTvosTarget(): Boolean =
+    isTvosSimulatorTarget() || isTvosDeviceTarget()
+
 private fun KotlinNativeTarget.isMacTarget(): Boolean =
     konanTarget === KonanTarget.MACOS_X64 || konanTarget === KonanTarget.MACOS_ARM64
 
+
 private fun KotlinNativeTarget.isIosOrMacTarget(): Boolean =
-    isIosTarget() || isMacTarget()
+    isIosTarget() || isMacTarget() || isTvosTarget()

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResourcesTasks.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/resources/IosResourcesTasks.kt
@@ -24,7 +24,7 @@ internal abstract class SyncComposeResourcesForIosTask : DefaultTask() {
         return this.orElse(noProvidedValue).map {
             if (it == noProvidedValue) {
                 error(
-                    "Could not infer iOS target $attribute. Make sure to build " +
+                    "Could not infer Apple target $attribute. Make sure to build " +
                             "via XCode (directly or via Kotlin Multiplatform Mobile plugin for Android Studio)"
                 )
             }
@@ -118,6 +118,26 @@ private fun getRequestedKonanTargetsByXcode(platform: String, archs: List<String
             })
         }
 
+        // Add tvOS support
+        platform.startsWith("appletvos") -> {
+            targets.addAll(archs.map { arch ->
+                when (arch) {
+                    "arm64", "arm64e" -> KonanTarget.TVOS_ARM64
+                    else -> error("Unknown tvOS device arch: '$arch'")
+                }
+            })
+        }
+
+        platform.startsWith("appletvsimulator") -> {
+            targets.addAll(archs.map { arch ->
+                when (arch) {
+                    "arm64", "arm64e" -> KonanTarget.TVOS_SIMULATOR_ARM64
+                    "x86_64" -> KonanTarget.TVOS_X64
+                    else -> error("Unknown tvOS simulator arch: '$arch'")
+                }
+            })
+        }
+
         platform.startsWith("macosx") -> {
             targets.addAll(archs.map { arch ->
                 when (arch) {
@@ -139,6 +159,7 @@ private fun getRequestedKonanTargetsByXcode(platform: String, archs: List<String
  * It's set in project.pbxproj
  *
  * SyncComposeResourcesForIosTask fails to work with it right now.
+ * (Note: Despite the name, this task handles all Apple platforms: iOS, tvOS, and macOS)
  *
  * Gradle attempts to create an output folder for SyncComposeResourcesForIosTask on our behalf,
  * so we can't handle an exception when it occurs. Therefore, we make SyncComposeResourcesForIosTask


### PR DESCRIPTION
## Add tvOS Support to Compose Gradle Plugin
### Changes

Add tvOS target detection (tvos_x64, tvos_arm64, tvos_simulator_arm64)
Update isIosOrMacTarget() to include tvOS targets
Add tvOS platform handling in XCode target detection (appletvos, appletvsimulator)
Update error messages to reference "Apple platforms" instead of just "iOS"

Enables Apple TV development with Compose Multiplatform using the same resource management workflow as iOS.
## Testing

Tested on physical Apple TV (tvOS 26.1)
Verified resource sync during Xcode builds
Confirmed iOS, Android, and Desktop builds remain unaffected
Framework generation works for all tvOS targets (arm64, x64, simulator arm64)

## Release Notes
### Features - Gradle Plugin

Add support for tvOS platform in Compose Multiplatform Gradle plugin, enabling Apple TV development with the same resource management capabilities as iOS