### PR TITLE
Fix navigationevent version in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ _Changes since 1.11.0_
 | Lifecycle | `org.jetbrains.androidx.lifecycle:lifecycle-*:2.11.0-beta01` | [Lifecycle 2.11.0-beta01](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.11.0-beta01) |
 | Navigation | `org.jetbrains.androidx.navigation:navigation-*:2.9.2` | [Navigation 2.9.7](https://developer.android.com/jetpack/androidx/releases/navigation#2.9.7) |
 | Navigation3 | `org.jetbrains.androidx.navigation3:navigation3-*:1.1.2` | [Navigation3 1.1.2](https://developer.android.com/jetpack/androidx/releases/navigation3#1.1.2) |
-| Navigation Event | `org.jetbrains.androidx.navigationevent:navigationevent-compose:1.1.1` | [Navigation Event 1.1.1](https://developer.android.com/jetpack/androidx/releases/navigationevent#1.1.1) |
+| Navigation Event | `org.jetbrains.androidx.navigationevent:navigationevent-compose:1.1.0` | [Navigation Event 1.1.1](https://developer.android.com/jetpack/androidx/releases/navigationevent#1.1.1) |
 | Savedstate | `org.jetbrains.androidx.savedstate:savedstate*:1.4.0` | [Savedstate 1.4.0](https://developer.android.com/jetpack/androidx/releases/savedstate#1.4.0) |
 | WindowManager Core | `org.jetbrains.androidx.window:window-core:1.5.1` | [WindowManager 1.5.1](https://developer.android.com/jetpack/androidx/releases/window#1.5.1) |
 


### PR DESCRIPTION
Fixes [CMP-10268](https://youtrack.jetbrains.com/issue/CMP-10268) Could not find org.jetbrains.androidx.navigationevent:navigationevent-compose:1.1.1.

## Release Notes
N/A