### PR TITLE
Update oldest supported Kotlin version to 2.3.0 in GradlePluginTest

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -86,7 +86,7 @@ class GradlePluginTest : GradlePluginTestBase() {
             }
         }
 
-    // Note: we can't test non-jvm targets with Kotlin older than 2.2.0, because of klib abi version bump in 2.2.0
+    // Note: we can't test non-jvm targets with Kotlin older than 2.3.0, because of klib abi version bump in 2.3.0
     private val oldestSupportedKotlinVersion = "2.3.0"
     @Test
     fun testOldestKotlinMpp() = with(


### PR DESCRIPTION
Because we bump Kotlin version in CMP core and in components.

## Testing
N/A

## Release Notes
N/A