### PR TITLE
Remove iosX64 target from resources demo

### DIFF
--- a/components/resources/demo/shared/build.gradle.kts
+++ b/components/resources/demo/shared/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
     }
     jvm("desktop")
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->


### PR DESCRIPTION
I missed it when doing https://github.com/JetBrains/compose-multiplatform/pull/5515

## Testing
N/A

## Release Notes
N/A
