### PR TITLE
Refactor gradle API

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeExtension.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeExtension.kt
@@ -11,7 +11,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import javax.inject.Inject
 
@@ -34,7 +34,7 @@ abstract class ComposeExtension @Inject constructor(
      * (see available versions here: https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility)
      */
     @Deprecated("Since Kotlin $newCompilerIsAvailableVersion Compose Compiler configuration is moved to the \"$newComposeCompilerKotlinSupportPluginId\" plugin")
-    val kotlinCompilerPlugin: Property<String> = objects.notNullProperty()
+    val kotlinCompilerPlugin: Property<String> = objects.property()
 
     /**
      * List of the arguments applied to the Compose Compiler. Example:

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeExtension.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeExtension.kt
@@ -11,7 +11,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
-import org.jetbrains.compose.internal.utils.nullableProperty
+import org.jetbrains.compose.internal.utils.notNullProperty
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import javax.inject.Inject
 
@@ -34,7 +34,7 @@ abstract class ComposeExtension @Inject constructor(
      * (see available versions here: https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility)
      */
     @Deprecated("Since Kotlin $newCompilerIsAvailableVersion Compose Compiler configuration is moved to the \"$newComposeCompilerKotlinSupportPluginId\" plugin")
-    val kotlinCompilerPlugin: Property<String?> = objects.nullableProperty()
+    val kotlinCompilerPlugin: Property<String> = objects.notNullProperty()
 
     /**
      * List of the arguments applied to the Compose Compiler. Example:

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/MacOSNotarizationSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/MacOSNotarizationSettings.kt
@@ -12,7 +12,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.jetbrains.compose.desktop.application.internal.ComposeProperties
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import javax.inject.Inject
 
 abstract class MacOSNotarizationSettings {
@@ -24,25 +24,25 @@ abstract class MacOSNotarizationSettings {
 
     @get:Input
     @get:Optional
-    val appleID: Property<String> = objects.notNullProperty<String>().apply {
+    val appleID: Property<String> = objects.property<String>().apply {
         set(ComposeProperties.macNotarizationAppleID(providers))
     }
 
     @get:Input
     @get:Optional
-    val password: Property<String> = objects.notNullProperty<String>().apply {
+    val password: Property<String> = objects.property<String>().apply {
         set(ComposeProperties.macNotarizationPassword(providers))
     }
 
     @get:Input
     @get:Optional
-    val teamID: Property<String> = objects.notNullProperty<String>().apply {
+    val teamID: Property<String> = objects.property<String>().apply {
         set(ComposeProperties.macNotarizationTeamID(providers))
     }
 
     @Deprecated("This option is no longer supported and got replaced by teamID", level = DeprecationLevel.ERROR)
     @get:Internal
-    val ascProvider: Property<String> = objects.notNullProperty<String>().apply {
+    val ascProvider: Property<String> = objects.property<String>().apply {
         set(providers.provider {
             throw UnsupportedOperationException("This option is not supported by notary tool and was replaced by teamID")
         })

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/MacOSNotarizationSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/MacOSNotarizationSettings.kt
@@ -12,7 +12,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.jetbrains.compose.desktop.application.internal.ComposeProperties
-import org.jetbrains.compose.internal.utils.nullableProperty
+import org.jetbrains.compose.internal.utils.notNullProperty
 import javax.inject.Inject
 
 abstract class MacOSNotarizationSettings {
@@ -24,25 +24,25 @@ abstract class MacOSNotarizationSettings {
 
     @get:Input
     @get:Optional
-    val appleID: Property<String?> = objects.nullableProperty<String>().apply {
+    val appleID: Property<String> = objects.notNullProperty<String>().apply {
         set(ComposeProperties.macNotarizationAppleID(providers))
     }
 
     @get:Input
     @get:Optional
-    val password: Property<String?> = objects.nullableProperty<String>().apply {
+    val password: Property<String> = objects.notNullProperty<String>().apply {
         set(ComposeProperties.macNotarizationPassword(providers))
     }
 
     @get:Input
     @get:Optional
-    val teamID: Property<String?> = objects.nullableProperty<String>().apply {
+    val teamID: Property<String> = objects.notNullProperty<String>().apply {
         set(ComposeProperties.macNotarizationTeamID(providers))
     }
 
     @Deprecated("This option is no longer supported and got replaced by teamID", level = DeprecationLevel.ERROR)
     @get:Internal
-    val ascProvider: Property<String?> = objects.nullableProperty<String>().apply {
+    val ascProvider: Property<String> = objects.notNullProperty<String>().apply {
         set(providers.provider {
             throw UnsupportedOperationException("This option is not supported by notary tool and was replaced by teamID")
         })

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/MacOSSigningSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/MacOSSigningSettings.kt
@@ -11,7 +11,7 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.jetbrains.compose.desktop.application.internal.ComposeProperties
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import javax.inject.Inject
 
 abstract class MacOSSigningSettings {
@@ -21,7 +21,7 @@ abstract class MacOSSigningSettings {
     protected abstract val providers: ProviderFactory
 
     @get:Input
-    val sign: Property<Boolean> = objects.notNullProperty<Boolean>().apply {
+    val sign: Property<Boolean> = objects.property<Boolean>().apply {
         set(
             ComposeProperties.macSign(providers)
                 .orElse(false)
@@ -29,17 +29,17 @@ abstract class MacOSSigningSettings {
     }
     @get:Input
     @get:Optional
-    val identity: Property<String> = objects.notNullProperty<String>().apply {
+    val identity: Property<String> = objects.property<String>().apply {
         set(ComposeProperties.macSignIdentity(providers))
     }
     @get:Input
     @get:Optional
-    val keychain: Property<String> = objects.notNullProperty<String>().apply {
+    val keychain: Property<String> = objects.property<String>().apply {
         set(ComposeProperties.macSignKeychain(providers))
     }
     @get:Input
     @get:Optional
-    val prefix: Property<String> = objects.notNullProperty<String>().apply {
+    val prefix: Property<String> = objects.property<String>().apply {
         set(ComposeProperties.macSignPrefix(providers))
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/MacOSSigningSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/MacOSSigningSettings.kt
@@ -12,7 +12,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.jetbrains.compose.desktop.application.internal.ComposeProperties
 import org.jetbrains.compose.internal.utils.notNullProperty
-import org.jetbrains.compose.internal.utils.nullableProperty
 import javax.inject.Inject
 
 abstract class MacOSSigningSettings {
@@ -30,17 +29,17 @@ abstract class MacOSSigningSettings {
     }
     @get:Input
     @get:Optional
-    val identity: Property<String?> = objects.nullableProperty<String>().apply {
+    val identity: Property<String> = objects.notNullProperty<String>().apply {
         set(ComposeProperties.macSignIdentity(providers))
     }
     @get:Input
     @get:Optional
-    val keychain: Property<String?> = objects.nullableProperty<String>().apply {
+    val keychain: Property<String> = objects.notNullProperty<String>().apply {
         set(ComposeProperties.macSignKeychain(providers))
     }
     @get:Input
     @get:Optional
-    val prefix: Property<String?> = objects.nullableProperty<String>().apply {
+    val prefix: Property<String> = objects.notNullProperty<String>().apply {
         set(ComposeProperties.macSignPrefix(providers))
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
@@ -8,7 +8,7 @@ package org.jetbrains.compose.desktop.application.dsl
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import javax.inject.Inject
 
 private const val DEFAULT_PROGUARD_VERSION = "7.8.0"
@@ -16,11 +16,11 @@ private const val DEFAULT_PROGUARD_VERSION = "7.8.0"
 abstract class ProguardSettings @Inject constructor(
     objects: ObjectFactory,
 ) {
-    val version: Property<String> = objects.notNullProperty(DEFAULT_PROGUARD_VERSION)
-    val maxHeapSize: Property<String> = objects.notNullProperty()
+    val version: Property<String> = objects.property(DEFAULT_PROGUARD_VERSION)
+    val maxHeapSize: Property<String> = objects.property()
     val configurationFiles: ConfigurableFileCollection = objects.fileCollection()
-    val isEnabled: Property<Boolean> = objects.notNullProperty(false)
-    val obfuscate: Property<Boolean> = objects.notNullProperty(false)
-    val optimize: Property<Boolean> = objects.notNullProperty(true)
-    val joinOutputJars: Property<Boolean> = objects.notNullProperty(false)
+    val isEnabled: Property<Boolean> = objects.property(false)
+    val obfuscate: Property<Boolean> = objects.property(false)
+    val optimize: Property<Boolean> = objects.property(true)
+    val joinOutputJars: Property<Boolean> = objects.property(false)
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
@@ -9,7 +9,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.jetbrains.compose.internal.utils.notNullProperty
-import org.jetbrains.compose.internal.utils.nullableProperty
 import javax.inject.Inject
 
 private const val DEFAULT_PROGUARD_VERSION = "7.8.0"
@@ -18,7 +17,7 @@ abstract class ProguardSettings @Inject constructor(
     objects: ObjectFactory,
 ) {
     val version: Property<String> = objects.notNullProperty(DEFAULT_PROGUARD_VERSION)
-    val maxHeapSize: Property<String?> = objects.nullableProperty()
+    val maxHeapSize: Property<String> = objects.notNullProperty()
     val configurationFiles: ConfigurableFileCollection = objects.fileCollection()
     val isEnabled: Property<Boolean> = objects.notNullProperty(false)
     val obfuscate: Property<Boolean> = objects.notNullProperty(false)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
@@ -16,11 +16,11 @@ private const val DEFAULT_PROGUARD_VERSION = "7.8.0"
 abstract class ProguardSettings @Inject constructor(
     objects: ObjectFactory,
 ) {
-    val version: Property<String> = objects.property(DEFAULT_PROGUARD_VERSION)
+    val version: Property<String> = objects.property<String>().value(DEFAULT_PROGUARD_VERSION)
     val maxHeapSize: Property<String> = objects.property()
     val configurationFiles: ConfigurableFileCollection = objects.fileCollection()
-    val isEnabled: Property<Boolean> = objects.property(false)
-    val obfuscate: Property<Boolean> = objects.property(false)
-    val optimize: Property<Boolean> = objects.property(true)
-    val joinOutputJars: Property<Boolean> = objects.property(false)
+    val isEnabled: Property<Boolean> = objects.property<Boolean>().value(false)
+    val obfuscate: Property<Boolean> = objects.property<Boolean>().value(false)
+    val optimize: Property<Boolean> = objects.property<Boolean>().value(true)
+    val joinOutputJars: Property<Boolean> = objects.property<Boolean>().value(false)
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
@@ -39,22 +39,22 @@ internal object ComposeProperties {
     fun macSign(providers: ProviderFactory): Provider<Boolean> =
         providers.valueOrNull(MAC_SIGN).toBooleanProvider(false)
 
-    fun macSignIdentity(providers: ProviderFactory): Provider<String?> =
+    fun macSignIdentity(providers: ProviderFactory): Provider<String> =
         providers.valueOrNull(MAC_SIGN_ID)
 
-    fun macSignKeychain(providers: ProviderFactory): Provider<String?> =
+    fun macSignKeychain(providers: ProviderFactory): Provider<String> =
         providers.valueOrNull(MAC_SIGN_KEYCHAIN)
 
-    fun macSignPrefix(providers: ProviderFactory): Provider<String?> =
+    fun macSignPrefix(providers: ProviderFactory): Provider<String> =
         providers.valueOrNull(MAC_SIGN_PREFIX)
 
-    fun macNotarizationAppleID(providers: ProviderFactory): Provider<String?> =
+    fun macNotarizationAppleID(providers: ProviderFactory): Provider<String> =
         providers.valueOrNull(MAC_NOTARIZATION_APPLE_ID)
 
-    fun macNotarizationPassword(providers: ProviderFactory): Provider<String?> =
+    fun macNotarizationPassword(providers: ProviderFactory): Provider<String> =
         providers.valueOrNull(MAC_NOTARIZATION_PASSWORD)
 
-    fun macNotarizationTeamID(providers: ProviderFactory): Provider<String?> =
+    fun macNotarizationTeamID(providers: ProviderFactory): Provider<String> =
         providers.valueOrNull(MAC_NOTARIZATION_TEAM_ID_PROVIDER)
 
     fun checkJdkVendor(providers: ProviderFactory): Provider<Boolean> =

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
@@ -10,7 +10,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.compose.internal.utils.findLocalOrGlobalProperty
 import org.jetbrains.compose.internal.utils.toBooleanProvider
-import org.jetbrains.compose.internal.utils.valueOrNull
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
 internal object ComposeProperties {
@@ -31,48 +30,48 @@ internal object ComposeProperties {
     internal const val DISABLE_LIBRARY_COMPATIBILITY_CHECK = "org.jetbrains.compose.library.compatibility.check.disable"
 
     fun isVerbose(providers: ProviderFactory): Provider<Boolean> =
-        providers.valueOrNull(VERBOSE).toBooleanProvider(false)
+        providers.gradleProperty(VERBOSE).toBooleanProvider(false)
 
     fun preserveWorkingDir(providers: ProviderFactory): Provider<Boolean> =
-        providers.valueOrNull(PRESERVE_WD).toBooleanProvider(false)
+        providers.gradleProperty(PRESERVE_WD).toBooleanProvider(false)
 
     fun macSign(providers: ProviderFactory): Provider<Boolean> =
-        providers.valueOrNull(MAC_SIGN).toBooleanProvider(false)
+        providers.gradleProperty(MAC_SIGN).toBooleanProvider(false)
 
     fun macSignIdentity(providers: ProviderFactory): Provider<String> =
-        providers.valueOrNull(MAC_SIGN_ID)
+        providers.gradleProperty(MAC_SIGN_ID)
 
     fun macSignKeychain(providers: ProviderFactory): Provider<String> =
-        providers.valueOrNull(MAC_SIGN_KEYCHAIN)
+        providers.gradleProperty(MAC_SIGN_KEYCHAIN)
 
     fun macSignPrefix(providers: ProviderFactory): Provider<String> =
-        providers.valueOrNull(MAC_SIGN_PREFIX)
+        providers.gradleProperty(MAC_SIGN_PREFIX)
 
     fun macNotarizationAppleID(providers: ProviderFactory): Provider<String> =
-        providers.valueOrNull(MAC_NOTARIZATION_APPLE_ID)
+        providers.gradleProperty(MAC_NOTARIZATION_APPLE_ID)
 
     fun macNotarizationPassword(providers: ProviderFactory): Provider<String> =
-        providers.valueOrNull(MAC_NOTARIZATION_PASSWORD)
+        providers.gradleProperty(MAC_NOTARIZATION_PASSWORD)
 
     fun macNotarizationTeamID(providers: ProviderFactory): Provider<String> =
-        providers.valueOrNull(MAC_NOTARIZATION_TEAM_ID_PROVIDER)
+        providers.gradleProperty(MAC_NOTARIZATION_TEAM_ID_PROVIDER)
 
     fun checkJdkVendor(providers: ProviderFactory): Provider<Boolean> =
-        providers.valueOrNull(CHECK_JDK_VENDOR).toBooleanProvider(true)
+        providers.gradleProperty(CHECK_JDK_VENDOR).toBooleanProvider(true)
 
     fun disableMultimoduleResources(providers: ProviderFactory): Provider<Boolean> =
-        providers.valueOrNull(DISABLE_MULTIMODULE_RESOURCES).toBooleanProvider(false)
+        providers.gradleProperty(DISABLE_MULTIMODULE_RESOURCES).toBooleanProvider(false)
 
     fun disableHotReload(providers: ProviderFactory): Provider<Boolean> =
-        providers.valueOrNull(DISABLE_HOT_RELOAD).toBooleanProvider(false)
+        providers.gradleProperty(DISABLE_HOT_RELOAD).toBooleanProvider(false)
 
     fun disableResourceContentHashGeneration(providers: ProviderFactory): Provider<Boolean> =
-        providers.valueOrNull(DISABLE_RESOURCE_CONTENT_HASH_GENERATION).toBooleanProvider(false)
+        providers.gradleProperty(DISABLE_RESOURCE_CONTENT_HASH_GENERATION).toBooleanProvider(false)
 
     fun disableLibraryCompatibilityCheck(providers: ProviderFactory): Provider<Boolean> =
-        providers.valueOrNull(DISABLE_LIBRARY_COMPATIBILITY_CHECK).toBooleanProvider(false)
+        providers.gradleProperty(DISABLE_LIBRARY_COMPATIBILITY_CHECK).toBooleanProvider(false)
 
-    //providers.valueOrNull works only with root gradle.properties
+    //providers.gradleProperty works only with root gradle.properties
     fun dontSyncResources(project: Project): Provider<Boolean> =
         project.findLocalOrGlobalProperty(SYNC_RESOURCES_PROPERTY).map { it == "false" }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/JvmApplicationContext.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/JvmApplicationContext.kt
@@ -52,6 +52,10 @@ internal data class JvmApplicationContext(
     inline fun <reified T> provider(noinline fn: () -> T): Provider<T> =
         project.provider(fn)
 
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T : Any> nullableProvider(noinline fn: () -> T?): Provider<T> =
+        project.provider(fn) as Provider<T>
+
     fun configureDefaultApp() {
         if (project.plugins.hasPlugin(KOTLIN_MPP_PLUGIN_ID)) {
             var isJvmTargetConfigured = false

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/cliArgUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/cliArgUtils.kt
@@ -10,7 +10,7 @@ import org.gradle.api.provider.Provider
 import org.jetbrains.compose.desktop.application.internal.files.normalizedPath
 import java.io.File
 
-internal fun <T : Any?> MutableCollection<String>.cliArg(
+internal fun <T : Any> MutableCollection<String>.cliArg(
     name: String,
     value: T?,
     fn: (T) -> String = defaultToString()
@@ -23,7 +23,7 @@ internal fun <T : Any?> MutableCollection<String>.cliArg(
     }
 }
 
-internal fun <T : Any?> MutableCollection<String>.cliArg(
+internal fun <T : Any> MutableCollection<String>.cliArg(
     name: String,
     value: Provider<T>,
     fn: (T) -> String = defaultToString()
@@ -35,7 +35,7 @@ internal fun MutableCollection<String>.javaOption(value: String) {
     cliArg("--java-options", "'$value'")
 }
 
-private fun <T : Any?> defaultToString(): (T) -> String =
+private fun <T : Any> defaultToString(): (T) -> String =
     {
         val asString = when (it) {
             is FileSystemLocation -> it.asFile.normalizedPath()

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -313,9 +313,9 @@ private fun JvmApplicationContext.configurePackageTask(
 
     app.nativeDistributions.let { executables ->
         packageTask.packageName.set(packageNameProvider)
-        packageTask.packageDescription.set(packageTask.provider { executables.description })
-        packageTask.packageCopyright.set(packageTask.provider { executables.copyright })
-        packageTask.packageVendor.set(packageTask.provider { executables.vendor })
+        packageTask.packageDescription.set(nullableProvider { executables.description })
+        packageTask.packageCopyright.set(nullableProvider { executables.copyright })
+        packageTask.packageVendor.set(nullableProvider { executables.vendor })
         packageTask.packageVersion.set(packageVersionFor(packageTask.targetFormat))
         packageTask.licenseFile.set(executables.licenseFile)
     }
@@ -338,7 +338,7 @@ private fun JvmApplicationContext.configurePackageTask(
         }
     }
 
-    packageTask.launcherMainClass.set(provider { app.mainClass })
+    packageTask.launcherMainClass.set(nullableProvider { app.mainClass })
     packageTask.launcherJvmArgs.set(provider { defaultJvmArgs + app.jvmArgs })
     packageTask.launcherArgs.set(provider { app.args })
 }
@@ -349,7 +349,7 @@ internal fun JvmApplicationContext.configureCommonNotarizationSettings(
     notarizationTask.nonValidatedNotarizationSettings = app.nativeDistributions.macOS.notarization
 }
 
-private fun <T> TaskProvider<AbstractUnpackDefaultComposeApplicationResourcesTask>.get(
+private fun <T : Any> TaskProvider<AbstractUnpackDefaultComposeApplicationResourcesTask>.get(
     fn: AbstractUnpackDefaultComposeApplicationResourcesTask.DefaultResourcesProvider.() -> Provider<T>
 ) = flatMap { fn(it.resources) }
 
@@ -363,12 +363,12 @@ internal fun JvmApplicationContext.configurePlatformSettings(
         OS.Linux -> {
             app.nativeDistributions.linux.also { linux ->
                 packageTask.linuxShortcut.set(provider { linux.shortcut })
-                packageTask.linuxAppCategory.set(provider { linux.appCategory })
-                packageTask.linuxAppRelease.set(provider { linux.appRelease })
-                packageTask.linuxDebMaintainer.set(provider { linux.debMaintainer })
-                packageTask.linuxMenuGroup.set(provider { linux.menuGroup })
-                packageTask.linuxPackageName.set(provider { linux.packageName })
-                packageTask.linuxRpmLicenseType.set(provider { linux.rpmLicenseType })
+                packageTask.linuxAppCategory.set(nullableProvider { linux.appCategory })
+                packageTask.linuxAppRelease.set(nullableProvider { linux.appRelease })
+                packageTask.linuxDebMaintainer.set(nullableProvider { linux.debMaintainer })
+                packageTask.linuxMenuGroup.set(nullableProvider { linux.menuGroup })
+                packageTask.linuxPackageName.set(nullableProvider { linux.packageName })
+                packageTask.linuxRpmLicenseType.set(nullableProvider { linux.rpmLicenseType })
                 packageTask.iconFile.set(linux.iconFile.orElse(defaultResources.get { linuxIcon }))
                 packageTask.installationPath.set(linux.installationPath)
                 packageTask.fileAssociations.set(provider { linux.fileAssociations })
@@ -381,8 +381,8 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.winPerUserInstall.set(provider { win.perUserInstall })
                 packageTask.winShortcut.set(provider { win.shortcut })
                 packageTask.winMenu.set(provider { win.menu })
-                packageTask.winMenuGroup.set(provider { win.menuGroup })
-                packageTask.winUpgradeUuid.set(provider { win.upgradeUuid })
+                packageTask.winMenuGroup.set(nullableProvider { win.menuGroup })
+                packageTask.winUpgradeUuid.set(nullableProvider { win.upgradeUuid })
                 packageTask.iconFile.set(win.iconFile.orElse(defaultResources.get { windowsIcon }))
                 packageTask.installationPath.set(win.installationPath)
                 packageTask.fileAssociations.set(provider { win.fileAssociations })
@@ -390,13 +390,13 @@ internal fun JvmApplicationContext.configurePlatformSettings(
         }
         OS.MacOS -> {
             app.nativeDistributions.macOS.also { mac ->
-                packageTask.macPackageName.set(provider { mac.packageName })
+                packageTask.macPackageName.set(nullableProvider { mac.packageName })
                 packageTask.macDockName.set(
                     if (mac.setDockNameSameAsPackageName)
-                        provider { mac.dockName }
+                        nullableProvider { mac.dockName }
                             .orElse(packageTask.macPackageName).orElse(packageTask.packageName)
                     else
-                        provider { mac.dockName }
+                        nullableProvider { mac.dockName }
                 )
                 packageTask.macAppStore.set(mac.appStore)
                 packageTask.macAppCategory.set(mac.appCategory)
@@ -405,10 +405,10 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.macEntitlementsFile.set(mac.entitlementsFile.orElse(defaultEntitlements))
                 packageTask.macRuntimeEntitlementsFile.set(mac.runtimeEntitlementsFile.orElse(defaultEntitlements))
                 packageTask.packageBuildVersion.set(packageBuildVersionFor(packageTask.targetFormat))
-                packageTask.nonValidatedMacBundleID.set(provider { mac.bundleID })
+                packageTask.nonValidatedMacBundleID.set(nullableProvider { mac.bundleID })
                 packageTask.macProvisioningProfile.set(mac.provisioningProfile)
                 packageTask.macRuntimeProvisioningProfile.set(mac.runtimeProvisioningProfile)
-                packageTask.macExtraPlistKeysRawXml.set(provider { mac.infoPlistSettings.extraKeysRawXml })
+                packageTask.macExtraPlistKeysRawXml.set(nullableProvider { mac.infoPlistSettings.extraKeysRawXml })
                 packageTask.nonValidatedMacSigningSettings = app.nativeDistributions.macOS.signing
                 packageTask.iconFile.set(mac.iconFile.orElse(defaultResources.get { macIcon }))
                 packageTask.installationPath.set(mac.installationPath)
@@ -425,7 +425,7 @@ private fun JvmApplicationContext.configureRunTask(
 ) {
     exec.dependsOn(prepareAppResources)
 
-    exec.mainClass.set(exec.provider { app.mainClass })
+    exec.mainClass.set(nullableProvider { app.mainClass })
     exec.executable(javaExecutable(app.javaHome))
     exec.jvmArgs = arrayListOf<String>().apply {
         addAll(defaultJvmArgs)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/packageVersions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/packageVersions.kt
@@ -12,7 +12,7 @@ import org.jetbrains.compose.internal.utils.OS
 
 internal fun JvmApplicationContext.packageVersionFor(
     targetFormat: TargetFormat
-): Provider<String?> =
+): Provider<String> =
     project.provider {
         app.nativeDistributions.packageVersionFor(targetFormat)
             ?: project.version.toString().takeIf { it != "unspecified" }
@@ -43,7 +43,7 @@ private fun JvmApplicationDistributions.packageVersionFor(
 
 internal fun JvmApplicationContext.packageBuildVersionFor(
     targetFormat: TargetFormat
-): Provider<String?> =
+): Provider<String> =
     project.provider {
         app.nativeDistributions.packageBuildVersionFor(targetFormat)
             // fallback to normal version

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
@@ -33,9 +33,9 @@ internal data class ValidatedMacOSSigningSettings(
 }
 
 internal fun MacOSSigningSettings.validate(
-    bundleIDProvider: Provider<String?>,
+    bundleIDProvider: Provider<String>,
     project: Project,
-    appStoreProvider: Provider<Boolean?>
+    appStoreProvider: Provider<Boolean>
 ): ValidatedMacOSSigningSettings {
     check(currentOS == OS.MacOS) { ERR_WRONG_OS }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/validateBundleID.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/validateBundleID.kt
@@ -7,7 +7,7 @@ package org.jetbrains.compose.desktop.application.internal.validation
 
 import org.gradle.api.provider.Provider
 
-internal fun validateBundleID(bundleIDProvider: Provider<String?>): String {
+internal fun validateBundleID(bundleIDProvider: Provider<String>): String {
     val bundleID = bundleIDProvider.orNull
     check(!bundleID.isNullOrEmpty()) { ERR_BUNDLE_ID_IS_EMPTY }
     check(bundleID.matches("[A-Za-z0-9\\-\\.]+".toRegex())) { ERR_BUNDLE_ID_WRONG_FORMAT }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractCheckNativeDistributionRuntime.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractCheckNativeDistributionRuntime.kt
@@ -19,7 +19,7 @@ import org.jetbrains.compose.internal.utils.OS
 import org.jetbrains.compose.internal.utils.currentOS
 import org.jetbrains.compose.internal.utils.executableName
 import org.jetbrains.compose.internal.utils.ioFile
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.*
@@ -34,7 +34,7 @@ abstract class AbstractCheckNativeDistributionRuntime : AbstractComposeDesktopTa
 
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:InputDirectory
-    val jdkHome: Property<String> = objects.notNullProperty()
+    val jdkHome: Property<String> = objects.property()
 
     @get:Input
     abstract val checkJdkVendor: Property<Boolean>

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
@@ -18,7 +18,7 @@ import org.jetbrains.compose.desktop.application.internal.RuntimeCompressionLeve
 import org.jetbrains.compose.desktop.application.internal.JvmRuntimeProperties
 import org.jetbrains.compose.desktop.application.internal.cliArg
 import org.jetbrains.compose.internal.utils.ioFile
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import java.io.File
 
 // todo: public DSL
@@ -29,27 +29,27 @@ abstract class AbstractJLinkTask : AbstractJvmToolOperationTask("jlink") {
     val modules: ListProperty<String> = objects.listProperty(String::class.java)
 
     @get:Input
-    val includeAllModules: Property<Boolean> = objects.notNullProperty()
+    val includeAllModules: Property<Boolean> = objects.property()
 
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NONE)
     val javaRuntimePropertiesFile: RegularFileProperty = objects.fileProperty()
 
     @get:Input
-    internal val stripDebug: Property<Boolean> = objects.notNullProperty(true)
+    internal val stripDebug: Property<Boolean> = objects.property(true)
 
     @get:Input
-    internal val noHeaderFiles: Property<Boolean> = objects.notNullProperty(true)
+    internal val noHeaderFiles: Property<Boolean> = objects.property(true)
 
     @get:Input
-    internal val noManPages: Property<Boolean> = objects.notNullProperty(true)
+    internal val noManPages: Property<Boolean> = objects.property(true)
 
     @get:Input
-    internal val stripNativeCommands: Property<Boolean> = objects.notNullProperty(true)
+    internal val stripNativeCommands: Property<Boolean> = objects.property(true)
 
     @get:Input
     @get:Optional
-    internal val compressionLevel: Property<RuntimeCompressionLevel> = objects.notNullProperty()
+    internal val compressionLevel: Property<RuntimeCompressionLevel> = objects.property()
 
     override fun makeArgs(tmpDir: File): MutableList<String> = super.makeArgs(tmpDir).apply {
         val modulesToInclude =

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
@@ -36,16 +36,16 @@ abstract class AbstractJLinkTask : AbstractJvmToolOperationTask("jlink") {
     val javaRuntimePropertiesFile: RegularFileProperty = objects.fileProperty()
 
     @get:Input
-    internal val stripDebug: Property<Boolean> = objects.property(true)
+    internal val stripDebug: Property<Boolean> = objects.property<Boolean>().value(true)
 
     @get:Input
-    internal val noHeaderFiles: Property<Boolean> = objects.property(true)
+    internal val noHeaderFiles: Property<Boolean> = objects.property<Boolean>().value(true)
 
     @get:Input
-    internal val noManPages: Property<Boolean> = objects.property(true)
+    internal val noManPages: Property<Boolean> = objects.property<Boolean>().value(true)
 
     @get:Input
-    internal val stripNativeCommands: Property<Boolean> = objects.property(true)
+    internal val stripNativeCommands: Property<Boolean> = objects.property<Boolean>().value(true)
 
     @get:Input
     @get:Optional

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
@@ -19,7 +19,6 @@ import org.jetbrains.compose.desktop.application.internal.JvmRuntimeProperties
 import org.jetbrains.compose.desktop.application.internal.cliArg
 import org.jetbrains.compose.internal.utils.ioFile
 import org.jetbrains.compose.internal.utils.notNullProperty
-import org.jetbrains.compose.internal.utils.nullableProperty
 import java.io.File
 
 // todo: public DSL
@@ -50,7 +49,7 @@ abstract class AbstractJLinkTask : AbstractJvmToolOperationTask("jlink") {
 
     @get:Input
     @get:Optional
-    internal val compressionLevel: Property<RuntimeCompressionLevel?> = objects.nullableProperty()
+    internal val compressionLevel: Property<RuntimeCompressionLevel> = objects.notNullProperty()
 
     override fun makeArgs(tmpDir: File): MutableList<String> = super.makeArgs(tmpDir).apply {
         val modulesToInclude =

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -67,7 +67,7 @@ import org.jetbrains.compose.internal.utils.delete
 import org.jetbrains.compose.internal.utils.ioFile
 import org.jetbrains.compose.internal.utils.ioFileOrNull
 import org.jetbrains.compose.internal.utils.mkdirs
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import org.jetbrains.compose.internal.utils.stacktraceToString
 import org.jetbrains.kotlin.gradle.internal.ensureParentDirsCreated
 import java.io.File
@@ -113,13 +113,13 @@ abstract class AbstractJPackageTask @Inject constructor(
      *  need to mangle twice.
      */
     @get:Input
-    val mangleJarFilesNames: Property<Boolean> = objects.notNullProperty(true)
+    val mangleJarFilesNames: Property<Boolean> = objects.property(true)
 
     /**
      * Indicates that task will get the uber JAR as input.
      */
     @get:Input
-    val packageFromUberJar: Property<Boolean> = objects.notNullProperty(false)
+    val packageFromUberJar: Property<Boolean> = objects.property(false)
 
     @get:InputDirectory
     @get:Optional
@@ -129,7 +129,7 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    val installationPath: Property<String> = objects.notNullProperty()
+    val installationPath: Property<String> = objects.property()
 
     @get:InputFile
     @get:Optional
@@ -142,7 +142,7 @@ abstract class AbstractJPackageTask @Inject constructor(
     val iconFile: RegularFileProperty = objects.fileProperty()
 
     @get:Input
-    val launcherMainClass: Property<String> = objects.notNullProperty()
+    val launcherMainClass: Property<String> = objects.property()
 
     @get:InputFile
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
@@ -157,71 +157,71 @@ abstract class AbstractJPackageTask @Inject constructor(
     val launcherJvmArgs: ListProperty<String> = objects.listProperty(String::class.java)
 
     @get:Input
-    val packageName: Property<String> = objects.notNullProperty()
+    val packageName: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val packageDescription: Property<String> = objects.notNullProperty()
+    val packageDescription: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val packageCopyright: Property<String> = objects.notNullProperty()
+    val packageCopyright: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val packageVendor: Property<String> = objects.notNullProperty()
+    val packageVendor: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val packageVersion: Property<String> = objects.notNullProperty()
+    val packageVersion: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val linuxShortcut: Property<Boolean> = objects.notNullProperty()
+    val linuxShortcut: Property<Boolean> = objects.property()
 
     @get:Input
     @get:Optional
-    val linuxPackageName: Property<String> = objects.notNullProperty()
+    val linuxPackageName: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val linuxAppRelease: Property<String> = objects.notNullProperty()
+    val linuxAppRelease: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val linuxAppCategory: Property<String> = objects.notNullProperty()
+    val linuxAppCategory: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val linuxDebMaintainer: Property<String> = objects.notNullProperty()
+    val linuxDebMaintainer: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val linuxMenuGroup: Property<String> = objects.notNullProperty()
+    val linuxMenuGroup: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val linuxRpmLicenseType: Property<String> = objects.notNullProperty()
+    val linuxRpmLicenseType: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val macPackageName: Property<String> = objects.notNullProperty()
+    val macPackageName: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val macDockName: Property<String> = objects.notNullProperty()
+    val macDockName: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val macAppStore: Property<Boolean> = objects.notNullProperty()
+    val macAppStore: Property<Boolean> = objects.property()
 
     @get:Input
     @get:Optional
-    val macAppCategory: Property<String> = objects.notNullProperty()
+    val macAppCategory: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val macMinimumSystemVersion: Property<String> = objects.notNullProperty()
+    val macMinimumSystemVersion: Property<String> = objects.property()
 
     @get:InputFile
     @get:Optional
@@ -235,7 +235,7 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    val packageBuildVersion: Property<String> = objects.notNullProperty()
+    val packageBuildVersion: Property<String> = objects.property()
 
     @get:InputFile
     @get:Optional
@@ -249,31 +249,31 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    val winConsole: Property<Boolean> = objects.notNullProperty()
+    val winConsole: Property<Boolean> = objects.property()
 
     @get:Input
     @get:Optional
-    val winDirChooser: Property<Boolean> = objects.notNullProperty()
+    val winDirChooser: Property<Boolean> = objects.property()
 
     @get:Input
     @get:Optional
-    val winPerUserInstall: Property<Boolean> = objects.notNullProperty()
+    val winPerUserInstall: Property<Boolean> = objects.property()
 
     @get:Input
     @get:Optional
-    val winShortcut: Property<Boolean> = objects.notNullProperty()
+    val winShortcut: Property<Boolean> = objects.property()
 
     @get:Input
     @get:Optional
-    val winMenu: Property<Boolean> = objects.notNullProperty()
+    val winMenu: Property<Boolean> = objects.property()
 
     @get:Input
     @get:Optional
-    val winMenuGroup: Property<String> = objects.notNullProperty()
+    val winMenuGroup: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val winUpgradeUuid: Property<String> = objects.notNullProperty()
+    val winUpgradeUuid: Property<String> = objects.property()
 
     @get:InputDirectory
     @get:Optional
@@ -287,11 +287,11 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    internal val nonValidatedMacBundleID: Property<String> = objects.notNullProperty()
+    internal val nonValidatedMacBundleID: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    internal val macExtraPlistKeysRawXml: Property<String> = objects.notNullProperty()
+    internal val macExtraPlistKeysRawXml: Property<String> = objects.property()
 
     @get:InputFile
     @get:Optional

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -68,7 +68,6 @@ import org.jetbrains.compose.internal.utils.ioFile
 import org.jetbrains.compose.internal.utils.ioFileOrNull
 import org.jetbrains.compose.internal.utils.mkdirs
 import org.jetbrains.compose.internal.utils.notNullProperty
-import org.jetbrains.compose.internal.utils.nullableProperty
 import org.jetbrains.compose.internal.utils.stacktraceToString
 import org.jetbrains.kotlin.gradle.internal.ensureParentDirsCreated
 import java.io.File
@@ -130,7 +129,7 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    val installationPath: Property<String?> = objects.nullableProperty()
+    val installationPath: Property<String> = objects.notNullProperty()
 
     @get:InputFile
     @get:Optional
@@ -162,67 +161,67 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    val packageDescription: Property<String?> = objects.nullableProperty()
+    val packageDescription: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val packageCopyright: Property<String?> = objects.nullableProperty()
+    val packageCopyright: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val packageVendor: Property<String?> = objects.nullableProperty()
+    val packageVendor: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val packageVersion: Property<String?> = objects.nullableProperty()
+    val packageVersion: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val linuxShortcut: Property<Boolean?> = objects.nullableProperty()
+    val linuxShortcut: Property<Boolean> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val linuxPackageName: Property<String?> = objects.nullableProperty()
+    val linuxPackageName: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val linuxAppRelease: Property<String?> = objects.nullableProperty()
+    val linuxAppRelease: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val linuxAppCategory: Property<String?> = objects.nullableProperty()
+    val linuxAppCategory: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val linuxDebMaintainer: Property<String?> = objects.nullableProperty()
+    val linuxDebMaintainer: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val linuxMenuGroup: Property<String?> = objects.nullableProperty()
+    val linuxMenuGroup: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val linuxRpmLicenseType: Property<String?> = objects.nullableProperty()
+    val linuxRpmLicenseType: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val macPackageName: Property<String?> = objects.nullableProperty()
+    val macPackageName: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val macDockName: Property<String?> = objects.nullableProperty()
+    val macDockName: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val macAppStore: Property<Boolean?> = objects.nullableProperty()
+    val macAppStore: Property<Boolean> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val macAppCategory: Property<String?> = objects.nullableProperty()
+    val macAppCategory: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val macMinimumSystemVersion: Property<String?> = objects.nullableProperty()
+    val macMinimumSystemVersion: Property<String> = objects.notNullProperty()
 
     @get:InputFile
     @get:Optional
@@ -236,7 +235,7 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    val packageBuildVersion: Property<String?> = objects.nullableProperty()
+    val packageBuildVersion: Property<String> = objects.notNullProperty()
 
     @get:InputFile
     @get:Optional
@@ -250,31 +249,31 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    val winConsole: Property<Boolean?> = objects.nullableProperty()
+    val winConsole: Property<Boolean> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val winDirChooser: Property<Boolean?> = objects.nullableProperty()
+    val winDirChooser: Property<Boolean> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val winPerUserInstall: Property<Boolean?> = objects.nullableProperty()
+    val winPerUserInstall: Property<Boolean> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val winShortcut: Property<Boolean?> = objects.nullableProperty()
+    val winShortcut: Property<Boolean> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val winMenu: Property<Boolean?> = objects.nullableProperty()
+    val winMenu: Property<Boolean> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val winMenuGroup: Property<String?> = objects.nullableProperty()
+    val winMenuGroup: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val winUpgradeUuid: Property<String?> = objects.nullableProperty()
+    val winUpgradeUuid: Property<String> = objects.notNullProperty()
 
     @get:InputDirectory
     @get:Optional
@@ -288,11 +287,11 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
-    internal val nonValidatedMacBundleID: Property<String?> = objects.nullableProperty()
+    internal val nonValidatedMacBundleID: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    internal val macExtraPlistKeysRawXml: Property<String?> = objects.nullableProperty()
+    internal val macExtraPlistKeysRawXml: Property<String> = objects.notNullProperty()
 
     @get:InputFile
     @get:Optional

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -113,13 +113,13 @@ abstract class AbstractJPackageTask @Inject constructor(
      *  need to mangle twice.
      */
     @get:Input
-    val mangleJarFilesNames: Property<Boolean> = objects.property(true)
+    val mangleJarFilesNames: Property<Boolean> = objects.property<Boolean>().value(true)
 
     /**
      * Indicates that task will get the uber JAR as input.
      */
     @get:Input
-    val packageFromUberJar: Property<Boolean> = objects.property(false)
+    val packageFromUberJar: Property<Boolean> = objects.property<Boolean>().value(false)
 
     @get:InputDirectory
     @get:Optional

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJvmToolOperationTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJvmToolOperationTask.kt
@@ -32,7 +32,7 @@ abstract class AbstractJvmToolOperationTask(private val toolName: String) : Abst
     val freeArgs: ListProperty<String> = objects.listProperty(String::class.java)
 
     @get:Internal
-    val javaHome: Property<String> = objects.notNullProperty<String>().apply {
+    val javaHome: Property<String> = objects.property<String>().apply {
         set(providers.systemProperty("java.home"))
     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
@@ -15,7 +15,6 @@ import org.jetbrains.compose.desktop.application.internal.InfoPlistBuilder
 import org.jetbrains.compose.desktop.application.internal.PlistKeys
 import org.jetbrains.compose.internal.utils.ioFile
 import org.jetbrains.compose.internal.utils.notNullProperty
-import org.jetbrains.compose.internal.utils.nullableProperty
 import java.io.File
 
 private const val KOTLIN_NATIVE_MIN_SUPPORTED_MAC_OS = "10.13"
@@ -36,15 +35,15 @@ abstract class AbstractNativeMacApplicationPackageAppDirTask : AbstractNativeMac
 
     @get:Input
     @get:Optional
-    val appCategory: Property<String?> = objects.nullableProperty()
+    val appCategory: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val copyright: Property<String?> = objects.nullableProperty()
+    val copyright: Property<String> = objects.notNullProperty()
 
     @get:Input
     @get:Optional
-    val minimumSystemVersion: Property<String?> = objects.nullableProperty()
+    val minimumSystemVersion: Property<String> = objects.notNullProperty()
 
     @get:InputFiles
     @get:Optional

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
@@ -14,7 +14,7 @@ import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.compose.desktop.application.internal.InfoPlistBuilder
 import org.jetbrains.compose.desktop.application.internal.PlistKeys
 import org.jetbrains.compose.internal.utils.ioFile
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import java.io.File
 
 private const val KOTLIN_NATIVE_MIN_SUPPORTED_MAC_OS = "10.13"
@@ -31,19 +31,19 @@ abstract class AbstractNativeMacApplicationPackageAppDirTask : AbstractNativeMac
     val iconFile: RegularFileProperty = objects.fileProperty()
 
     @get:Input
-    val bundleID: Property<String> = objects.notNullProperty<String>().value(packageName)
+    val bundleID: Property<String> = objects.property<String>().value(packageName)
 
     @get:Input
     @get:Optional
-    val appCategory: Property<String> = objects.notNullProperty()
+    val appCategory: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val copyright: Property<String> = objects.notNullProperty()
+    val copyright: Property<String> = objects.property()
 
     @get:Input
     @get:Optional
-    val minimumSystemVersion: Property<String> = objects.notNullProperty()
+    val minimumSystemVersion: Property<String> = objects.property()
 
     @get:InputFiles
     @get:Optional

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageDmgTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageDmgTask.kt
@@ -25,7 +25,7 @@ abstract class AbstractNativeMacApplicationPackageDmgTask : AbstractNativeMacApp
     val osascript: RegularFileProperty = objects.fileProperty().value { File("/usr/bin/osascript") }
 
     @get:Input
-    val installDir: Property<String> = objects.property("/Applications")
+    val installDir: Property<String> = objects.property<String>().value("/Applications")
 
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageDmgTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageDmgTask.kt
@@ -11,7 +11,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.compose.internal.utils.ioFile
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import java.io.File
 
 @DisableCachingByDefault(because = "Uses platform-specific native tools whose output depends on local system")
@@ -25,7 +25,7 @@ abstract class AbstractNativeMacApplicationPackageDmgTask : AbstractNativeMacApp
     val osascript: RegularFileProperty = objects.fileProperty().value { File("/usr/bin/osascript") }
 
     @get:Input
-    val installDir: Property<String> = objects.notNullProperty("/Applications")
+    val installDir: Property<String> = objects.property("/Applications")
 
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageTask.kt
@@ -18,10 +18,10 @@ import java.io.File
 @DisableCachingByDefault(because = "Uses platform-specific native tools whose output depends on local system")
 abstract class AbstractNativeMacApplicationPackageTask : AbstractComposeDesktopTask() {
     @get:Input
-    val packageName: Property<String> = objects.notNullProperty()
+    val packageName: Property<String> = objects.property()
 
     @get:Input
-    val packageVersion: Property<String> = objects.notNullProperty("1.0.0")
+    val packageVersion: Property<String> = objects.property("1.0.0")
 
     @get:Internal
     internal val fullPackageName: Provider<String> =

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractNativeMacApplicationPackageTask.kt
@@ -21,7 +21,7 @@ abstract class AbstractNativeMacApplicationPackageTask : AbstractComposeDesktopT
     val packageName: Property<String> = objects.property()
 
     @get:Input
-    val packageVersion: Property<String> = objects.property("1.0.0")
+    val packageVersion: Property<String> = objects.property<String>().value("1.0.0")
 
     @get:Internal
     internal val fullPackageName: Provider<String> =

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractProguardTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractProguardTask.kt
@@ -41,15 +41,15 @@ abstract class AbstractProguardTask : AbstractComposeDesktopTask() {
 
     @get:Optional
     @get:Input
-    val dontobfuscate: Property<Boolean?> = objects.nullableProperty()
+    val dontobfuscate: Property<Boolean> = objects.notNullProperty()
 
     @get:Optional
     @get:Input
-    val dontoptimize: Property<Boolean?> = objects.nullableProperty()
+    val dontoptimize: Property<Boolean> = objects.notNullProperty()
 
     @get:Optional
     @get:Input
-    val joinOutputJars: Property<Boolean?> = objects.nullableProperty()
+    val joinOutputJars: Property<Boolean> = objects.notNullProperty()
 
     // todo: DSL for excluding default rules
     // also consider pulling coroutines rules from coroutines artifact
@@ -73,7 +73,7 @@ abstract class AbstractProguardTask : AbstractComposeDesktopTask() {
     val mainClass: Property<String> = objects.notNullProperty()
 
     @get:Internal
-    val maxHeapSize: Property<String?> = objects.nullableProperty()
+    val maxHeapSize: Property<String> = objects.notNullProperty()
 
     @get:OutputDirectory
     val destinationDir: DirectoryProperty = objects.directoryProperty()

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractProguardTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractProguardTask.kt
@@ -67,7 +67,7 @@ abstract class AbstractProguardTask : AbstractComposeDesktopTask() {
     val proguardFiles: ConfigurableFileCollection = objects.fileCollection()
 
     @get:Input
-    val javaHome: Property<String> = objects.property(System.getProperty("java.home"))
+    val javaHome: Property<String> = objects.property<String>().value(System.getProperty("java.home"))
 
     @get:Input
     val mainClass: Property<String> = objects.property()

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractProguardTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractProguardTask.kt
@@ -41,15 +41,15 @@ abstract class AbstractProguardTask : AbstractComposeDesktopTask() {
 
     @get:Optional
     @get:Input
-    val dontobfuscate: Property<Boolean> = objects.notNullProperty()
+    val dontobfuscate: Property<Boolean> = objects.property()
 
     @get:Optional
     @get:Input
-    val dontoptimize: Property<Boolean> = objects.notNullProperty()
+    val dontoptimize: Property<Boolean> = objects.property()
 
     @get:Optional
     @get:Input
-    val joinOutputJars: Property<Boolean> = objects.notNullProperty()
+    val joinOutputJars: Property<Boolean> = objects.property()
 
     // todo: DSL for excluding default rules
     // also consider pulling coroutines rules from coroutines artifact
@@ -60,20 +60,20 @@ abstract class AbstractProguardTask : AbstractComposeDesktopTask() {
     val defaultComposeRulesFile: RegularFileProperty = objects.fileProperty()
 
     @get:Input
-    val proguardVersion: Property<String> = objects.notNullProperty()
+    val proguardVersion: Property<String> = objects.property()
 
     @get:InputFiles
     @get:Classpath
     val proguardFiles: ConfigurableFileCollection = objects.fileCollection()
 
     @get:Input
-    val javaHome: Property<String> = objects.notNullProperty(System.getProperty("java.home"))
+    val javaHome: Property<String> = objects.property(System.getProperty("java.home"))
 
     @get:Input
-    val mainClass: Property<String> = objects.notNullProperty()
+    val mainClass: Property<String> = objects.property()
 
     @get:Internal
-    val maxHeapSize: Property<String> = objects.notNullProperty()
+    val maxHeapSize: Property<String> = objects.property()
 
     @get:OutputDirectory
     val destinationDir: DirectoryProperty = objects.directoryProperty()

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractSuggestModulesTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractSuggestModulesTask.kt
@@ -39,7 +39,7 @@ abstract class AbstractSuggestModulesTask : AbstractComposeDesktopTask() {
     val modules: ListProperty<String> = objects.listProperty(String::class.java)
 
     @get:Input
-    val jvmTarget: Property<String> = objects.property(MIN_JAVA_RUNTIME_VERSION.toString())
+    val jvmTarget: Property<String> = objects.property<String>().value(MIN_JAVA_RUNTIME_VERSION.toString())
 
     @get:LocalState
     protected val workingDir: Provider<Directory> = project.layout.buildDirectory.dir("compose/tmp/$name")

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractSuggestModulesTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractSuggestModulesTask.kt
@@ -23,7 +23,7 @@ import org.jetbrains.compose.internal.utils.*
 @DisableCachingByDefault(because = "Not worth caching — prints module suggestions to console")
 abstract class AbstractSuggestModulesTask : AbstractComposeDesktopTask() {
     @get:Input
-    val javaHome: Property<String> = objects.notNullProperty<String>().apply {
+    val javaHome: Property<String> = objects.property<String>().apply {
         set(providers.systemProperty("java.home"))
     }
 
@@ -39,7 +39,7 @@ abstract class AbstractSuggestModulesTask : AbstractComposeDesktopTask() {
     val modules: ListProperty<String> = objects.listProperty(String::class.java)
 
     @get:Input
-    val jvmTarget: Property<String> = objects.notNullProperty(MIN_JAVA_RUNTIME_VERSION.toString())
+    val jvmTarget: Property<String> = objects.property(MIN_JAVA_RUNTIME_VERSION.toString())
 
     @get:LocalState
     protected val workingDir: Provider<Directory> = project.layout.buildDirectory.dir("compose/tmp/$name")

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
@@ -12,7 +12,7 @@ import org.jetbrains.compose.desktop.ui.tooling.preview.rpc.*
 import org.jetbrains.compose.internal.utils.*
 import org.jetbrains.compose.internal.utils.currentTarget
 import org.jetbrains.compose.internal.utils.javaExecutable
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import java.io.File
 
 @DisableCachingByDefault(because = "Sends preview configuration to IDE — not a build artifact to cache")
@@ -26,7 +26,7 @@ abstract class AbstractConfigureDesktopPreviewTask : AbstractComposeDesktopTask(
     internal abstract val skikoRuntime: Property<FileCollection>
 
     @get:Internal
-    internal val javaHome: Property<String> = objects.notNullProperty<String>().apply {
+    internal val javaHome: Property<String> = objects.property<String>().apply {
         set(providers.systemProperty("java.home"))
     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractComposeDesktopTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/tasks/AbstractComposeDesktopTask.kt
@@ -19,7 +19,7 @@ import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.compose.desktop.application.internal.ComposeProperties
 import org.jetbrains.compose.desktop.application.internal.ExternalToolRunner
-import org.jetbrains.compose.internal.utils.notNullProperty
+import org.jetbrains.compose.internal.utils.property
 import javax.inject.Inject
 
 @DisableCachingByDefault(because = "Abstract base task — subclasses opt in to caching individually")
@@ -43,7 +43,7 @@ abstract class AbstractComposeDesktopTask : DefaultTask() {
     protected val logsDir: Provider<Directory> = project.layout.buildDirectory.dir("compose/logs/$name")
 
     @get:Internal
-    val verbose: Property<Boolean> = objects.notNullProperty<Boolean>().apply {
+    val verbose: Property<Boolean> = objects.property<Boolean>().apply {
         set(providers.provider {
             logger.isDebugEnabled || ComposeProperties.isVerbose(providers).get()
         })

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
@@ -18,9 +18,6 @@ internal inline fun <reified T : Any> ObjectFactory.new(vararg params: Any): T =
 internal inline fun <reified T : Any> ObjectFactory.property(): Property<T> =
     property(T::class.java)
 
-internal inline fun <reified T : Any> ObjectFactory.property(defaultValue: T): Property<T> =
-    property(T::class.java).value(defaultValue)
-
 internal inline fun <reified T : Any> Provider<T>.toProperty(objects: ObjectFactory): Property<T> =
     objects.property(T::class.java).value(this)
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
@@ -10,16 +10,15 @@ import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
 internal inline fun <reified T : Any> ObjectFactory.new(vararg params: Any): T =
     newInstance(T::class.java, *params)
 
-internal inline fun <reified T : Any> ObjectFactory.notNullProperty(): Property<T> =
+internal inline fun <reified T : Any> ObjectFactory.property(): Property<T> =
     property(T::class.java)
 
-internal inline fun <reified T : Any> ObjectFactory.notNullProperty(defaultValue: T): Property<T> =
+internal inline fun <reified T : Any> ObjectFactory.property(defaultValue: T): Property<T> =
     property(T::class.java).value(defaultValue)
 
 internal inline fun <reified T : Any> Provider<T>.toProperty(objects: ObjectFactory): Property<T> =
@@ -27,9 +26,6 @@ internal inline fun <reified T : Any> Provider<T>.toProperty(objects: ObjectFact
 
 internal inline fun <reified T : Any> Task.provider(noinline fn: () -> T): Provider<T> =
     project.provider(fn)
-
-internal fun ProviderFactory.valueOrNull(prop: String): Provider<String> =
-    gradleProperty(prop)
 
 internal fun Provider<String>.toBooleanProvider(defaultValue: Boolean): Provider<Boolean> =
     orElse(defaultValue.toString()).map { "true" == it }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/providerUtils.kt
@@ -13,12 +13,8 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
-internal inline fun <reified T> ObjectFactory.new(vararg params: Any): T =
+internal inline fun <reified T : Any> ObjectFactory.new(vararg params: Any): T =
     newInstance(T::class.java, *params)
-
-@SuppressWarnings("UNCHECKED_CAST")
-internal inline fun <reified T : Any> ObjectFactory.nullableProperty(): Property<T?> =
-    property(T::class.java) as Property<T?>
 
 internal inline fun <reified T : Any> ObjectFactory.notNullProperty(): Property<T> =
     property(T::class.java)
@@ -26,21 +22,19 @@ internal inline fun <reified T : Any> ObjectFactory.notNullProperty(): Property<
 internal inline fun <reified T : Any> ObjectFactory.notNullProperty(defaultValue: T): Property<T> =
     property(T::class.java).value(defaultValue)
 
-internal inline fun <reified T> Provider<T>.toProperty(objects: ObjectFactory): Property<T> =
+internal inline fun <reified T : Any> Provider<T>.toProperty(objects: ObjectFactory): Property<T> =
     objects.property(T::class.java).value(this)
 
-internal inline fun <reified T> Task.provider(noinline fn: () -> T): Provider<T> =
+internal inline fun <reified T : Any> Task.provider(noinline fn: () -> T): Provider<T> =
     project.provider(fn)
 
-internal fun ProviderFactory.valueOrNull(prop: String): Provider<String?> =
-    provider {
-        gradleProperty(prop).orNull
-    }
+internal fun ProviderFactory.valueOrNull(prop: String): Provider<String> =
+    gradleProperty(prop)
 
-internal fun Provider<String?>.toBooleanProvider(defaultValue: Boolean): Provider<Boolean> =
+internal fun Provider<String>.toBooleanProvider(defaultValue: Boolean): Provider<Boolean> =
     orElse(defaultValue.toString()).map { "true" == it }
 
 internal fun Project.findLocalOrGlobalProperty(name: String, default: String = ""): Provider<String> = provider {
-    if (extraProperties.has(name)) extraProperties.get(name).toString()
+    if (extraProperties.has(name)) extraProperties.get(name)?.toString() ?: default
     else providers.gradleProperty(name).getOrElse(default)
 }


### PR DESCRIPTION
Migrate from `nullableProperty` to `notNullProperty` for improved property handling. Remove deprecated `nullableProperty` utility.

Fixes https://youtrack.jetbrains.com/issue/CMP-10189

## Release Notes
N/A