### PR TITLE
Recover jpackage libs dir from stale state

### DIFF
--- a/ci/templates/desktop-template/build.gradle.kts
+++ b/ci/templates/desktop-template/build.gradle.kts
@@ -35,3 +35,82 @@ compose.desktop {
         }
     }
 }
+
+fun printCommand(label: String, vararg command: String) {
+    println(">>> $label")
+    try {
+        val output = providers.exec {
+            commandLine(*command)
+            isIgnoreExitValue = true
+        }
+        output.standardOutput.asText.get().trimEnd().takeIf { it.isNotEmpty() }?.let(::println)
+        output.standardError.asText.get().trimEnd().takeIf { it.isNotEmpty() }?.let(::println)
+        println("exitCode=${output.result.get().exitValue}")
+    } catch (e: Throwable) {
+        println("<failed to run ${command.joinToString(" ")}: ${e.message}>")
+    }
+}
+
+fun printTool(tool: String) {
+    printCommand("$tool location", "bash", "-lc", "command -v $tool || true")
+    printCommand("$tool version", "bash", "-lc", "$tool --version 2>&1 | sed -n '1,8p'")
+}
+
+fun dumpFile(file: File) {
+    println("----- ${file.relativeToOrSelf(projectDir)} -----")
+    if (file.isFile) {
+        file.useLines { lines ->
+            lines.take(240).forEach(::println)
+        }
+    } else {
+        println("<missing>")
+    }
+}
+
+fun printNativePackagingDiagnostics(stage: String) {
+    println("===== Native packaging diagnostics ($stage) =====")
+    println("projectDir=$projectDir")
+    println("buildDir=${layout.buildDirectory.get().asFile}")
+    println("java.home=${System.getProperty("java.home")}")
+    println("PATH=${System.getenv("PATH")}")
+    println("JAVA_HOME=${System.getenv("JAVA_HOME") ?: "<unset>"}")
+    println("GRADLE_OPTS=${System.getenv("GRADLE_OPTS") ?: "<unset>"}")
+    printCommand("uname", "uname", "-a")
+    printCommand("os-release", "bash", "-lc", "sed -n '1,40p' /etc/os-release")
+    printCommand("java version", "java", "-version")
+    printTool("jpackage")
+    printTool("fakeroot")
+    printTool("dpkg")
+    printTool("dpkg-deb")
+    printTool("rpm")
+    printTool("rpmbuild")
+    printCommand("disk usage", "df", "-h", projectDir.absolutePath)
+
+    val composeDir = layout.buildDirectory.dir("compose").get().asFile
+    println(">>> build/compose tree")
+    if (composeDir.exists()) {
+        composeDir.walkTopDown().maxDepth(8).forEach { println(it.relativeToOrSelf(projectDir)) }
+    } else {
+        println("<missing>")
+    }
+
+    if (composeDir.exists()) {
+        composeDir.walkTopDown()
+            .filter { it.isFile && it.name.endsWith(".args.txt") }
+            .forEach(::dumpFile)
+    }
+    println("================================================")
+}
+
+val printNativePackagingDiagnostics by tasks.registering {
+    doLast {
+        printNativePackagingDiagnostics("after packaging task")
+    }
+}
+
+tasks.matching { it.name == "packageDeb" || it.name == "packageReleaseDeb" }.configureEach {
+    doFirst {
+        printNativePackagingDiagnostics("before $path")
+    }
+    finalizedBy(printNativePackagingDiagnostics)
+}

--- a/ci/templates/multiplatform-template/desktop/build.gradle.kts
+++ b/ci/templates/multiplatform-template/desktop/build.gradle.kts
@@ -18,6 +18,85 @@ kotlin {
     }
 }
 
+fun printCommand(label: String, vararg command: String) {
+    println(">>> $label")
+    try {
+        val output = providers.exec {
+            commandLine(*command)
+            isIgnoreExitValue = true
+        }
+        output.standardOutput.asText.get().trimEnd().takeIf { it.isNotEmpty() }?.let(::println)
+        output.standardError.asText.get().trimEnd().takeIf { it.isNotEmpty() }?.let(::println)
+        println("exitCode=${output.result.get().exitValue}")
+    } catch (e: Throwable) {
+        println("<failed to run ${command.joinToString(" ")}: ${e.message}>")
+    }
+}
+
+fun printTool(tool: String) {
+    printCommand("$tool location", "bash", "-lc", "command -v $tool || true")
+    printCommand("$tool version", "bash", "-lc", "$tool --version 2>&1 | sed -n '1,8p'")
+}
+
+fun dumpFile(file: File) {
+    println("----- ${file.relativeToOrSelf(projectDir)} -----")
+    if (file.isFile) {
+        file.useLines { lines ->
+            lines.take(240).forEach(::println)
+        }
+    } else {
+        println("<missing>")
+    }
+}
+
+fun printNativePackagingDiagnostics(stage: String) {
+    println("===== Native packaging diagnostics ($stage) =====")
+    println("projectDir=$projectDir")
+    println("buildDir=${layout.buildDirectory.get().asFile}")
+    println("java.home=${System.getProperty("java.home")}")
+    println("PATH=${System.getenv("PATH")}")
+    println("JAVA_HOME=${System.getenv("JAVA_HOME") ?: "<unset>"}")
+    println("GRADLE_OPTS=${System.getenv("GRADLE_OPTS") ?: "<unset>"}")
+    printCommand("uname", "uname", "-a")
+    printCommand("os-release", "bash", "-lc", "sed -n '1,40p' /etc/os-release")
+    printCommand("java version", "java", "-version")
+    printTool("jpackage")
+    printTool("fakeroot")
+    printTool("dpkg")
+    printTool("dpkg-deb")
+    printTool("rpm")
+    printTool("rpmbuild")
+    printCommand("disk usage", "df", "-h", projectDir.absolutePath)
+
+    val composeDir = layout.buildDirectory.dir("compose").get().asFile
+    println(">>> build/compose tree")
+    if (composeDir.exists()) {
+        composeDir.walkTopDown().maxDepth(8).forEach { println(it.relativeToOrSelf(projectDir)) }
+    } else {
+        println("<missing>")
+    }
+
+    if (composeDir.exists()) {
+        composeDir.walkTopDown()
+            .filter { it.isFile && it.name.endsWith(".args.txt") }
+            .forEach(::dumpFile)
+    }
+    println("================================================")
+}
+
+val printNativePackagingDiagnostics by tasks.registering {
+    doLast {
+        printNativePackagingDiagnostics("after packaging task")
+    }
+}
+
+tasks.matching { it.name == "packageDeb" || it.name == "packageReleaseDeb" }.configureEach {
+    doFirst {
+        printNativePackagingDiagnostics("before $path")
+    }
+    finalizedBy(printNativePackagingDiagnostics)
+}
+
 compose.desktop {
     application {
         mainClass = "MainKt"

--- a/examples/validateExamples.sh
+++ b/examples/validateExamples.sh
@@ -12,10 +12,90 @@ fi
 COMPOSE_VERSION=$1
 KOTLIN_VERSION=$2
 
+printCommand() {
+    local label=$1
+    shift
+
+    echo ">>> $label"
+    "$@" || true
+}
+
+printTool() {
+    local tool=$1
+    if command -v "$tool" >/dev/null 2>&1; then
+        echo "$tool: $(command -v "$tool")"
+        "$tool" --version 2>&1 | sed -n '1,5p' || true
+    else
+        echo "$tool: <missing>"
+    fi
+}
+
+printEnvironmentDiagnostics() {
+    echo "===== Validation environment ====="
+    echo "PWD: $PWD"
+    echo "USER: ${USER:-<unset>}"
+    echo "HOME: ${HOME:-<unset>}"
+    echo "PATH: ${PATH:-<unset>}"
+    echo "JAVA_HOME: ${JAVA_HOME:-<unset>}"
+    echo "GRADLE_OPTS: ${GRADLE_OPTS:-<unset>}"
+    echo "COMPOSE_VERSION: $COMPOSE_VERSION"
+    echo "KOTLIN_VERSION: $KOTLIN_VERSION"
+    printCommand "uname" uname -a
+    printCommand "os-release" sed -n '1,40p' /etc/os-release
+    printCommand "java version" java -version
+    printTool jpackage
+    printTool fakeroot
+    printTool dpkg
+    printTool dpkg-deb
+    printTool rpm
+    printTool rpmbuild
+    printCommand "disk usage" df -h .
+    echo "=================================="
+}
+
+dumpFile() {
+    local file=$1
+    echo "----- $file -----"
+    if [ -f "$file" ]; then
+        sed -n '1,240p' "$file" || true
+    else
+        echo "<missing>"
+    fi
+}
+
+dumpComposeDiagnostics() {
+    local project=$1
+    echo "===== Compose diagnostics for $project ====="
+    printCommand "build/compose tree" find . -maxdepth 8 \( -path '*/build/compose' -o -path '*/build/compose/*' \) -print
+    printCommand "jpackage args files" find . -path '*/build/compose/tmp/*.args.txt' -type f -print
+    while IFS= read -r argsFile; do
+        dumpFile "$argsFile"
+    done < <(find . -path '*/build/compose/tmp/*.args.txt' -type f -print 2>/dev/null)
+
+    printCommand "packageDeb tmp contents" find . -maxdepth 8 -path '*/build/compose/tmp/packageDeb*' -print
+    printCommand "packageReleaseDeb tmp contents" find . -maxdepth 8 -path '*/build/compose/tmp/packageReleaseDeb*' -print
+    printCommand "package outputs" find . -maxdepth 8 -path '*/build/compose/binaries/*' -print
+    echo "==========================================="
+}
 
 runGradle() {
-    pushd $1
-    ./gradlew $2 -Pcompose.version=$COMPOSE_VERSION -Pkotlin.version=$KOTLIN_VERSION
+    local project=$1
+    local task=$2
+
+    pushd "$project"
+    echo "===== Running $project :: $task ====="
+    printEnvironmentDiagnostics
+    dumpComposeDiagnostics "$project"
+    if ./gradlew "$task" -Pcompose.version="$COMPOSE_VERSION" -Pkotlin.version="$KOTLIN_VERSION" --info --stacktrace; then
+        echo "===== Completed $project :: $task ====="
+        dumpComposeDiagnostics "$project"
+    else
+        local status=$?
+        echo "===== Failed $project :: $task with exit code $status ====="
+        dumpComposeDiagnostics "$project"
+        popd
+        return "$status"
+    fi
     popd
 }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -549,8 +549,8 @@ abstract class AbstractJPackageTask @Inject constructor(
         }
 
         when {
-            !libsDirFile.exists() -> {
-                invalidateAllLibs("libs dir does not exist")
+            !libsDirFile.isDirectory -> {
+                invalidateAllLibs("libs dir does not exist or is not a directory")
             }
             libsMapping.hasMissingOutputFiles() -> {
                 invalidateAllLibs("libs mapping points to missing output files")
@@ -568,7 +568,7 @@ abstract class AbstractJPackageTask @Inject constructor(
                         }
                     }
                 } catch (e: Exception) {
-                    logger.debug("Could remove outdated libs incrementally: ${e.stacktraceToString()}")
+                    logger.debug("Could not remove outdated libs incrementally: ${e.stacktraceToString()}")
                     invalidateAllLibs("failed to process incremental input changes")
                 }
             }
@@ -820,6 +820,7 @@ private class FilesMapping : Serializable {
                 .forEach { (k, values) ->
                     (sequenceOf(k) + values.asSequence())
                         .joinTo(writer, separator = File.pathSeparator, transform = { it.absolutePath })
+                    writer.newLine()
                 }
         }
     }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -32,6 +32,7 @@ import org.jetbrains.compose.desktop.application.dsl.FileAssociation
 import org.jetbrains.compose.desktop.application.dsl.MacOSSigningSettings
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.compose.desktop.application.internal.APP_RESOURCES_DIR
+import org.jetbrains.compose.desktop.application.internal.ComposeProperties
 import org.jetbrains.compose.desktop.application.internal.InfoPlistBuilder
 import org.jetbrains.compose.desktop.application.internal.InfoPlistBuilder.InfoPlistValue.InfoPlistListValue
 import org.jetbrains.compose.desktop.application.internal.InfoPlistBuilder.InfoPlistValue.InfoPlistMapValue
@@ -377,6 +378,29 @@ abstract class AbstractJPackageTask @Inject constructor(
     @get:Internal
     private val libsMapping = FilesMapping()
 
+    init {
+        outputs.upToDateWhen {
+            !ComposeProperties.preserveWorkingDir(providers).get() || isWorkingDirStateValidForUpToDateCheck()
+        }
+    }
+
+    private fun isWorkingDirStateValidForUpToDateCheck(): Boolean {
+        if (targetFormat != TargetFormat.AppImage && appImage.orNull != null) return true
+
+        val libsDirFile = libsDir.ioFile
+        if (!libsDirFile.isDirectory) return false
+
+        val mappingFile = libsMappingFile.ioFile
+        if (!mappingFile.isFile) return false
+
+        return try {
+            !FilesMapping().apply { loadFrom(mappingFile) }.hasMissingOutputFiles()
+        } catch (e: Exception) {
+            logger.debug("Could not check jpackage libs mapping: ${e.stacktraceToString()}")
+            false
+        }
+    }
+
     override fun makeArgs(tmpDir: File): MutableList<String> = super.makeArgs(tmpDir).apply {
         fun appDir(vararg pathParts: String): String {
             /** For windows we need to pass '\\' to jpackage file, each '\' need to be escaped.
@@ -516,33 +540,44 @@ abstract class AbstractJPackageTask @Inject constructor(
         val outdatedLibs = HashSet<File>()
         val libsDirFile = libsDir.ioFile
 
-        fun invalidateAllLibs() {
+        fun invalidateAllLibs(reason: String) {
             outdatedLibs.addAll(files.files)
+            libsMapping.clear()
 
-            logger.debug("Clearing all files in working dir: $libsDirFile")
+            logger.debug("Clearing all files in working dir: $libsDirFile. Reason: $reason")
             fileOperations.clearDirs(libsDirFile)
         }
 
-        if (inputChanges.isIncremental) {
-            val allChanges = inputChanges.getFileChanges(files).asSequence()
-
-            try {
-                for (change in allChanges) {
-                    libsMapping.remove(change.file)?.let { files ->
-                        files.forEach { fileOperations.delete(it) }
-                    }
-                    if (change.changeType != ChangeType.REMOVED) {
-                        outdatedLibs.add(change.file)
-                    }
-                }
-            } catch (e: Exception) {
-                logger.debug("Could remove outdated libs incrementally: ${e.stacktraceToString()}")
-                invalidateAllLibs()
+        when {
+            !libsDirFile.exists() -> {
+                invalidateAllLibs("libs dir does not exist")
             }
-        } else {
-            invalidateAllLibs()
+            libsMapping.hasMissingOutputFiles() -> {
+                invalidateAllLibs("libs mapping points to missing output files")
+            }
+            inputChanges.isIncremental -> {
+                val allChanges = inputChanges.getFileChanges(files).asSequence()
+
+                try {
+                    for (change in allChanges) {
+                        libsMapping.remove(change.file)?.let { files ->
+                            files.forEach { fileOperations.delete(it) }
+                        }
+                        if (change.changeType != ChangeType.REMOVED) {
+                            outdatedLibs.add(change.file)
+                        }
+                    }
+                } catch (e: Exception) {
+                    logger.debug("Could remove outdated libs incrementally: ${e.stacktraceToString()}")
+                    invalidateAllLibs("failed to process incremental input changes")
+                }
+            }
+            else -> {
+                invalidateAllLibs("input changes are not incremental")
+            }
         }
 
+        fileOperations.mkdirs(libsDirFile)
         return outdatedLibs
     }
 
@@ -756,6 +791,15 @@ private class FilesMapping : Serializable {
 
     fun remove(key: File): List<File>? =
         mapping.remove(key)
+
+    fun clear() {
+        mapping.clear()
+    }
+
+    fun hasMissingOutputFiles(): Boolean =
+        mapping.values.asSequence()
+            .flatten()
+            .any { !it.exists() }
 
     fun loadFrom(mappingFile: File) {
         mappingFile.readLines().forEach { line ->

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJvmToolOperationTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJvmToolOperationTask.kt
@@ -69,12 +69,13 @@ abstract class AbstractJvmToolOperationTask(private val toolName: String) : Abst
                 args = listOf("@${argsFile.absolutePath}"),
                 environment = jvmToolEnvironment()
             ).also { checkResult(it) }
+
+            saveStateAfterFinish()
         } finally {
             if (!ComposeProperties.preserveWorkingDir(providers).get()) {
                 fileOperations.delete(workingDir)
             }
         }
-        saveStateAfterFinish()
     }
 
     protected open fun initState() {}

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -215,7 +215,20 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     }
 
     @Test
-    fun packageDebRestoresMissingLibsDir() {
+    fun packageDebDoesNotKeepLibsMappingWhenWorkingDirIsNotPreserved() {
+        with(testProject("application/jvm")) {
+            Assumptions.assumeTrue(currentOS == OS.Linux) { "The test is only relevant for Linux Deb packaging" }
+            gradle(":packageDeb").checks {
+                check.taskSuccessful(":packageDeb")
+            }
+
+            file("build/compose/tmp/packageDeb/libs").checkNotExists()
+            file("build/compose/tmp/packageDeb/libs-mapping.txt").checkNotExists()
+        }
+    }
+
+    @Test
+    fun packageDebRestoresBrokenLibsState() {
         with(testProject("application/jvm")) {
             Assumptions.assumeTrue(currentOS == OS.Linux) { "The test is only relevant for Linux Deb packaging" }
             modifyGradleProperties {
@@ -226,7 +239,23 @@ class DesktopApplicationTest : GradlePluginTestBase() {
             }
 
             val libsDir = file("build/compose/tmp/packageDeb/libs").checkExists()
-            file("build/compose/tmp/packageDeb/libs-mapping.txt").checkExists()
+            val libsMapping = file("build/compose/tmp/packageDeb/libs-mapping.txt").checkExists()
+
+            fun mappedOutputFiles() = libsMapping.readLines()
+                .asSequence()
+                .flatMap { it.split(File.pathSeparatorChar).drop(1).asSequence() }
+                .map(::File)
+                .toList()
+
+            val mappedOutputFile = mappedOutputFiles().first { it.isFile }
+            mappedOutputFile.delete()
+            mappedOutputFile.checkNotExists()
+
+            gradle(":packageDeb").checks {
+                check.taskSuccessful(":packageDeb")
+            }
+            mappedOutputFiles().forEach { it.checkExists() }
+
             libsDir.deleteRecursively()
             libsDir.checkNotExists()
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -214,6 +214,29 @@ class DesktopApplicationTest : GradlePluginTestBase() {
         testPackageJvmDistributions()
     }
 
+    @Test
+    fun packageDebRestoresMissingLibsDir() {
+        with(testProject("application/jvm")) {
+            Assumptions.assumeTrue(currentOS == OS.Linux) { "The test is only relevant for Linux Deb packaging" }
+            modifyGradleProperties {
+                setProperty("compose.preserve.working.dir", "true")
+            }
+            gradle(":packageDeb").checks {
+                check.taskSuccessful(":packageDeb")
+            }
+
+            val libsDir = file("build/compose/tmp/packageDeb/libs").checkExists()
+            file("build/compose/tmp/packageDeb/libs-mapping.txt").checkExists()
+            libsDir.deleteRecursively()
+            libsDir.checkNotExists()
+
+            gradle(":packageDeb").checks {
+                check.taskSuccessful(":packageDeb")
+            }
+            libsDir.checkExists()
+        }
+    }
+
 
     private fun TestProject.testPackageJvmDistributions() {
         val result = gradle(":packageDistributionForCurrentOS")


### PR DESCRIPTION
Invalidate preserved jpackage working state when the libs directory or mapped outputs are missing so packageDeb/packageReleaseDeb rebuild their input directory before invoking jpackage.

Most likely fixes [CMP-4622](https://youtrack.jetbrains.com/issue/CMP-4622) :packageDeb or :packageReleaseDeb fails at jpackage task

## Release Notes
N/A