### PR TITLE
Update replaceVersion.sh to include html/buildSrc/gradle.properties

### DIFF
--- a/html/buildSrc/gradle.properties
+++ b/html/buildSrc/gradle.properties
@@ -1,1 +1,1 @@
-kotlin.version=2.2.20
+kotlin.version=2.3.0

--- a/html/gradle.properties
+++ b/html/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx8g
 
 #Versions
-compose.version=1.9.0
+compose.version=1.10.0
 
 #Compose
 compose.web.buildSamples=false

--- a/tools/replaceVersion.sh
+++ b/tools/replaceVersion.sh
@@ -10,6 +10,7 @@ declare -a folders=(
     "$ROOT/gradle-plugins"
     "$ROOT/ci"
     "$ROOT/tutorials"
+    "$ROOT/html"
 )
 
 if [ ! -z "$COMPOSE_TEMPLATES_FOLDER" ]; then
@@ -62,7 +63,7 @@ replaceVersionInFile() {
 }
 
 replaceVersionInFolder() {
-    find $1 -wholename $2 -not -path "**/build**" -not -path "**/.gradle**" | while read file; do replaceVersionInFile "$file"; done
+    find $1 -wholename $2 -not -path "**/build/*" -not -path "**/.gradle**" | while read file; do replaceVersionInFile "$file"; done
 }
 
 for folder in "${folders[@]}"


### PR DESCRIPTION
Also, update compose-html to CMP 1.10.0 and Kotlin 2.3.0 (it has not been updated before because replaceVersion.sh missed it).

Other sub-projects already use CMP 1.10.0 and Kotlin 2.3.0

## Testing
N/A

## Release Notes
N/A
