### PR TITLE
Fix docker: Android SDK & Chrome installations

### DIFF
--- a/ci/docker/linux-tests/Dockerfile
+++ b/ci/docker/linux-tests/Dockerfile
@@ -62,13 +62,11 @@ RUN mkdir -p $CMD_TOOLS_ROOT && \
     unzip cmd-tools.zip && \
     rm cmd-tools.zip && \
     mv cmdline-tools/* $CMD_TOOLS_ROOT/
-ARG ANDROID_PLATFORM=android-37
-ARG ANDROID_PLATFORM_NAME=android-37.0
+ARG ANDROID_PLATFORM=android-37.0
 RUN yes | $SDK_MANAGER --licenses && \
-    $SDK_MANAGER --channel=1 "platforms;$ANDROID_PLATFORM_NAME" && \
-    cd $ANDROID_HOME/platforms/$ANDROID_PLATFORM_NAME && \
-    ls -1 | grep -v android.jar | xargs rm -rf && \
-    ln -s $ANDROID_HOME/platforms/$ANDROID_PLATFORM_NAME $ANDROID_HOME/platforms/$ANDROID_PLATFORM
+    $SDK_MANAGER --channel=1 "platforms;$ANDROID_PLATFORM" && \
+    cd $ANDROID_HOME/platforms/$ANDROID_PLATFORM && \
+    ls -1 | grep -v android.jar | xargs rm -rf
 
 # Install Google Chrome
 ARG CHROME_VERSION="148.0.7778.96-1"

--- a/ci/docker/linux-tests/Dockerfile
+++ b/ci/docker/linux-tests/Dockerfile
@@ -69,15 +69,16 @@ RUN yes | $SDK_MANAGER --licenses && \
     ls -1 | grep -v android.jar | xargs rm -rf
 
 # Install Google Chrome
-ARG CHROME_VERSION="148.0.7778.96-1"
+ARG CHROME_VERSION="148.0.7778.96"
 # https://googlechromelabs.github.io/chrome-for-testing/
 ARG CHROME_DRIVER_VERSION="148.0.7778.96"
 ARG CHROME_BIN=/usr/bin/google-chrome-stable
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A6DCF7707EBC211F && \
-    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
+RUN wget https://storage.googleapis.com/chrome-for-testing-public/$CHROME_VERSION/linux64/chrome-linux64.zip -P /tmp && \
+    unzip -q /tmp/chrome-linux64.zip -d /opt && \
+    rm /tmp/chrome-linux64.zip && \
     apt update -y && \
-    apt install -y google-chrome-stable=$CHROME_VERSION && \
+    while read pkg; do apt-get satisfy -y --no-install-recommends "${pkg}"; done < /opt/chrome-linux64/deb.deps && \
+    ln -sf /opt/chrome-linux64/chrome /usr/bin/google-chrome-stable && \
     wget https://storage.googleapis.com/chrome-for-testing-public/$CHROME_DRIVER_VERSION/linux64/chromedriver-linux64.zip -P ~/tmp && \
     mkdir -p /root/.gradle/selenium/chrome && unzip -d /root/.gradle/selenium/chrome ~/tmp/chromedriver-linux64.zip && rm ~/tmp/chromedriver-linux64.zip && \
     rm -rf /var/lib/apt/lists/*

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -17,7 +17,7 @@ compose.tests.kotlin.version=2.3.20
 # and Publish.Subtasks.buildTypes.gradle.GradlePluginTestKt#gradleVersions in the TC config
 # minimal and current gradle version
 compose.tests.gradle.versions=9.3.1, 9.5.0
-compose.tests.agp.versions=9.1.0, 9.2.0
+compose.tests.agp.versions=9.1.1, 9.2.0
 # gradle and agp versions should be compatible:
 # https://developer.android.com/build/releases/gradle-plugin#updating-plugin
 compose.tests.gradle-agp.exclude=9.3.1/9.2.0


### PR DESCRIPTION
Update AGP to 9.1.1 as it was the root cause of problems that required symlinks etc

## Release Notes
N/A