### PR TITLE
CMP-9545: Cache Storage API extra check for protocol  (#5516)

### DIFF
--- a/components/resources/library/src/webMain/kotlin/org/jetbrains/compose/resources/ResourceWebCache.web.kt
+++ b/components/resources/library/src/webMain/kotlin/org/jetbrains/compose/resources/ResourceWebCache.web.kt
@@ -37,7 +37,7 @@ internal object ResourceWebCache {
     // A mutex to avoid multiple cache reset
     private val resetMutex = Mutex()
 
-    private val supportsCacheApi: Boolean by lazy { supportsCacheApi() }
+    private val supportsCacheApi: Boolean by lazy { supportsCacheApi() && isCacheableProtocol() }
 
     suspend fun load(path: String, onNoCacheHit: suspend (path: String) -> Response): Response {
         if (!supportsCacheApi) return onNoCacheHit(path)
@@ -87,6 +87,10 @@ internal object ResourceWebCache {
 // https://developer.mozilla.org/en-US/docs/Web/API/Window/caches
 // Supported only in secure contexts (HTTPS or localhost)
 private fun supportsCacheApi(): Boolean = js("Boolean(window.caches)")
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Cache/put
+// Ensure the protocol of the request is http / https - edge cases like "vscode-webview:" are not supported by CacheStorage
+private fun isCacheableProtocol(): Boolean = window.location.protocol.startsWith("http")
 
 // Promise.await is not yet available in webMain: https://github.com/Kotlin/kotlinx.coroutines/issues/4544
 // TODO(o.karpovich): get rid of this function, when kotlinx-coroutines provide Promise.await in webMain out of a box


### PR DESCRIPTION
Cherry pick from https://github.com/JetBrains/compose-multiplatform/pull/5516

Fixes
https://youtrack.jetbrains.com/issue/CMP-9545/ComposeResources-on-Web-not-loading-because-Cache-Storage-API-is-not-supported-everywhere

## Testing
This should be tested by QA

## Release Notes
### Fixes - Resources
Fixes an issue where web resources failed to load when calling the Cache Storage API with unsupported protocols (e.g., vscode-webview: in VS Code webviews).


