### PR TITLE
Remove iosX64 and macosX64 targets across examples

### DIFF
--- a/examples/chat/shared/build.gradle.kts
+++ b/examples/chat/shared/build.gradle.kts
@@ -30,13 +30,6 @@ kotlin {
         browser()
     }
 
-    macosX64 {
-        binaries {
-            executable {
-                entryPoint = "main"
-            }
-        }
-    }
     macosArm64 {
         binaries {
             executable {
@@ -85,9 +78,6 @@ kotlin {
 
         val macosMain by creating {
             dependsOn(commonMain)
-        }
-        val macosX64Main by getting {
-            dependsOn(macosMain)
         }
         val macosArm64Main by getting {
             dependsOn(macosMain)

--- a/examples/chat/shared/build.gradle.kts
+++ b/examples/chat/shared/build.gradle.kts
@@ -15,7 +15,6 @@ kotlin {
     jvm("desktop")
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -71,9 +70,6 @@ kotlin {
         }
         val iosMain by creating {
             dependsOn(commonMain)
-        }
-        val iosX64Main by getting {
-            dependsOn(iosMain)
         }
         val iosArm64Main by getting {
             dependsOn(iosMain)

--- a/examples/codeviewer/shared/build.gradle.kts
+++ b/examples/codeviewer/shared/build.gradle.kts
@@ -15,7 +15,6 @@ kotlin {
     jvm("desktop")
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -50,9 +49,6 @@ kotlin {
         }
         val iosMain by creating {
             dependsOn(commonMain)
-        }
-        val iosX64Main by getting {
-            dependsOn(iosMain)
         }
         val iosArm64Main by getting {
             dependsOn(iosMain)

--- a/examples/graphics-2d/shared/build.gradle.kts
+++ b/examples/graphics-2d/shared/build.gradle.kts
@@ -28,7 +28,6 @@ kotlin {
     }
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->

--- a/examples/graphics-2d/shared/build.gradle.kts
+++ b/examples/graphics-2d/shared/build.gradle.kts
@@ -17,7 +17,6 @@ kotlin {
     }
 
     listOf(
-        macosX64(),
         macosArm64()
     ).forEach { macosTarget ->
         macosTarget.binaries {

--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -22,7 +22,6 @@ kotlin {
     wasmJs { browser() }
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->

--- a/examples/interop/ios-compose-in-swiftui/shared/build.gradle.kts
+++ b/examples/interop/ios-compose-in-swiftui/shared/build.gradle.kts
@@ -10,7 +10,6 @@ version = "1.0-SNAPSHOT"
 
 kotlin {
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -32,9 +31,6 @@ kotlin {
         }
         val iosMain by creating {
             dependsOn(commonMain)
-        }
-        val iosX64Main by getting {
-            dependsOn(iosMain)
         }
         val iosArm64Main by getting {
             dependsOn(iosMain)

--- a/examples/interop/ios-compose-in-uikit/shared/build.gradle.kts
+++ b/examples/interop/ios-compose-in-uikit/shared/build.gradle.kts
@@ -10,7 +10,6 @@ version = "1.0-SNAPSHOT"
 
 kotlin {
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -32,9 +31,6 @@ kotlin {
         }
         val iosMain by creating {
             dependsOn(commonMain)
-        }
-        val iosX64Main by getting {
-            dependsOn(iosMain)
         }
         val iosArm64Main by getting {
             dependsOn(iosMain)

--- a/examples/interop/ios-swiftui-in-compose/shared/build.gradle.kts
+++ b/examples/interop/ios-swiftui-in-compose/shared/build.gradle.kts
@@ -10,7 +10,6 @@ version = "1.0-SNAPSHOT"
 
 kotlin {
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -32,9 +31,6 @@ kotlin {
         }
         val iosMain by creating {
             dependsOn(commonMain)
-        }
-        val iosX64Main by getting {
-            dependsOn(iosMain)
         }
         val iosArm64Main by getting {
             dependsOn(iosMain)

--- a/examples/interop/ios-uikit-in-compose/shared/build.gradle.kts
+++ b/examples/interop/ios-uikit-in-compose/shared/build.gradle.kts
@@ -10,7 +10,6 @@ version = "1.0-SNAPSHOT"
 
 kotlin {
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -32,9 +31,6 @@ kotlin {
         }
         val iosMain by creating {
             dependsOn(commonMain)
-        }
-        val iosX64Main by getting {
-            dependsOn(iosMain)
         }
         val iosArm64Main by getting {
             dependsOn(iosMain)

--- a/examples/nav_cupcake/composeApp/build.gradle.kts
+++ b/examples/nav_cupcake/composeApp/build.gradle.kts
@@ -41,7 +41,6 @@ kotlin {
     jvm("desktop")
     
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -66,12 +65,10 @@ kotlin {
         val desktopMain by getting {
             dependsOn(jbMain)
         }
-        val iosX64Main by getting
         val iosArm64Main by getting
         val iosSimulatorArm64Main by getting
         val iosMain by creating {
             dependsOn(jbMain)
-            iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
             iosSimulatorArm64Main.dependsOn(this)
         }


### PR DESCRIPTION
Compose-Runtime doesn't support iosX64 anymore due to deprecation in Kotlin. We remove it too.

## Release Notes
N/A
