### PR TITLE
Bump CHR version to 1.2.0-alpha01

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v5
 
-      - name: Setup JDK 21
+      - name: Setup JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: 'jetbrains'
-          java-version: '21'
+          java-version: '25'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/ci/docker/linux-tests/Dockerfile
+++ b/ci/docker/linux-tests/Dockerfile
@@ -44,7 +44,7 @@ ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
 
 # Install JBR
-ARG JBR_DISTR=jbr_jcef-21.0.8-linux-x64-b1163.62
+ARG JBR_DISTR=jbr_jcef-25.0.3-linux-x64-b496.62
 ARG JBR_DISTR_ARCH=$JBR_DISTR.tar.gz
 RUN wget https://cache-redirector.jetbrains.com/intellij-jbr/$JBR_DISTR_ARCH && \
     tar xzf $JBR_DISTR_ARCH && \

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt
@@ -12,7 +12,7 @@ import org.jetbrains.compose.internal.utils.notNullProperty
 import org.jetbrains.compose.internal.utils.nullableProperty
 import javax.inject.Inject
 
-private const val DEFAULT_PROGUARD_VERSION = "7.7.0"
+private const val DEFAULT_PROGUARD_VERSION = "7.8.0"
 
 abstract class ProguardSettings @Inject constructor(
     objects: ObjectFactory,

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/HotReloadTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/HotReloadTest.kt
@@ -103,7 +103,7 @@ class HotReloadTest : GradlePluginTestBase() {
 
     @Test
     fun testExternalHotReload() = with(testProject("application/mpp")) {
-        val externalHotReloadVersion = "1.0.0-rc01"
+        val externalHotReloadVersion = "1.1.0"
         modifyText("settings.gradle") {
             //  Set the explicit version of Compose Hot Reload in the "pluginManagement {" block
             it.replace(

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/HotReloadTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/HotReloadTest.kt
@@ -124,6 +124,15 @@ class HotReloadTest : GradlePluginTestBase() {
                 """.trimIndent()
             )
         }
+        modifyText("build.gradle") {
+            //  Set JDK 25 toolchain as we use JBR 25 on CI
+            it.replace("jvm()",
+                """
+                    jvm()
+                    jvmToolchain(25)
+                """.trimIndent()
+                )
+        }
         gradle("hotRunJvm", "-Pcompose.reload.headless=true").checks {
             check.taskSuccessful(":hotRunJvm")
             check.logContains("Compose Hot Reload ($externalHotReloadVersion)")

--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ plugin-android = "8.10.1"
 shadow-jar = "9.1.0"
 publish-plugin = "1.2.1"
 # we use "prefer" here for the strategy: "explicitly specified hot reload plugin always wins".
-plugin-hot-reload = { prefer = "1.1.1" }
+plugin-hot-reload = { prefer = "1.2.0-alpha01" }
 
 [libraries]
 download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }


### PR DESCRIPTION
+ use JDK 25 as CHR requires it since 1.2.0-alpha01


Fixes [CMP-10253](https://youtrack.jetbrains.com/issue/CMP-10253)

## Release Notes
### Features - Desktop
- The default ProGuard version is set to 7.8.0
- _(prerelease fix)_ Bump Compose Hot Reload to [1.2.0-alpha01](https://github.com/JetBrains/compose-hot-reload/releases/tag/v1.2.0-alpha01)