### PR TITLE
Bump CHR version to 1.1.0

### DIFF
--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ plugin-android = "8.10.1"
 shadow-jar = "8.1.1"
 publish-plugin = "1.2.1"
 # we use "prefer" here for the strategy: "explicitly specified hot reload plugin always wins".
-plugin-hot-reload = { prefer = "1.1.0-rc01" }
+plugin-hot-reload = { prefer = "1.1.0" }
 
 [libraries]
 download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }


### PR DESCRIPTION
Fixes [CMP-10136](https://youtrack.jetbrains.com/issue/CMP-10136)

## Release Notes
### Fixes - Desktop
- (prerelease fix) Update bundled Compose Hot Reload version to 1.1.0
