### PR TITLE
Remove k/native macosX64 and iosX64 targets

### DIFF
--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
             }
         }
     }
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
     js {
@@ -51,7 +50,6 @@ kotlin {
         }
         binaries.executable()
     }
-    macosX64()
     macosArm64()
 
     applyDefaultHierarchyTemplate()

--- a/components/ui-tooling-preview/demo/shared/build.gradle.kts
+++ b/components/ui-tooling-preview/demo/shared/build.gradle.kts
@@ -19,7 +19,6 @@ kotlin {
     }
     jvm("desktop")
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -38,7 +37,6 @@ kotlin {
     }
 
     listOf(
-        macosX64(),
         macosArm64()
     ).forEach { macosTarget ->
         macosTarget.binaries {

--- a/components/ui-tooling-preview/library/build.gradle.kts
+++ b/components/ui-tooling-preview/library/build.gradle.kts
@@ -19,7 +19,6 @@ kotlin {
             }
         }
     }
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
     js {
@@ -31,7 +30,6 @@ kotlin {
         browser {
         }
     }
-    macosX64()
     macosArm64()
 
     applyDefaultHierarchyTemplate()


### PR DESCRIPTION
AOSP does not support Apple X64 targets anymore
https://android-review.googlesource.com/c/platform/frameworks/support/+/3889609

Fixes https://youtrack.jetbrains.com/issue/CMP-9543/Drop-apple-x64-targets-in-CMP

## Testing
N/A

## Release Notes
### Migration Notes - iOS
- Compose Multiplatform doesn't support Apple x86_64 targets anymore due to [deprecation in Kotlin](https://youtrack.jetbrains.com/issue/KT-81596)
