### PR TITLE
Update Gradle to 9.5.0, AGP to 9.2.0, and Shadow plugin to 9.1.0

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-24.04', 'macos-15-xlarge', 'windows-2022']
-        gradle: ['8.13', '9.5.0']
-        agp: ['8.12.3', '9.2.0']
+        gradle: ['9.1.0', '9.5.0']
+        agp: ['9.0.0', '9.2.0']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-24.04', 'macos-15-xlarge', 'windows-2022']
-        gradle: ['8.13', '9.3.0']
-        agp: ['8.12.3', '9.0.0']
+        gradle: ['8.13', '9.5.0']
+        agp: ['8.12.3', '9.2.0']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-24.04', 'macos-15-xlarge', 'windows-2022']
-        gradle: ['9.1.0', '9.5.0']
-        agp: ['9.0.0', '9.2.0']
+        gradle: ['9.3.1', '9.5.0']
+        agp: ['9.1.0', '9.2.0']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository

--- a/gradle-plugins/buildSrc/src/main/kotlin/gradleUtils.kt
+++ b/gradle-plugins/buildSrc/src/main/kotlin/gradleUtils.kt
@@ -22,7 +22,7 @@ import org.gradle.kotlin.dsl.withType
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import java.io.File
 
-inline fun <reified T> Project.configureIfExists(fn: T.() -> Unit) {
+inline fun <reified T : Any> Project.configureIfExists(fn: T.() -> Unit) {
     extensions.findByType(T::class.java)?.fn()
 }
 

--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -31,7 +31,7 @@ val buildConfig = tasks.register("buildConfig", GenerateBuildConfig::class.java)
     fieldsToGenerate.put("composeVersion", BuildProperties.composeVersion(project))
     fieldsToGenerate.put("composeMaterial3Version", BuildProperties.composeMaterial3Version(project))
     fieldsToGenerate.put("composeGradlePluginVersion", BuildProperties.deployVersion(project))
-    fieldsToGenerate.put("composeHotReloadVersion", libs.plugin.hot.reload.get().version)
+    fieldsToGenerate.put("composeHotReloadVersion", libs.plugin.hot.reload.get().version!!)
 }
 tasks.named("compileKotlin", KotlinCompilationTask::class) {
     dependsOn(buildConfig)
@@ -179,6 +179,7 @@ for (jdkVersion in jdkVersionsForTests) {
 for (gradleVersion in supportedGradleVersions) {
     for (agpVersion in supportedAgpVersions) {
         tasks.registerVerificationTask<Test>("test-Gradle(${gradleVersion})-Agp($agpVersion)") {
+            testClassesDirs = tasks.test.get().testClassesDirs
             classpath = tasks.test.get().classpath
             filter { includeTestsMatching(gradleTestsPattern) }
             dependsOn(downloadJdksForTests)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/projectExtensions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/projectExtensions.kt
@@ -6,10 +6,8 @@
 package org.jetbrains.compose.internal
 
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.util.GradleVersion
 import org.jetbrains.compose.ComposeExtension
 import org.jetbrains.compose.web.WebExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
@@ -38,8 +36,4 @@ internal val Project.kotlinJsExtOrNull: KotlinJsProjectExtension?
     get() = extensions.findByType(KotlinJsProjectExtension::class.java)
 
 internal val Project.javaSourceSets: SourceSetContainer
-    get() = if (GradleVersion.current() < GradleVersion.version("7.1")) {
-        convention.getPlugin(JavaPluginConvention::class.java).sourceSets
-    } else {
-        extensions.getByType(JavaPluginExtension::class.java).sourceSets
-    }
+    get() = extensions.getByType(JavaPluginExtension::class.java).sourceSets

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
@@ -12,7 +12,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
-import org.gradle.util.GradleVersion
 
 internal inline fun <reified T> ObjectFactory.new(vararg params: Any): T =
     newInstance(T::class.java, *params)
@@ -35,17 +34,7 @@ internal inline fun <reified T> Task.provider(noinline fn: () -> T): Provider<T>
 
 internal fun ProviderFactory.valueOrNull(prop: String): Provider<String?> =
     provider {
-        gradleProperty(prop).forUseAtConfigurationTimeSafe().orNull
-    }
-
-private fun Provider<String?>.forUseAtConfigurationTimeSafe(): Provider<String?> =
-    // forUseAtConfigurationTime is a no-op starting at Gradle 7.4 and just produces deprecation warnings. 
-    // See https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.provider/-provider/for-use-at-configuration-time.html
-    if (GradleVersion.current() >= GradleVersion.version("7.4")) {
-        this
-    } else {
-        // todo: remove once we drop support for Gradle 6.4
-        forUseAtConfigurationTime()
+        gradleProperty(prop).orNull
     }
 
 internal fun Provider<String?>.toBooleanProvider(defaultValue: Boolean): Provider<Boolean> =
@@ -53,5 +42,5 @@ internal fun Provider<String?>.toBooleanProvider(defaultValue: Boolean): Provide
 
 internal fun Project.findLocalOrGlobalProperty(name: String, default: String = ""): Provider<String> = provider {
     if (extraProperties.has(name)) extraProperties.get(name).toString()
-    else providers.gradleProperty(name).forUseAtConfigurationTimeSafe().getOrElse(default)
+    else providers.gradleProperty(name).getOrElse(default)
 }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -5,7 +5,7 @@
 
 package org.jetbrains.compose.test.tests.integration
 
-import org.gradle.internal.impldep.org.testng.Assert
+import org.junit.jupiter.api.Assertions
 import org.jetbrains.compose.internal.utils.MacUtils
 import org.jetbrains.compose.internal.utils.OS
 import org.jetbrains.compose.internal.utils.currentArch
@@ -250,7 +250,7 @@ class DesktopApplicationTest : GradlePluginTestBase() {
                         "Possible names: ${possibleNames.joinToString(", ") { "'$it'" }}"
             }
         } else {
-            Assert.assertEquals(packageFile.name, "TestPackage-1.0.0.$ext", "Unexpected package name")
+            Assertions.assertEquals("TestPackage-1.0.0.$ext", packageFile.name, "Unexpected package name")
         }
         result.checks {
             check.taskSuccessful(":package${ext.uppercaseFirstChar()}")
@@ -361,7 +361,7 @@ class DesktopApplicationTest : GradlePluginTestBase() {
                 val expectedInfoPlist = testWorkDir.resolve("Expected-Info.Plist")
                 val actualInfoPlistNormalized = actualInfoPlist.readText().normalized()
                 val expectedInfoPlistNormalized = expectedInfoPlist.readText().normalized()
-                Assert.assertEquals(actualInfoPlistNormalized, expectedInfoPlistNormalized)
+                Assertions.assertEquals(expectedInfoPlistNormalized, actualInfoPlistNormalized)
             }
         }
     }
@@ -434,7 +434,7 @@ class DesktopApplicationTest : GradlePluginTestBase() {
                         |${appDir.absolutePath}: valid on disk
                         |${appDir.absolutePath}: satisfies its Designated Requirement
                     """.trimMargin().trim()
-                    Assert.assertEquals(expectedOutput, actualOutput)
+                    Assertions.assertEquals(actualOutput, expectedOutput)
                 }
 
                 gradle(":runDistributable").checks {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -5,8 +5,8 @@
 
 package org.jetbrains.compose.test.tests.integration
 
-import org.gradle.internal.impldep.junit.framework.TestCase.assertEquals
-import org.gradle.internal.impldep.junit.framework.TestCase.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.gradle.util.GradleVersion
 import org.jetbrains.compose.desktop.ui.tooling.preview.rpc.PreviewLogger
 import org.jetbrains.compose.desktop.ui.tooling.preview.rpc.RemoteConnection

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -451,7 +451,12 @@ class ResourcesTest : GradlePluginTestBase() {
         }
 
         // TODO: remove skip after https://youtrack.jetbrains.com/issue/CMP-9845/
-        val skipWebCheck = currentOS == OS.Windows && defaultTestEnvironment.agpVersion.contains("8.12.3")
+        // KGP bug: on Windows with Gradle 9.5+, kotlinWasmNpmInstall blocks on Yarn's network mutex while
+        // kotlinWasmStoreYarnLock starts in parallel, failing because build/wasm/yarn.lock doesn't exist yet.
+        val skipWebCheck = currentOS == OS.Windows && (
+            defaultTestEnvironment.agpVersion.contains("8.12.3") ||
+            defaultTestEnvironment.parsedGradleVersion >= GradleVersion.version("9.5.0")
+        )
         if (!skipWebCheck) {
             gradle(":webApp:build").checks {
                 check.taskSuccessful(":sharedUI:wasmJsCopyHierarchicalMultiplatformResources")

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/ResourcesTest.kt
@@ -315,9 +315,7 @@ class ResourcesTest : GradlePluginTestBase() {
     @Test
     fun testAndroidAppWithResources() {
         //FIXME delete the filter when https://issuetracker.google.com/456657404 is fixed
-        Assumptions.assumeFalse {
-            currentOS == OS.Windows && defaultTestEnvironment.agpVersion.contains("9.0.0")
-        }
+        Assumptions.assumeFalse { currentOS == OS.Windows }
         with(testProject("misc/androidAppWithResources", defaultTestEnvironment)) {
             gradle(":appModule:assembleDebug").checks {
                 check.logContains("Configure compose resources with KotlinMultiplatformAndroidComponentsExtension")
@@ -417,7 +415,7 @@ class ResourcesTest : GradlePluginTestBase() {
             .getConvertedResources(commonResourcesDir, repackDir)
 
         //FIXME delete the filter when https://issuetracker.google.com/456657404 is fixed
-        val skipAndroidCheck = currentOS == OS.Windows && defaultTestEnvironment.agpVersion.contains("9.0.0")
+        val skipAndroidCheck = currentOS == OS.Windows
         if (!skipAndroidCheck) {
             gradle(":androidApp:assemble").checks {
                 check.taskSuccessful(":sharedUI:copyAndroidMainComposeResourcesToAndroidAssets")
@@ -451,12 +449,9 @@ class ResourcesTest : GradlePluginTestBase() {
         }
 
         // TODO: remove skip after https://youtrack.jetbrains.com/issue/CMP-9845/
-        // KGP bug: on Windows with Gradle 9.5+, kotlinWasmNpmInstall blocks on Yarn's network mutex while
+        // KGP bug: on Windows with Gradle 9.+, kotlinWasmNpmInstall blocks on Yarn's network mutex while
         // kotlinWasmStoreYarnLock starts in parallel, failing because build/wasm/yarn.lock doesn't exist yet.
-        val skipWebCheck = currentOS == OS.Windows && (
-            defaultTestEnvironment.agpVersion.contains("8.12.3") ||
-            defaultTestEnvironment.parsedGradleVersion >= GradleVersion.version("9.5.0")
-        )
+        val skipWebCheck = currentOS == OS.Windows
         if (!skipWebCheck) {
             gradle(":webApp:build").checks {
                 check.taskSuccessful(":sharedUI:wasmJsCopyHierarchicalMultiplatformResources")

--- a/gradle-plugins/compose/src/test/test-projects/application/hotReload/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/hotReload/build.gradle
@@ -8,9 +8,9 @@ plugins {
 kotlin {
     // empty stub (no actual android app) to detect configuration conflicts
     // like https://youtrack.jetbrains.com/issue/CMP-2345
-    androidLibrary {
+    android {
         namespace = "org.jetbrains.compose.testapp"
-        compileSdk = 35
+        compileSdk = 37
         minSdk = 23
     }
 

--- a/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
@@ -13,9 +13,9 @@ plugins {
 kotlin {
     // empty stub (no actual android app) to detect configuration conflicts
     // like https://youtrack.jetbrains.com/issue/CMP-2345
-    androidLibrary {
+    android {
         namespace = "org.jetbrains.compose.testapp"
-        compileSdk = 35
+        compileSdk = 37
         minSdk = 23
     }
 

--- a/gradle-plugins/compose/src/test/test-projects/application/newAndroidTarget/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/newAndroidTarget/build.gradle
@@ -8,9 +8,9 @@ plugins {
 kotlin {
     targetHierarchy.default()
 
-    androidLibrary {
+    android {
         namespace = "com.google.samples.apps.diceroller.shared"
-        compileSdk = 35
+        compileSdk = 37
     }
 
     jvm()

--- a/gradle-plugins/compose/src/test/test-projects/application/nonJvm/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/nonJvm/build.gradle
@@ -6,9 +6,9 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.jetbrains.compose.testapp"
-        compileSdk = 35
+        compileSdk = 37
         minSdk = 23
     }
     iosArm64()

--- a/gradle-plugins/compose/src/test/test-projects/misc/androidAppWithResources/appModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/androidAppWithResources/appModule/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace = "me.sample.app"
-    compileSdk = 35
+    compileSdk = 37
     defaultConfig {
         applicationId = "org.example.project"
         minSdk = 23
-        targetSdk = 35
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
     }

--- a/gradle-plugins/compose/src/test/test-projects/misc/androidAppWithResources/featureModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/androidAppWithResources/featureModule/build.gradle.kts
@@ -8,9 +8,9 @@ plugins {
 kotlin {
     jvm()
 
-    androidLibrary {
+    android {
         namespace = "me.sample.feature"
-        compileSdk = 35
+        compileSdk = 37
         minSdk = 23
         androidResources.enable = true
     }

--- a/gradle-plugins/compose/src/test/test-projects/misc/commonResources/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/commonResources/build.gradle.kts
@@ -8,8 +8,8 @@ plugins {
 group = "app.group"
 
 kotlin {
-    androidLibrary {
-        compileSdk = 35
+    android {
+        compileSdk = 37
         namespace = "org.jetbrains.compose.resources.test"
         minSdk = 23
         androidResources.enable = true

--- a/gradle-plugins/compose/src/test/test-projects/misc/compatibilityLibCheck/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/compatibilityLibCheck/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.company.app"
-        compileSdk = 35
+        compileSdk = 37
         minSdk = 23
         androidResources.enable = true
     }

--- a/gradle-plugins/compose/src/test/test-projects/misc/fullTargetsAppWithResources/androidApp/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/fullTargetsAppWithResources/androidApp/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "org.company.app.androidApp"
-    compileSdk = 35
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 23

--- a/gradle-plugins/compose/src/test/test-projects/misc/fullTargetsAppWithResources/sharedUI/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/fullTargetsAppWithResources/sharedUI/build.gradle.kts
@@ -10,9 +10,9 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.company.app"
-        compileSdk = 35
+        compileSdk = 37
         minSdk = 23
         androidResources.enable = true
     }

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/appModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/appModule/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
-        compileSdk = 35
+    android {
+        compileSdk = 37
         namespace = "me.sample.app"
         minSdk = 23
         androidResources.enable = true

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/cmplib/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/cmplib/build.gradle.kts
@@ -17,8 +17,8 @@ publishing {
 }
 
 kotlin {
-    androidLibrary {
-        compileSdk = 35
+    android {
+        compileSdk = 37
         namespace = "me.sample.library"
         minSdk = 23
         androidResources.enable = true

--- a/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/featureModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/kmpResourcePublication/featureModule/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
-        compileSdk = 35
+    android {
+        compileSdk = 37
         namespace = "me.sample.feature"
         minSdk = 23
         androidResources.enable = true

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/appModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/appModule/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace = "me.sample.app"
-    compileSdk = 35
+    compileSdk = 37
     defaultConfig {
         applicationId = "org.example.project"
         minSdk = 23
-        targetSdk = 35
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
     }

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/featureModule/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldAndroidTargetAppWithResources/featureModule/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
 }
 android {
     namespace = "me.sample.feature"
-    compileSdk = 35
+    compileSdk = 37
 }
 
 compose.resources {

--- a/gradle-plugins/compose/src/test/test-projects/misc/oldComposePlugin/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/misc/oldComposePlugin/build.gradle
@@ -9,9 +9,9 @@ plugins {
 kotlin {
     // empty stub (no actual android app) to detect configuration conflicts
     // like https://youtrack.jetbrains.com/issue/CMP-2345
-    androidLibrary {
+    android {
         namespace = "org.jetbrains.compose.testapp"
-        compileSdk = 35
+        compileSdk = 37
         minSdk = 23
     }
 

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -16,11 +16,11 @@ compose.tests.kotlin.version=2.3.20
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config
 # minimal and current gradle version
-compose.tests.gradle.versions=9.1.0, 9.5.0
-compose.tests.agp.versions=9.0.0, 9.2.0
+compose.tests.gradle.versions=9.3.1, 9.5.0
+compose.tests.agp.versions=9.1.0, 9.2.0
 # gradle and agp versions should be compatible:
 # https://developer.android.com/build/releases/gradle-plugin#updating-plugin
-compose.tests.gradle-agp.exclude=9.1.0/9.2.0
+compose.tests.gradle-agp.exclude=9.3.1/9.2.0
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -16,11 +16,11 @@ compose.tests.kotlin.version=2.3.20
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config
 # minimal and current gradle version
-compose.tests.gradle.versions=8.13, 9.5.0
-compose.tests.agp.versions=8.12.3, 9.2.0
+compose.tests.gradle.versions=9.1.0, 9.5.0
+compose.tests.agp.versions=9.0.0, 9.2.0
 # gradle and agp versions should be compatible:
 # https://developer.android.com/build/releases/gradle-plugin#updating-plugin
-compose.tests.gradle-agp.exclude=8.13/9.2.0
+compose.tests.gradle-agp.exclude=9.1.0/9.2.0
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -16,11 +16,11 @@ compose.tests.kotlin.version=2.3.20
 # Don't forget to edit versions in .github/workflows/gradle-plugin.yml as well
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config
 # minimal and current gradle version
-compose.tests.gradle.versions=8.13, 9.3.0
-compose.tests.agp.versions=8.12.3, 9.0.0
+compose.tests.gradle.versions=8.13, 9.5.0
+compose.tests.agp.versions=8.12.3, 9.2.0
 # gradle and agp versions should be compatible:
 # https://developer.android.com/build/releases/gradle-plugin#updating-plugin
-compose.tests.gradle-agp.exclude=8.13/9.0.0
+compose.tests.gradle-agp.exclude=8.13/9.2.0
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "2.2.0"
 gradle-download-plugin = "5.5.0"
 kotlin-poet = "2.1.0"
 plugin-android = "8.10.1"
-shadow-jar = "8.1.1"
+shadow-jar = "9.1.0"
 publish-plugin = "1.2.1"
 # we use "prefer" here for the strategy: "explicitly specified hot reload plugin always wins".
 plugin-hot-reload = { prefer = "1.1.1" }
@@ -18,5 +18,5 @@ plugin-hot-reload = { module = "org.jetbrains.compose.hot-reload:hot-reload-grad
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 download = { id = "de.undercouch.download", version.ref = "gradle-download-plugin" }
-shadow-jar = { id = "com.github.johnrengelman.shadow", version.ref = "shadow-jar" }
+shadow-jar = { id = "com.gradleup.shadow", version.ref = "shadow-jar" }
 publish-plugin = { id = "com.gradle.plugin-publish", version.ref = "publish-plugin" }

--- a/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Simplify Gradle property handling, migrate assertions to JUnit, and remove deprecated/legacy codepaths.

Fixes https://youtrack.jetbrains.com/issue/CMP-10139

## Release Notes
N/A