### PR TITLE
Fix validation errors after updating TeamCity base image

### DIFF
--- a/ci/templates/maven-test-project/pom.xml
+++ b/ci/templates/maven-test-project/pom.xml
@@ -100,6 +100,11 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.compose.runtime</groupId>
+            <artifactId>runtime-saveable-desktop</artifactId>
+            <version>${compose.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.compose.ui</groupId>
             <artifactId>ui-desktop</artifactId>
             <version>${compose.version}</version>

--- a/ci/templates/multiplatform-template/android/build.gradle.kts
+++ b/ci/templates/multiplatform-template/android/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.application")
     kotlin("android")
@@ -20,8 +23,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlin {
-        jvmToolchain(17)
+}
+
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/ci/templates/multiplatform-template/common/build.gradle.kts
+++ b/ci/templates/multiplatform-template/common/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.library")
     kotlin("multiplatform")
@@ -28,6 +31,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 android {
     compileSdk = 35
     namespace = "com.myapplication.common"
@@ -38,9 +47,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
     sourceSets {
         named("main") {

--- a/ci/templates/multiplatform-template/settings.gradle.kts
+++ b/ci/templates/multiplatform-template/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("1.0.0")
 }
 
 include(":common", ":android", ":desktop")

--- a/examples/chat/androidApp/build.gradle.kts
+++ b/examples/chat/androidApp/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.compose")
@@ -16,6 +19,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 android {
     compileSdk = 35
     namespace = "org.jetbrains.chat"
@@ -29,8 +38,5 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
 }

--- a/examples/chat/settings.gradle.kts
+++ b/examples/chat/settings.gradle.kts
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("1.0.0")
 }
 
 rootProject.name = "chat-mpp"

--- a/examples/chat/shared/build.gradle.kts
+++ b/examples/chat/shared/build.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("OPT_IN_IS_NOT_ENABLED")
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.compose")
@@ -85,6 +88,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 android {
     compileSdk = 35
     namespace = "org.jetbrains.chat"
@@ -96,8 +105,5 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
 }

--- a/examples/codeviewer/androidApp/build.gradle.kts
+++ b/examples/codeviewer/androidApp/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.compose")
@@ -16,6 +19,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 android {
     compileSdk = 35
     namespace = "org.jetbrains.codeviewer"
@@ -29,8 +38,5 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
 }

--- a/examples/codeviewer/settings.gradle.kts
+++ b/examples/codeviewer/settings.gradle.kts
@@ -23,7 +23,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("1.0.0")
 }
 
 rootProject.name = "codeviewer"

--- a/examples/codeviewer/shared/build.gradle.kts
+++ b/examples/codeviewer/shared/build.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("OPT_IN_IS_NOT_ENABLED")
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.compose")
@@ -65,6 +68,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 android {
     compileSdk = 35
     namespace = "org.jetbrains.codeviewer.common"
@@ -75,8 +84,5 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
 }

--- a/examples/graphics-2d/androidApp/build.gradle.kts
+++ b/examples/graphics-2d/androidApp/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.compose")
@@ -16,6 +19,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 android {
     compileSdk = 35
     namespace = "org.jetbrains.graphics2d"
@@ -29,8 +38,5 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
 }

--- a/examples/graphics-2d/settings.gradle.kts
+++ b/examples/graphics-2d/settings.gradle.kts
@@ -22,7 +22,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("1.0.0")
 }
 
 rootProject.name = "graphics-2d"

--- a/examples/graphics-2d/shared/build.gradle.kts
+++ b/examples/graphics-2d/shared/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("multiplatform")
@@ -66,6 +68,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 android {
     compileSdk = 35
     namespace = "org.jetbrains.Graphics2D"
@@ -77,8 +85,5 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
 }

--- a/examples/imageviewer/androidApp/build.gradle.kts
+++ b/examples/imageviewer/androidApp/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.compose")
@@ -17,6 +20,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 android {
     compileSdk = 35
     namespace = "example.imageviewer"
@@ -30,9 +39,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
 }
 

--- a/examples/imageviewer/settings.gradle.kts
+++ b/examples/imageviewer/settings.gradle.kts
@@ -23,7 +23,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("1.0.0")
 }
 
 rootProject.name = "imageviewer"

--- a/examples/imageviewer/shared/build.gradle.kts
+++ b/examples/imageviewer/shared/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("multiplatform")
@@ -92,6 +94,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 android {
     compileSdk = 35
     namespace = "example.imageviewer.shared"
@@ -104,8 +112,5 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
 }

--- a/examples/issues/android/build.gradle.kts
+++ b/examples/issues/android/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.application")
     kotlin("android")
@@ -20,8 +23,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlin {
-        jvmToolchain(17)
+}
+
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/examples/issues/common/build.gradle.kts
+++ b/examples/issues/common/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.library")
     kotlin("multiplatform")
@@ -35,6 +38,12 @@ kotlin {
     }
 }
 
+tasks.withType<KotlinCompile>() {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
 apollo {
     generateKotlinModels.set(true)
     customTypeMapping.putAll(mapOf("DateTime" to "java.util.Date"))
@@ -50,9 +59,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        jvmToolchain(17)
     }
     sourceSets {
         named("main") {

--- a/examples/issues/settings.gradle.kts
+++ b/examples/issues/settings.gradle.kts
@@ -21,7 +21,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("1.0.0")
 }
 
 include(":common", ":android", ":desktop")

--- a/gradle-plugins/compose/src/test/test-projects/application/jvm/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/jvm/build.gradle
@@ -1,4 +1,7 @@
+import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id "org.jetbrains.kotlin.jvm"
@@ -11,9 +14,14 @@ dependencies {
     implementation compose.desktop.currentOs
 }
 
-kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType(KotlinCompile).configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }
 

--- a/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
@@ -1,4 +1,7 @@
+import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id "com.android.kotlin.multiplatform.library"
@@ -26,8 +29,16 @@ kotlin {
             }
         }
     }
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
+}
+
+tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType(KotlinCompile).configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }
 


### PR DESCRIPTION
```
org.gradle.jvm.toolchain.internal.install.exceptions.ToolchainProvisioningException: Cannot find a Java installation on your machine (Linux 5.15.0-1084-aws amd64) matching: {languageVersion=17, vendor=any vendor, implementation=vendor-specific}. Some toolchain resolvers had internal failures: foojay (Requesting vendor list failed: {
  "result":[],
  "message":"There was an internal error and the pkg cache is currently be restored, please try again later"
}).
```

- Use `jvmTarget` instead of `jvmToolchain` to build the project without JDK 17 installed (only with JDK 21)
- Update `org.gradle.toolchains.foojay-resolver-convention` to a stable version

## Release Notes
N/A