### PR TITLE
Clarify deprecation message for `materialIconsExtended`

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -94,7 +94,12 @@ abstract class ComposePlugin : Plugin<Project> {
         val uiUtil get() = composeDependency("org.jetbrains.compose.ui:ui-util")
         @Deprecated("Specify dependency directly", replaceWith = ReplaceWith("\"org.jetbrains.compose.ui:ui-tooling-preview:${ComposeBuildConfig.composeVersion}\""))
         val preview get() = composeDependency("org.jetbrains.compose.ui:ui-tooling-preview")
-        @Deprecated("Specify dependency directly", replaceWith = ReplaceWith("\"org.jetbrains.compose.material:material-icons-extended:1.7.3\""))
+        @Deprecated(
+            "This artifact is pinned to version 1.7.3 and will not receive updates. " +
+                "Either use this version explicitly or migrate to Material Symbols (vector resources). " +
+                "See https://kotlinlang.org/docs/multiplatform/whats-new-compose-180.html",
+            replaceWith = ReplaceWith("\"org.jetbrains.compose.material:material-icons-extended:1.7.3\"")
+        )
         val materialIconsExtended get() = "org.jetbrains.compose.material:material-icons-extended:1.7.3"
         @Deprecated("Specify dependency directly")
         val components get() = CommonComponentsDependencies


### PR DESCRIPTION
## Problem

When using `compose.materialIconsExtended` in Compose Multiplatform 1.10+, developers see the deprecation warning:

```
'val materialIconsExtended: String' is deprecated. Specify dependency directly.
```

This message is confusing because it implies you can simply switch to a direct dependency like other Compose artifacts. However, unlike `compose.runtime` or `compose.ui`, the `material-icons-extended` artifact is **intentionally pinned to version 1.7.3** and newer versions aren't published.

When developers try to follow the deprecation guidance by adding:
```kotlin
implementation("org.jetbrains.compose.material:material-icons-extended:1.10.0")
```

They get a dependency resolution failure because this artifact doesn't exist at that version.

I ran into this while updating dependencies in a project and spent some time investigating before discovering that the artifact was intentionally discontinued after 1.7.3.

## Solution

This PR updates the deprecation message to be more helpful:

```kotlin
@Deprecated(
    "This artifact is pinned to version 1.7.3 and will not receive updates. " +
        "Either use this version explicitly or migrate to Material Symbols (vector resources). " +
        "See https://kotlinlang.org/docs/multiplatform/whats-new-compose-180.html",
    replaceWith = ReplaceWith("\"org.jetbrains.compose.material:material-icons-extended:1.7.3\"")
)
```

The new message:
- Explains that the artifact is pinned and won't receive updates
- Offers two clear migration paths: use 1.7.3 explicitly, or migrate to Material Symbols
- Links to the documentation that explains the change

## Context

- PR #5462 introduced the deprecation for all dependency aliases
- PRs #5151 and #5247 pinned the material-icons-extended version to 1.7.3
- The "What's new in 1.8" docs explain the removal but the deprecation message doesn't connect the dots

## Testing

Built the gradle-plugins module locally and verified the deprecation message appears correctly.

## Release Notes
N/A