### PR TITLE
Add awaitSkikoWasm to ensure Skiko initialization before running benchmarks

### DIFF
--- a/benchmarks/multiplatform/benchmarks/src/wasmJsMain/kotlin/main.wasmJs.kt
+++ b/benchmarks/multiplatform/benchmarks/src/wasmJsMain/kotlin/main.wasmJs.kt
@@ -27,12 +27,23 @@ fun mainBrowser() {
             println("No benchmark server found.")
             return@launch
         }
+        awaitSkikoWasm()
+
         runBenchmarks()
         println("Completed!")
         if (Config.saveStats()) {
             GlobalScope.launch {
                 BenchmarksSaveServerClient.stopServer()
             }
+        }
+    }
+}
+
+private suspend fun awaitSkikoWasm() {
+    suspendCancellableCoroutine { c ->
+        @Suppress("INVISIBLE_REFERENCE")
+        androidx.compose.ui.window.onSkikoReady {
+            c.resumeWith(Result.success(Unit))
         }
     }
 }


### PR DESCRIPTION
CMP 1.9.0 had some changes in the area of skiko loading. 

The apps usually call `fun ComposeViewport` which internally takes care of ensuring that skiko.wasm is ready. But the benchmarks call skiko API directly - `Surface.makeNull`

Solution: wait for skiko.wasm initialization before running the benchmarks.

## Testing
`/gradlew :benchmarks:wasmJsBrowserProductionRun`

## Release Notes
N/A
