### PR TITLE
nav_cupcake android compilesdk 35

### DIFF
--- a/examples/nav_cupcake/gradle/libs.versions.toml
+++ b/examples/nav_cupcake/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.9.0"
 android-compileSdk = "34"
 android-minSdk = "24"
-android-targetSdk = "34"
+android-targetSdk = "35"
 androidx-activity = "1.8.2"
 androidx-lifecycle = "2.9.0"
 androidx-navigation = "2.9.0-rc01"


### PR DESCRIPTION
In the multiplatform nav_cupcake example, building StartOrderPreview failed with compilesdk 35. See logs below.

Upgrading to Android Compilesdk 35 in the nav_cupcake example and rebuilding the StartOrderPreview was successful.

```kotlin
Executing tasks: [:composeApp:compileDebugSources] in project /Users/jq/examples/compose-multiplatform/examples/nav_cupcake
 
Type-safe project accessors is an incubating feature.
 
> Configure project :composeApp
w: Default Kotlin Hierarchy Template Not Applied Correctly
The Default Kotlin Hierarchy Template was not applied to 'project ':composeApp'':
Explicit .dependsOn() edges were configured for the following source sets:
[desktopMain, iosArm64Main, iosMain, iosSimulatorArm64Main, iosX64Main, jbMain, wasmJsMain]
 
Consider removing dependsOn-calls or disabling the default template by adding
    'kotlin.mpp.applyDefaultHierarchyTemplate=false'
to your gradle.properties
Solution: Please remove the dependsOn-calls or disable the default template.
Learn more about hierarchy templates: https://kotl.in/hierarchy-template
 
 
> Task :composeApp:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :composeApp:convertXmlValueResourcesForAndroidMain NO-SOURCE
> Task :composeApp:copyNonXmlValueResourcesForAndroidMain NO-SOURCE
> Task :composeApp:prepareComposeResourcesTaskForAndroidMain NO-SOURCE
> Task :composeApp:generateResourceAccessorsForAndroidMain NO-SOURCE
> Task :composeApp:convertXmlValueResourcesForCommonMain UP-TO-DATE
> Task :composeApp:copyNonXmlValueResourcesForCommonMain UP-TO-DATE
> Task :composeApp:prepareComposeResourcesTaskForCommonMain UP-TO-DATE
> Task :composeApp:generateResourceAccessorsForCommonMain UP-TO-DATE
> Task :composeApp:generateActualResourceCollectorsForAndroidMain UP-TO-DATE
> Task :composeApp:generateComposeResClass UP-TO-DATE
> Task :composeApp:generateExpectResourceCollectorsForCommonMain UP-TO-DATE
> Task :composeApp:convertXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :composeApp:copyNonXmlValueResourcesForAndroidDebug NO-SOURCE
> Task :composeApp:prepareComposeResourcesTaskForAndroidDebug NO-SOURCE
> Task :composeApp:generateResourceAccessorsForAndroidDebug NO-SOURCE
> Task :composeApp:preBuild UP-TO-DATE
> Task :composeApp:preDebugBuild UP-TO-DATE
> Task :composeApp:generateDebugResValues UP-TO-DATE
> Task :composeApp:mapDebugSourceSetPaths UP-TO-DATE
> Task :composeApp:generateDebugResources UP-TO-DATE
> Task :composeApp:checkDebugAarMetadata FAILED
> Task :composeApp:mergeDebugResources UP-TO-DATE
> Task :composeApp:packageDebugResources UP-TO-DATE
> Task :composeApp:parseDebugLocalResources UP-TO-DATE
> Task :composeApp:createDebugCompatibleScreenManifests UP-TO-DATE
> Task :composeApp:extractDeepLinksDebug UP-TO-DATE
> Task :composeApp:processDebugMainManifest UP-TO-DATE
> Task :composeApp:processDebugManifest UP-TO-DATE
> Task :composeApp:processDebugManifestForPackage UP-TO-DATE
> Task :composeApp:javaPreCompileDebug UP-TO-DATE
> Task :composeApp:copyDebugComposeResourcesToAndroidAssets UP-TO-DATE
 
[Incubating] Problems report is available at: file:///Users/jq/examples/compose-multiplatform/examples/nav_cupcake/build/reports/problems/problems-report.html
 
FAILURE: Build failed with an exception.
 
* What went wrong:
Execution failed for task ':composeApp:checkDebugAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > 16 issues were found when checking AAR metadata:
     
       1.  Dependency 'androidx.navigation:navigation-compose-android:2.9.1' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
       2.  Dependency 'androidx.compose.material:material-ripple-android:1.8.2' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
       3.  Dependency 'androidx.compose.foundation:foundation-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
       4.  Dependency 'androidx.compose.foundation:foundation-layout-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
       5.  Dependency 'androidx.compose.animation:animation-core-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
       6.  Dependency 'androidx.compose.animation:animation-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
       7.  Dependency 'androidx.compose.ui:ui-tooling-data-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
       8.  Dependency 'androidx.compose.ui:ui-graphics-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
       9.  Dependency 'androidx.compose.ui:ui-text-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
      10.  Dependency 'androidx.compose.runtime:runtime-saveable-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
      11.  Dependency 'androidx.core:core-ktx:1.15.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
      12.  Dependency 'androidx.core:core:1.15.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
      13.  Dependency 'androidx.lifecycle:lifecycle-runtime-compose-android:2.9.2' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
      14.  Dependency 'androidx.lifecycle:lifecycle-viewmodel-compose-android:2.9.2' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
      15.  Dependency 'androidx.compose.ui:ui-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
     
      16.  Dependency 'androidx.compose.ui:ui-tooling-android:1.9.0' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
     
           :composeApp is currently compiled against android-34.
     
           Recommended action: Update this project to use a newer compileSdk
           of at least 35, for example 35.
     
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
 
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
 
BUILD FAILED in 468ms
21 actionable tasks: 1 executed, 20 up-to-date
```

## Release Notes
N/A