### PR TITLE
Add packagingResourcesRootDir to expose jpackage --resource-dir

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/AbstractDistributions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/AbstractDistributions.kt
@@ -30,6 +30,20 @@ abstract class AbstractDistributions {
     var description: String? = null
     var vendor: String? = null
     val appResourcesRootDir: DirectoryProperty = objects.directoryProperty()
+
+    /**
+     * Root directory for files passed to the underlying packaging tool (jpackage)
+     * via `--resource-dir`, used to override the tool's own packaging resources (e.g.
+     * a `<package-name>-volume.icns` DMG volume icon, a DMG background, Linux
+     * `preinst`/`postinst` scripts, or WiX templates). See
+     * https://docs.oracle.com/en/java/javase/21/jpackage/override-jpackage-resources.html
+     *
+     * Files are resolved from `common`, `<os>` and `<os>-<arch>` subdirectories, the
+     * same layout as [appResourcesRootDir]. The generated `Info.plist` and
+     * `product-def.plist` are managed by Compose and always take precedence.
+     */
+    val packagingResourcesRootDir: DirectoryProperty = objects.directoryProperty()
+
     val licenseFile: RegularFileProperty = objects.fileProperty()
 
     var targetFormats: Set<TargetFormat> = EnumSet.noneOf(TargetFormat::class.java)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -318,6 +318,7 @@ private fun JvmApplicationContext.configurePackageTask(
         packageTask.packageVendor.set(packageTask.provider { executables.vendor })
         packageTask.packageVersion.set(packageVersionFor(packageTask.targetFormat))
         packageTask.licenseFile.set(executables.licenseFile)
+        packageTask.packagingResourcesRootDir.set(executables.packagingResourcesRootDir)
     }
 
     packageTask.destinationDir.set(app.nativeDistributions.outputBaseDir.map {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -377,6 +377,11 @@ abstract class AbstractJPackageTask @Inject constructor(
     @get:Internal
     val appResourcesDir: DirectoryProperty = objects.directoryProperty()
 
+    @get:InputDirectory
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    val packagingResourcesRootDir: DirectoryProperty = objects.directoryProperty()
+
     @get:Internal
     private val libsMappingFile: Provider<RegularFile> = workingDir.map {
         it.file("libs-mapping.txt")
@@ -607,6 +612,7 @@ abstract class AbstractJPackageTask @Inject constructor(
         }
 
         fileOperations.clearDirs(jpackageResources)
+        copyUserPackagingResources()
         if (currentOS == OS.MacOS) {
             InfoPlistBuilder(macExtraPlistKeysRawXml.orNull)
                 .also { setInfoPlistValues(it) }
@@ -622,6 +628,33 @@ abstract class AbstractJPackageTask @Inject constructor(
                 """.trimIndent()
                 InfoPlistBuilder(productDefPlistXml)
                     .writeToFile(jpackageResources.ioFile.resolve("product-def.plist"))
+            }
+        }
+    }
+
+    /**
+     * Copies user-supplied packaging override resources into [jpackageResources]
+     * (the `--resource-dir` passed to jpackage). Files are taken from the `common`,
+     * `<os>` and `<os>-<arch>` subdirectories of [packagingResourcesRootDir], mirroring
+     * the layout of `appResourcesRootDir`. Called after [jpackageResources] is cleared
+     * but before the generated `Info.plist`/`product-def.plist` are written, so those
+     * Compose-managed files always win over anything the user drops in.
+     */
+    private fun copyUserPackagingResources() {
+        val rootDir = packagingResourcesRootDir.ioFileOrNull ?: return
+        val destDir = jpackageResources.ioFile
+        for (subDirName in listOf("common", currentOS.id, currentTarget.id)) {
+            val sourceDir = rootDir.resolve(subDirName)
+            if (!sourceDir.isDirectory) continue
+            for (file in sourceDir.walk()) {
+                val relPath = file.relativeTo(sourceDir).path
+                if (relPath.isEmpty()) continue
+                val destFile = destDir.resolve(relPath)
+                if (file.isDirectory) {
+                    fileOperations.mkdirs(destFile)
+                } else {
+                    file.copyTo(destFile, overwrite = true)
+                }
             }
         }
     }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -594,6 +594,19 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     }
 
     @Test
+    fun packagingResources() = with(testProject("application/packagingResources")) {
+        gradle(":createDistributable").checks {
+            check.taskSuccessful(":createDistributable")
+
+            // Files from packagingResourcesRootDir must be copied into the
+            // directory passed to jpackage via --resource-dir, for both the
+            // `common` and the current-OS subdirectories.
+            file("build/compose/tmp/resources/common-packaging-resource.txt").checkExists()
+            file("build/compose/tmp/resources/os-specific-packaging-resource.txt").checkExists()
+        }
+    }
+
+    @Test
     fun testWixUnzip() {
         Assumptions.assumeTrue(currentOS == OS.Windows) { "The test is only relevant for Windows" }
 

--- a/gradle-plugins/compose/src/test/test-projects/application/packagingResources/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/packagingResources/build.gradle
@@ -1,0 +1,24 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    id "org.jetbrains.kotlin.jvm"
+    id "org.jetbrains.kotlin.plugin.compose"
+    id "org.jetbrains.compose"
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    implementation compose.desktop.currentOs
+}
+
+compose.desktop {
+    application {
+        mainClass = "MainKt"
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageVersion = "1.0.0"
+
+            packagingResourcesRootDir.set(project.layout.projectDirectory.dir("packaging-resources"))
+        }
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/packagingResources/packaging-resources/common/common-packaging-resource.txt
+++ b/gradle-plugins/compose/src/test/test-projects/application/packagingResources/packaging-resources/common/common-packaging-resource.txt
@@ -1,0 +1,1 @@
+common packaging resource

--- a/gradle-plugins/compose/src/test/test-projects/application/packagingResources/packaging-resources/linux/os-specific-packaging-resource.txt
+++ b/gradle-plugins/compose/src/test/test-projects/application/packagingResources/packaging-resources/linux/os-specific-packaging-resource.txt
@@ -1,0 +1,1 @@
+linux only packaging resource

--- a/gradle-plugins/compose/src/test/test-projects/application/packagingResources/packaging-resources/macos/os-specific-packaging-resource.txt
+++ b/gradle-plugins/compose/src/test/test-projects/application/packagingResources/packaging-resources/macos/os-specific-packaging-resource.txt
@@ -1,0 +1,1 @@
+macos only packaging resource

--- a/gradle-plugins/compose/src/test/test-projects/application/packagingResources/packaging-resources/windows/os-specific-packaging-resource.txt
+++ b/gradle-plugins/compose/src/test/test-projects/application/packagingResources/packaging-resources/windows/os-specific-packaging-resource.txt
@@ -1,0 +1,1 @@
+windows only packaging resource

--- a/gradle-plugins/compose/src/test/test-projects/application/packagingResources/settings.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/packagingResources/settings.gradle
@@ -1,0 +1,27 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version 'KOTLIN_VERSION_PLACEHOLDER'
+        id 'org.jetbrains.kotlin.plugin.compose' version 'KOTLIN_VERSION_PLACEHOLDER'
+        id 'org.jetbrains.compose' version 'COMPOSE_GRADLE_PLUGIN_VERSION_PLACEHOLDER'
+    }
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+        maven {
+            url 'https://packages.jetbrains.team/maven/p/cmp/dev'
+        }
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        google()
+        maven {
+            url 'https://packages.jetbrains.team/maven/p/cmp/dev'
+        }
+        mavenLocal()
+    }
+}
+rootProject.name = "packagingResources"

--- a/gradle-plugins/compose/src/test/test-projects/application/packagingResources/src/main/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/packagingResources/src/main/kotlin/main.kt
@@ -1,0 +1,3 @@
+fun main() {
+    println("Hello, world!")
+}


### PR DESCRIPTION
jpackage's `--resource-dir` is the documented mechanism for overriding the packaging tool's own resources — the DMG volume icon (`<package-name>-volume.icns`), the DMG background, Linux `preinst`/`postinst` scripts, WiX templates, and so on (see the [jpackage docs](https://docs.oracle.com/en/java/javase/21/jpackage/override-jpackage-resources.html)).

Today Compose fully owns that directory and gives users no supported way to put files into it: `AbstractJPackageTask` points `--resource-dir` at `build/compose/tmp/resources`, and on every run it calls `clearDirs(...)` and then writes the generated `Info.plist` there. Because the clear happens inside the task action, dropping a file in via a `doFirst` is always wiped before jpackage runs. This blocks a recurring class of customizations.

This PR adds a `packagingResourcesRootDir` DSL property that mirrors the existing `appResourcesRootDir` (with `common`, `<os>` and `<os>-<arch>` subdirectories). Its files are copied into the resource dir **after** the dir is cleared but **before** the generated `Info.plist`/`product-def.plist` are written, so the Compose-managed plists always take precedence over user-supplied files.

```kotlin
compose.desktop {
    application {
        nativeDistributions {
            // drops e.g. packaging-resources/macos/MyApp-volume.icns into --resource-dir
            packagingResourcesRootDir.set(project.layout.projectDirectory.dir("packaging-resources"))
        }
    }
}
```

This revives the approach a maintainer suggested on #1843 (exposing the jpackage resource dir via the DSL rather than reusing `appResourcesDir`) and supersedes the abandoned #3647. Unlike #1843 — which repointed the internal `jpackageResources` dir at a `Sync` output and so had its files deleted by the task's own `clearDirs(...)` (the unresolved concern raised in that PR's review) — this copies the files in after the clear, so nothing is wiped.

Fixes [CMP-2042](https://youtrack.jetbrains.com/issue/CMP-2042) and [CMP-6122](https://youtrack.jetbrains.com/issue/CMP-6122) (both the DMG volume icon, set via `<package-name>-volume.icns`). Also helps [CMP-6411](https://youtrack.jetbrains.com/issue/CMP-6411), [CMP-1972](https://youtrack.jetbrains.com/issue/CMP-1972), and [CMP-9837](https://youtrack.jetbrains.com/issue/CMP-9837).

## Testing

Added an integration test (`DesktopApplicationTest.packagingResources`) with a new `application/packagingResources` test project. It runs `:createDistributable` and asserts that both the `common` file and the current-OS file are copied into `build/compose/tmp/resources` (the `--resource-dir` passed to jpackage). Verified locally on macOS:

```
DesktopApplicationTest > packagingResources(kotlin=2.3.20, gradle=9.3.1, agp=9.1.1) PASSED
```

`:compose:compileKotlin` and `:compose:compileTestKotlin` both build cleanly.

## Release Notes
### Features - Gradle Plugin
- Added `nativeDistributions.packagingResourcesRootDir` to supply custom files to the packaging tool's resource directory (jpackage's `--resource-dir`), allowing overrides such as the DMG volume icon, DMG background, Linux `preinst`/`postinst` scripts, and WiX templates.
