### PR TITLE
Migrate Shadow plugin to v9

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.publish.plugin) apply false
-    alias(libs.plugins.shadow.jar) apply false
+    alias(libs.plugins.shadow) apply false
     alias(libs.plugins.download) apply false
 }
 

--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     alias(libs.plugins.publish.plugin)
     id("java-gradle-plugin")
     id("maven-publish")
-    alias(libs.plugins.shadow.jar)
+    alias(libs.plugins.shadow)
     alias(libs.plugins.download)
 }
 
@@ -88,7 +88,7 @@ dependencies {
 
 val packagesToRelocate = listOf("de.undercouch", "com.squareup.kotlinpoet")
 
-val shadow = tasks.named<ShadowJar>("shadowJar") {
+val shadowJar = tasks.named<ShadowJar>("shadowJar") {
     for (packageToRelocate in packagesToRelocate) {
         relocate(packageToRelocate, "org.jetbrains.compose.internal.$packageToRelocate")
     }
@@ -96,13 +96,15 @@ val shadow = tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier.set("")
     archiveVersion.set("")
     configurations = listOf(embeddedDependencies)
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    failOnDuplicateEntries = true
     exclude("META-INF/gradle-plugins/de.undercouch.download.properties")
     exclude("META-INF/versions/**")
 }
 
 val jar = tasks.named<Jar>("jar") {
-    dependsOn(shadow)
-    from(zipTree(shadow.get().archiveFile))
+    dependsOn(shadowJar)
+    from(zipTree(shadowJar.get().archiveFile))
     this.duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "2.2.0"
 gradle-download-plugin = "5.5.0"
 kotlin-poet = "2.1.0"
 plugin-android = "8.10.1"
-shadow-jar = "8.1.1"
+shadow = "9.2.2"
 publish-plugin = "1.2.1"
 # we use "prefer" here for the strategy: "explicitly specified hot reload plugin always wins".
 plugin-hot-reload = { prefer = "1.1.0" }
@@ -18,5 +18,5 @@ plugin-hot-reload = { module = "org.jetbrains.compose.hot-reload:hot-reload-grad
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 download = { id = "de.undercouch.download", version.ref = "gradle-download-plugin" }
-shadow-jar = { id = "com.github.johnrengelman.shadow", version.ref = "shadow-jar" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 publish-plugin = { id = "com.gradle.plugin-publish", version.ref = "publish-plugin" }


### PR DESCRIPTION
Refs:

- https://github.com/GradleUp/shadow/issues/908
- https://github.com/GradleUp/shadow#current-status

## Testing

<details><summary>Jar diff:</summary>
<p>

```diff
OLD: old.jar
NEW: new.jar

 JAR   │ old       │ new       │ diff
───────┼───────────┼───────────┼──────────
 class │   8.5 MiB │   8.5 MiB │ -9.2 KiB
 other │ 896.3 KiB │ 896.3 KiB │    +50 B
───────┼───────────┼───────────┼──────────
 total │   9.4 MiB │   9.4 MiB │ -9.2 KiB

 CLASSES │ old   │ new   │ diff
─────────┼───────┼───────┼───────────
 classes │  1751 │  1751 │ 0 (+0 -0)
 methods │ 16372 │ 16372 │ 0 (+0 -0)
  fields │  5302 │  5302 │ 0 (+0 -0)

=================
====   JAR   ====
=================

 size     │ diff     │ path
──────────┼──────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    2 KiB │   +2 KiB │ + META-INF/compose.shadow.kotlin_module
          │   -2 KiB │ - META-INF/compose.kotlin_module
    426 B │   +426 B │ + META-INF/kotlinpoet.shadow.kotlin_module
          │   -368 B │ - META-INF/kotlinpoet.kotlin_module
    171 B │   +171 B │ + META-INF/preview-rpc.shadow.kotlin_module
          │   -175 B │ - META-INF/preview-rpc.kotlin_module
 14.2 KiB │     +1 B │ ∆ org/jetbrains/compose/experimental/internal/CheckExperimentalTargetsKt.class
  4.4 KiB │   +188 B │ ∆ org/jetbrains/compose/web/tasks/WebCompatibilityTaskKt$registerWebCompatibilityTask$$inlined$registerTask$1.class
 24.1 KiB │     -3 B │ ∆ org/jetbrains/compose/web/internal/ConfigureWebApplicationKt.class
  3.6 KiB │   +188 B │ ∆ org/jetbrains/compose/web/internal/ConfigureWebApplicationKt$configureWebApplication$$inlined$registerTask$1.class
  3.1 KiB │   +188 B │ ∆ org/jetbrains/compose/web/internal/ConfigureWebApplicationKt$configureWebApplication$$inlined$registerTask$2.class
 25.5 KiB │     -3 B │ ∆ org/jetbrains/compose/resources/IosResourcesKt.class
  4.1 KiB │   +207 B │ ∆ org/jetbrains/compose/resources/IosResourcesKt$configureSyncIosComposeResources$lambda$13$lambda$8$$inlined$registerOrConfigure$2.class
  3.2 KiB │   +207 B │ ∆ org/jetbrains/compose/resources/IosResourcesKt$configureSyncIosComposeResources$lambda$13$lambda$11$$inlined$registerOrConfigure$1.class
   17 KiB │     -2 B │ ∆ org/jetbrains/compose/resources/MultimoduleResourcesKt.class
  2.7 KiB │   +207 B │ ∆ org/jetbrains/compose/resources/IosResourcesKt$configureSyncIosComposeResources$lambda$13$lambda$8$$inlined$registerOrConfigure$1.class
 15.1 KiB │     -1 B │ ∆ org/jetbrains/compose/resources/SyncComposeResourcesForIosTask.class
 41.4 KiB │     -2 B │ ∆ org/jetbrains/compose/resources/ComposeResourcesGenerationKt.class
 11.5 KiB │     +3 B │ ∆ org/jetbrains/compose/resources/ComposeResourcesKt.class
  4.8 KiB │   +188 B │ ∆ org/jetbrains/compose/resources/MultimoduleResourcesKt$configureTargetResources$1$invoke$$inlined$registerTask$1.class
  2.4 KiB │   +129 B │ ∆ org/jetbrains/compose/resources/GeneratedResClassSpecKt$sortResources$lambda$26$lambda$25$$inlined$sortedBy$1.class
  3.4 KiB │   +188 B │ ∆ org/jetbrains/compose/resources/AndroidResourcesKt$configureGeneratedAndroidComponentAssets$$inlined$registerTask$1.class
 21.5 KiB │     -2 B │ ∆ org/jetbrains/compose/resources/AndroidResourcesKt.class
 10.7 KiB │     -3 B │ ∆ org/jetbrains/compose/internal/utils/ProviderUtilsKt.class
  2.6 KiB │   +129 B │ ∆ org/jetbrains/compose/desktop/application/tasks/FilesMapping$saveTo$lambda$5$$inlined$sortedBy$1.class
 62.7 KiB │    -80 B │ ∆ org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.class
  8.9 KiB │     -1 B │ ∆ org/jetbrains/compose/desktop/application/tasks/FilesMapping.class
  2.4 KiB │   +293 B │ ∆ org/jetbrains/compose/desktop/application/internal/ConfigureJvmApplicationKt$configurePackagingTasks$$inlined$register$default$1.class
   14 KiB │     -1 B │ ∆ org/jetbrains/compose/desktop/application/internal/ExternalToolRunner.class
  2.7 KiB │   +174 B │ ∆ org/jetbrains/compose/desktop/application/internal/ConfigureNativeApplicationKt$configureNativeApplication$$inlined$composeDesktopNativeTask$default$1.class
  2.7 KiB │   +188 B │ ∆ org/jetbrains/compose/desktop/application/internal/ConfigureDesktopKt$configureDesktop$$inlined$registerTask$1.class
  2.7 KiB │   +174 B │ ∆ org/jetbrains/compose/desktop/application/internal/ConfigureNativeApplicationKt$configureNativeApplication$$inlined$composeDesktopNativeTask$default$2.class
 11.2 KiB │    -13 B │ ∆ org/jetbrains/compose/desktop/application/internal/JvmApplicationInternal.class
 14.9 KiB │     -3 B │ ∆ org/jetbrains/compose/desktop/application/internal/JvmApplicationContext.class
 14.4 KiB │     -4 B │ ∆ org/jetbrains/compose/desktop/application/internal/files/FileUtilsKt.class
  2.5 KiB │   +129 B │ ∆ org/jetbrains/compose/desktop/application/internal/files/FileUtilsKt$contentHash$$inlined$sortedBy$1.class
 68.6 KiB │     -5 B │ ∆ org/jetbrains/compose/desktop/application/internal/ConfigureJvmApplicationKt.class
 23.5 KiB │     -1 B │ ∆ org/jetbrains/compose/desktop/application/internal/ConfigureNativeApplicationKt.class
   17 KiB │     -2 B │ ∆ org/jetbrains/compose/RuntimeLibrariesCompatibilityCheck.class
  4.8 KiB │   +207 B │ ∆ org/jetbrains/compose/RuntimeLibrariesCompatibilityCheckKt$configureRuntimeLibrariesCompatibilityCheck$3$invoke$$inlined$registerOrConfigure$1.class
 32.4 KiB │     -2 B │ ∆ org/jetbrains/compose/desktop/ui/tooling/preview/rpc/PreviewManagerImpl.class
    5 KiB │   +104 B │ ∆ org/jetbrains/compose/desktop/ui/tooling/preview/rpc/PreviewManagerImpl$special$$inlined$repeatWhileAliveThread$default$4.class
  6.1 KiB │   +104 B │ ∆ org/jetbrains/compose/desktop/ui/tooling/preview/rpc/PreviewManagerImpl$special$$inlined$repeatWhileAliveThread$default$2.class
 18.2 KiB │     -2 B │ ∆ org/jetbrains/compose/desktop/ui/tooling/preview/rpc/CommandsKt.class
  8.2 KiB │   +104 B │ ∆ org/jetbrains/compose/desktop/ui/tooling/preview/rpc/PreviewManagerImpl$special$$inlined$repeatWhileAliveThread$default$1.class
  4.7 KiB │   +104 B │ ∆ org/jetbrains/compose/desktop/ui/tooling/preview/rpc/PreviewManagerImpl$special$$inlined$repeatWhileAliveThread$default$3.class
   16 KiB │     -1 B │ ∆ org/jetbrains/compose/desktop/ui/tooling/preview/rpc/PreviewHost.class
    5 KiB │   -385 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/Annotatable$Builder.class
    6 KiB │   -288 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/AnnotationSpec$Builder.class
  7.9 KiB │    -97 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/AnnotationSpec$Visitor.class
 16.3 KiB │   -208 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/AnnotationSpec.class
 18.1 KiB │    -85 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/CodeBlock$Builder.class
  4.4 KiB │   -117 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/CodeBlock$Companion.class
 41.4 KiB │    -78 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/CodeWriter.class
  6.6 KiB │    -39 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/CodeWriterKt.class
  2.9 KiB │   -167 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/ContextReceivable$Builder.class
  1.9 KiB │    -72 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/ContextReceivableKt.class
    3 KiB │   -222 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/Documentable$Builder.class
    861 B │    -40 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/Documentable.class
 34.8 KiB │   -489 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/FileSpec$Builder.class
 32.1 KiB │   -103 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/FileSpec.class
 41.7 KiB │ -1.1 KiB │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/FunSpec$Builder.class
 31.2 KiB │   -208 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/FunSpec.class
  7.1 KiB │    -87 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/KModifier.class
  8.7 KiB │   -301 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/LambdaTypeName$Companion.class
 13.7 KiB │   -178 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/LambdaTypeName.class
 10.5 KiB │   -447 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/MemberName.class
   10 KiB │   -1 KiB │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/MemberSpecHolder$Builder.class
  2.5 KiB │    -98 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/OriginatingElementsHolder$Builder.class
  2.2 KiB │    -80 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/OriginatingElementsHolderKt.class
 12.9 KiB │   -403 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/ParameterSpec$Builder.class
 10.1 KiB │   -399 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/ParameterSpec$Companion.class
 18.3 KiB │   -319 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/ParameterSpec.class
 17.5 KiB │   -315 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/ParameterizedTypeName$Companion.class
 15.9 KiB │   -164 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/ParameterizedTypeName.class
 22.2 KiB │   -518 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/PropertySpec$Builder.class
    6 KiB │   -396 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/PropertySpec$Companion.class
 25.3 KiB │   -251 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/PropertySpec.class
  3.2 KiB │   -170 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/Taggable$Builder.class
  7.8 KiB │   -906 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/TaggableKt.class
 15.3 KiB │   -324 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/TypeAliasSpec$Builder.class
 13.1 KiB │   -147 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/TypeAliasSpec.class
 53.6 KiB │   -943 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/TypeSpec$Builder.class
 42.2 KiB │   -291 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/TypeSpec.class
  2.4 KiB │   -160 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/TypeSpecHolder$Builder.class
 20.9 KiB │   -385 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/TypeVariableName$Companion.class
   16 KiB │   -148 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/TypeVariableName.class
 19.5 KiB │    -57 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/UtilKt.class
  6.3 KiB │    -96 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/Util_jvmKt.class
 18.8 KiB │   -345 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/jvm/JvmAnnotations.class
  1.2 KiB │    -79 B │ ∆ org/jetbrains/compose/internal/com/squareup/kotlinpoet/tags/TypeAliasTag.class
──────────┼──────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  1.2 MiB │ -9.2 KiB │ (total)
```

</p>
</details> 

<details><summary>Maven artifacts diff:</summary>
<p>

```diff
Binary files old/.DS_Store and new/.DS_Store differ
Binary files old/compose-gradle-plugin/9999.0.0-SNAPSHOT/compose-gradle-plugin-9999.0.0-SNAPSHOT.jar and new/compose-gradle-plugin/9999.0.0-SNAPSHOT/compose-gradle-plugin-9999.0.0-SNAPSHOT.jar differ
diff --color=auto -r old/compose-gradle-plugin/9999.0.0-SNAPSHOT/compose-gradle-plugin-9999.0.0-SNAPSHOT.module new/compose-gradle-plugin/9999.0.0-SNAPSHOT/compose-gradle-plugin-9999.0.0-SNAPSHOT.module
70a71
>         "org.gradle.jvm.version": 11,
87,91c88,92
<           "size": 3882457,
<           "sha512": "252c44cdf7f5af34b873a356c56e19a83ee0340e9013d8296f1496d45a9409306a2811df43abfa1e2372306157daea89c05fee7a5ccbbb8f2b1d5d00ebc8bbd0",
<           "sha256": "3a4da63bdc5a5336607c7c9be78da5353f600355de3ad4cea5bdb833180b9595",
<           "sha1": "195c51f630a3373aae2b0d7cf5651bd3b7a9edab",
<           "md5": "4123de01e81e065d260e674e6b10df80"
---
>           "size": 3910553,
>           "sha512": "7b9dd8567440a3fb321bf861912bffdce57005e0dbf1154586771ba988c9cabf01a6c3dce0ec05da0b52d8bf46f459c678bbaf346a2e1d040a53d19ac19e6ac2",
>           "sha256": "35e759b3b11eb98541e25ec9829be6ae70ab8845d030435f54a8b94e46414ac1",
>           "sha1": "83c99a66d6e813558b8ef0aa8b448f232f099748",
>           "md5": "12280de52ec5892e6d9fa6b82cbec154"
diff --color=auto -r old/compose-gradle-plugin/9999.0.0-SNAPSHOT/compose-gradle-plugin-9999.0.0-SNAPSHOT.pom new/compose-gradle-plugin/9999.0.0-SNAPSHOT/compose-gradle-plugin-9999.0.0-SNAPSHOT.pom
26c26,27
<       <scope>runtime</scope>
---
>       <scope>compile</scope>
>       <optional>true</optional>
diff --color=auto -r old/compose-gradle-plugin/9999.0.0-SNAPSHOT/maven-metadata-local.xml new/compose-gradle-plugin/9999.0.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20260506032155</lastUpdated>
---
>     <lastUpdated>20260506032228</lastUpdated>
12,16d11
<         <extension>pom</extension>
<         <value>9999.0.0-SNAPSHOT</value>
<         <updated>20260506032155</updated>
<       </snapshotVersion>
<       <snapshotVersion>
20c15
<         <updated>20260506032155</updated>
---
>         <updated>20260506032228</updated>
23d17
<         <classifier>sources</classifier>
26c20
<         <updated>20260506032155</updated>
---
>         <updated>20260506032228</updated>
29c23
<         <extension>module</extension>
---
>         <extension>pom</extension>
31c25
<         <updated>20260506032155</updated>
---
>         <updated>20260506032228</updated>
33a28
>         <classifier>sources</classifier>
36c31,36
<         <updated>20260506032155</updated>
---
>         <updated>20260506032228</updated>
>       </snapshotVersion>
>       <snapshotVersion>
>         <extension>module</extension>
>         <value>9999.0.0-SNAPSHOT</value>
>         <updated>20260506032228</updated>
diff --color=auto -r old/compose-gradle-plugin/maven-metadata-local.xml new/compose-gradle-plugin/maven-metadata-local.xml
10c10
<     <lastUpdated>20260506032155</lastUpdated>
---
>     <lastUpdated>20260506032228</lastUpdated>
diff --color=auto -r old/gradle-plugin-internal-jdk-version-probe/9999.0.0-SNAPSHOT/maven-metadata-local.xml new/gradle-plugin-internal-jdk-version-probe/9999.0.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20260506032155</lastUpdated>
---
>     <lastUpdated>20260506032216</lastUpdated>
15c15
<         <updated>20260506032155</updated>
---
>         <updated>20260506032216</updated>
18c18
<         <extension>module</extension>
---
>         <extension>jar</extension>
20c20
<         <updated>20260506032155</updated>
---
>         <updated>20260506032216</updated>
25c25
<         <updated>20260506032155</updated>
---
>         <updated>20260506032216</updated>
28,29c28
<         <classifier>sources</classifier>
<         <extension>jar</extension>
---
>         <extension>module</extension>
31c30
<         <updated>20260506032155</updated>
---
>         <updated>20260506032216</updated>
33a33
>         <classifier>sources</classifier>
36c36
<         <updated>20260506032155</updated>
---
>         <updated>20260506032216</updated>
diff --color=auto -r old/gradle-plugin-internal-jdk-version-probe/maven-metadata-local.xml new/gradle-plugin-internal-jdk-version-probe/maven-metadata-local.xml
10c10
<     <lastUpdated>20260506032155</lastUpdated>
---
>     <lastUpdated>20260506032216</lastUpdated>
diff --color=auto -r old/org.jetbrains.compose.gradle.plugin/9999.0.0-SNAPSHOT/maven-metadata-local.xml new/org.jetbrains.compose.gradle.plugin/9999.0.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20260506032155</lastUpdated>
---
>     <lastUpdated>20260506032216</lastUpdated>
14c14
<         <updated>20260506032155</updated>
---
>         <updated>20260506032216</updated>
diff --color=auto -r old/org.jetbrains.compose.gradle.plugin/maven-metadata-local.xml new/org.jetbrains.compose.gradle.plugin/maven-metadata-local.xml
10c10
<     <lastUpdated>20260506032155</lastUpdated>
---
>     <lastUpdated>20260506032216</lastUpdated>
diff --color=auto -r old/preview-rpc/9999.0.0-SNAPSHOT/maven-metadata-local.xml new/preview-rpc/9999.0.0-SNAPSHOT/maven-metadata-local.xml
6c6
<     <lastUpdated>20260506032155</lastUpdated>
---
>     <lastUpdated>20260506032218</lastUpdated>
14c14
<         <updated>20260506032155</updated>
---
>         <updated>20260506032218</updated>
17,18c17
<         <classifier>javadoc</classifier>
<         <extension>jar</extension>
---
>         <extension>pom</extension>
20c19
<         <updated>20260506032155</updated>
---
>         <updated>20260506032218</updated>
23c22,23
<         <extension>pom</extension>
---
>         <classifier>sources</classifier>
>         <extension>jar</extension>
25c25
<         <updated>20260506032155</updated>
---
>         <updated>20260506032218</updated>
28c28
<         <classifier>sources</classifier>
---
>         <classifier>javadoc</classifier>
31c31
<         <updated>20260506032155</updated>
---
>         <updated>20260506032218</updated>
36c36
<         <updated>20260506032155</updated>
---
>         <updated>20260506032218</updated>
Binary files old/preview-rpc/9999.0.0-SNAPSHOT/preview-rpc-9999.0.0-SNAPSHOT-sources.jar and new/preview-rpc/9999.0.0-SNAPSHOT/preview-rpc-9999.0.0-SNAPSHOT-sources.jar differ
diff --color=auto -r old/preview-rpc/9999.0.0-SNAPSHOT/preview-rpc-9999.0.0-SNAPSHOT.module new/preview-rpc/9999.0.0-SNAPSHOT/preview-rpc-9999.0.0-SNAPSHOT.module
110,114c110,114
<           "size": 17320,
<           "sha512": "d05fc9cd26b62d78f4ecac93cda80a7d0d2c96fddea2a7a45c541698d3e2045ac2bcd2053ffaacc78c61358c30e90ab4c99cc60e70bc409129336fe400e39e92",
<           "sha256": "ca44df4c5d5c34d73e2c62f785c27e6f30d65118a4739bf14d246c40f2ac72e7",
<           "sha1": "4eb15678027058a82713507422b6827fa1229834",
<           "md5": "926de8d2af61db06e40f15673e76ffbe"
---
>           "size": 17638,
>           "sha512": "7863579dcf54d54360af04a7d7159de639cda13c21619b9c7eb3e9522f7eb565e4bf09c7d2013f40f4fa6aec4161f7ee0849d4df72d568cdef76398bac866a27",
>           "sha256": "f5b8e73f4b6639fc89860ed8b966ea69e3bd7e0df81c6f78e0d5ecda616f28dc",
>           "sha1": "23aea989bb9c6648240f77ec2ca060c9b11d4425",
>           "md5": "a2b6b083187d16d9b6f8165fa1aed831"
119,123c119,123
<           "size": 17320,
<           "sha512": "d05fc9cd26b62d78f4ecac93cda80a7d0d2c96fddea2a7a45c541698d3e2045ac2bcd2053ffaacc78c61358c30e90ab4c99cc60e70bc409129336fe400e39e92",
<           "sha256": "ca44df4c5d5c34d73e2c62f785c27e6f30d65118a4739bf14d246c40f2ac72e7",
<           "sha1": "4eb15678027058a82713507422b6827fa1229834",
<           "md5": "926de8d2af61db06e40f15673e76ffbe"
---
>           "size": 17638,
>           "sha512": "7863579dcf54d54360af04a7d7159de639cda13c21619b9c7eb3e9522f7eb565e4bf09c7d2013f40f4fa6aec4161f7ee0849d4df72d568cdef76398bac866a27",
>           "sha256": "f5b8e73f4b6639fc89860ed8b966ea69e3bd7e0df81c6f78e0d5ecda616f28dc",
>           "sha1": "23aea989bb9c6648240f77ec2ca060c9b11d4425",
>           "md5": "a2b6b083187d16d9b6f8165fa1aed831"
diff --color=auto -r old/preview-rpc/maven-metadata-local.xml new/preview-rpc/maven-metadata-local.xml
10c10
<     <lastUpdated>20260506032155</lastUpdated>
---
>     <lastUpdated>20260506032218</lastUpdated>
```

</p>
</details> 

## Release Notes
### Section - Subsection
- Describe change in format https://github.com/JetBrains/compose-multiplatform/blob/master/tools/changelog/PR_FORMAT.md
  - Sections: Highlights, Known Issues, Breaking Changes, Migration Notes, Features, Fixes
  - Subsections: Multiple Platforms, iOS, Desktop, Web, Android, Resources, Gradle Plugin, Lifecycle, Navigation, SavedState
