### PR TITLE
Deprecate `compose.desktop.currentOs`

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -66,6 +66,7 @@ abstract class ComposePlugin : Plugin<Project> {
 
     @Suppress("DEPRECATION")
     class Dependencies(project: Project) {
+        @Deprecated("Specify dependency directly")
         val desktop = DesktopDependencies
         @Deprecated("Specify dependency directly", replaceWith = ReplaceWith("\"org.jetbrains.compose.animation:animation:${ComposeBuildConfig.composeVersion}\""))
         val animation get() = composeDependency("org.jetbrains.compose.animation:animation")
@@ -132,6 +133,7 @@ abstract class ComposePlugin : Plugin<Project> {
         @Deprecated("Specify dependency directly", replaceWith = ReplaceWith("\"org.jetbrains.compose.ui:ui-test-junit4:${ComposeBuildConfig.composeVersion}\""))
         val uiTestJUnit4 get() = composeDependency("org.jetbrains.compose.ui:ui-test-junit4")
 
+        @Deprecated("Specify dependency directly", replaceWith = ReplaceWith("\"org.jetbrains.compose.desktop:desktop:${ComposeBuildConfig.composeVersion}\""))
         val currentOs by lazy {
             composeDependency("org.jetbrains.compose.desktop:desktop-jvm-${currentTarget.id}")
         }
@@ -193,11 +195,14 @@ abstract class ComposePlugin : Plugin<Project> {
     }
 }
 
+@Deprecated("Compose Multiplatform releases are published to Maven Central")
 fun RepositoryHandler.jetbrainsCompose(): MavenArtifactRepository =
     maven { repo -> repo.setUrl("https://packages.jetbrains.team/maven/p/cmp/dev") }
 
+@Deprecated("Specify dependency directly")
 fun KotlinDependencyHandler.compose(groupWithArtifact: String) = composeDependency(groupWithArtifact)
 
+@Deprecated("Specify dependency directly")
 fun DependencyHandler.compose(groupWithArtifact: String) = composeDependency(groupWithArtifact)
 
 private fun composeDependency(groupWithArtifact: String) = "$groupWithArtifact:$composeVersion"


### PR DESCRIPTION
Fixes [CMP-9176](https://youtrack.jetbrains.com/issue/CMP-9176) Deprecate `compose.desktop.currentOs` dependency alias in Gradle plugin
Fixes [CMP-5990](https://youtrack.jetbrains.com/issue/CMP-5990) Add the ability to not depend on the "compose.material" module

## Testing
Should check that suggested replacement works

## Release Notes
### Migration Notes - Desktop
- `compose.desktop.currentOs` alias in Gradle is now deprecated. Replace
```
implementation(compose.desktop.currentOs)
```
by
```
implementation("org.jetbrains.compose.desktop:desktop:<composeMultiplatformVersion>")
implementation("org.jetbrains.compose.material:material:<composeMultiplatformVersion>") // if needed
```