### PR TITLE
Clarify deprecation message for `materialIconsExtended` (#5520)

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -92,7 +92,12 @@ abstract class ComposePlugin : Plugin<Project> {
         val uiUtil get() = composeDependency("org.jetbrains.compose.ui:ui-util")
         @Deprecated("Specify dependency directly", replaceWith = ReplaceWith("\"org.jetbrains.compose.ui:ui-tooling-preview:${ComposeBuildConfig.composeVersion}\""))
         val preview get() = composeDependency("org.jetbrains.compose.ui:ui-tooling-preview")
-        @Deprecated("Specify dependency directly", replaceWith = ReplaceWith("\"org.jetbrains.compose.material:material-icons-extended:1.7.3\""))
+        @Deprecated(
+            "This artifact is pinned to version 1.7.3 and will not receive updates. " +
+                "Either use this version explicitly or migrate to Material Symbols (vector resources). " +
+                "See https://kotlinlang.org/docs/multiplatform/whats-new-compose-180.html",
+            replaceWith = ReplaceWith("\"org.jetbrains.compose.material:material-icons-extended:1.7.3\"")
+        )
         val materialIconsExtended get() = "org.jetbrains.compose.material:material-icons-extended:1.7.3"
         @Deprecated("Specify dependency directly")
         val components get() = CommonComponentsDependencies


### PR DESCRIPTION
See #5520 for details
Fixes [CMP-9684](https://youtrack.jetbrains.com/issue/CMP-9684) Clarify deprecation message for materialIconsExtended

## Release Notes
### Fixes - Multiple Platforms
- Improved the deprecation message for `compose.materialIconsExtended` to explain that the artifact is pinned to version `1.7.3` and suggest migration to Material Symbols