### PR TITLE
Update replaceVersion.sh to include components build files

### DIFF
--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -7,9 +7,9 @@ org.gradle.configuration-cache=true
 android.useAndroidX=true
 
 #Versions
-kotlin.version=2.2.20
+kotlin.version=2.3.0
 agp.version=8.9.0
-compose.version=1.9.0
+compose.version=1.10.0
 deploy.version=9999.0.0-SNAPSHOT
 
 #Compose

--- a/tools/replaceVersion.sh
+++ b/tools/replaceVersion.sh
@@ -11,6 +11,7 @@ declare -a folders=(
     "$ROOT/ci"
     "$ROOT/tutorials"
     "$ROOT/html"
+    "$ROOT/components"
 )
 
 if [ ! -z "$COMPOSE_TEMPLATES_FOLDER" ]; then


### PR DESCRIPTION
Also, update components (resources and other libs) to CMP 1.10.0 and Kotlin 2.3.0 (it has not been updated before because replaceVersion.sh missed it).

Other sub-projects already use CMP 1.10.0 and Kotlin 2.3.0

## Testing
N/A

## Release Notes
N/A
