### PR TITLE
Restore `buildSrc` in `jb-main`. Changes in Gradle plugin

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/RuntimeLibrariesCompatibilityCheckTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/RuntimeLibrariesCompatibilityCheckTest.kt
@@ -6,7 +6,6 @@ import org.jetbrains.compose.internal.utils.currentOS
 import org.jetbrains.compose.test.utils.GradlePluginTestBase
 import org.jetbrains.compose.test.utils.checks
 import org.jetbrains.compose.test.utils.modify
-import kotlin.test.Ignore
 import kotlin.test.Test
 
 class RuntimeLibrariesCompatibilityCheckTest : GradlePluginTestBase() {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-9523/Copy-new-buildSrc-to-jb-main

Other PRs:
https://github.com/JetBrains/compose-multiplatform-core/pull/2709
https://jetbrains.team/p/ui/reviews/101/timeline

This test fails after https://github.com/JetBrains/compose-multiplatform-core/pull/2709 because of new constraints in `ui-uikit`
```
// ./gradlew dependencyInsight --configuration iosArm64CompileKlibraries --dependency org.jetbrains.compose.ui:ui
org.jetbrains.compose.ui:ui:1.9.3 FAILED
   Failures:
      - Could not resolve org.jetbrains.compose.ui:ui:{strictly 1.9.3}.
          - Cannot find a version of 'org.jetbrains.compose.ui:ui' that satisfies the version constraints:
          Dependency path: 'root project :' (iosArm64CompileKlibraries) --> 'org.jetbrains.compose.ui:ui:{strictly 1.9.3}'
          ...
          Constraint path: ... 'org.jetbrains.compose.foundation:foundation:9999.0.0-SNAPSHOT' ... --> 'org.jetbrains.compose.ui:ui-uikit:9999.0.0-SNAPSHOT' ... --> 'org.jetbrains.compose.ui:ui:9999.0.0-SNAPSHOT'
          ...
```
(it theoretically should be not resolved with any explicit dependency of "foundation" on "ui-something", but I couldn't reproduce it, might be a bug/peculiarity of Gradle)

Instead of downgrading a middle-level dependency, we downgrade high-level dependencies. We downgrade both ui/foundation because we will add a constraint for them in [CMP-9710](https://youtrack.jetbrains.com/issue/CMP-9710) Prevent possible version mismatch between ui and foundation

## Release Notes
N/A