### PR TITLE
Benchmarks: use maven cache redirector

### DIFF
--- a/benchmarks/multiplatform/benchmarks/build.gradle.kts
+++ b/benchmarks/multiplatform/benchmarks/build.gradle.kts
@@ -15,7 +15,9 @@ version = "1.0-SNAPSHOT"
 repositories {
     mavenLocal()
     google()
-    mavenCentral()
+    mavenCentral {
+        url = uri("https://cache-redirector.jetbrains.com/maven-central")
+    }
     maven("https://packages.jetbrains.team/maven/p/cmp/dev")
 }
 

--- a/benchmarks/multiplatform/build.gradle.kts
+++ b/benchmarks/multiplatform/build.gradle.kts
@@ -10,7 +10,9 @@ plugins {
 allprojects {
     repositories {
         google()
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
         maven("https://packages.jetbrains.team/maven/p/cmp/dev")
         mavenLocal()
     }

--- a/benchmarks/multiplatform/settings.gradle.kts
+++ b/benchmarks/multiplatform/settings.gradle.kts
@@ -1,7 +1,9 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        mavenCentral()
+        mavenCentral {
+            url = uri("https://cache-redirector.jetbrains.com/maven-central")
+        }
         gradlePluginPortal()
         maven("https://packages.jetbrains.team/maven/p/cmp/dev")
         google()


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10196/Benchmarks-Gradle-build-failed-due-to-429-Too-Many-requests

## Release Notes
N/A