### PR TITLE
Web: empty UI when resource is cancelled

### DIFF
--- a/components/resources/library/src/blockingTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.blocking.kt
+++ b/components/resources/library/src/blockingTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.blocking.kt
@@ -1,0 +1,3 @@
+package org.jetbrains.compose.resources
+
+internal actual const val RESOURCE_RECOMPOSITIONS: Int = 1

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceCaches.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceCaches.kt
@@ -1,13 +1,12 @@
 package org.jetbrains.compose.resources
 
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 internal class AsyncCache<K, V> {
+    private val cacheJob = SupervisorJob()
+    private val cacheScope = CoroutineScope(cacheJob)
     private val mutex = Mutex()
     private val cache = mutableMapOf<K, Deferred<V>>()
 
@@ -15,21 +14,27 @@ internal class AsyncCache<K, V> {
         ResourceCaches.registerCache(this)
     }
 
-    suspend fun getOrLoad(key: K, load: suspend () -> V): V = coroutineScope {
+    suspend fun getOrLoad(key: K, load: suspend () -> V): V {
         val deferred = mutex.withLock {
             var cached = cache[key]
             if (cached == null || cached.isCancelled) {
-                //LAZY - to free the mutex lock as fast as possible
-                cached = async(start = CoroutineStart.LAZY) { load() }
+                cached = cacheScope.async { load() }
                 cache[key] = cached
             }
             cached
         }
-        deferred.await()
+        return deferred.await()
+    }
+
+    suspend fun waitAllJobs() {
+        mutex.withLock {
+            cacheJob.children.forEach { it.join() }
+        }
     }
 
     suspend fun clear() {
         mutex.withLock {
+            cacheJob.children.forEach { it.cancel() }
             cache.clear()
         }
     }
@@ -39,6 +44,17 @@ object ResourceCaches {
     private val caches = mutableListOf<AsyncCache<*, *>>()
 
     internal fun registerCache(cache: AsyncCache<*, *>) = caches.add(cache)
+
+    /**
+     * Waits for all ongoing resource loading jobs to complete.
+     *
+     * This method ensures that all asynchronous resource loading operations
+     * have finished before proceeding. It is useful for testing and ensuring
+     * that resources are fully loaded before further actions are taken.
+     */
+    internal suspend fun waitAllJobs() {
+        caches.forEach { it.waitAllJobs() }
+    }
 
     /**
      * Clears any cached resources maintained internally by the system.

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceCaches.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceCaches.kt
@@ -5,37 +5,52 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 internal class AsyncCache<K, V> {
-    private val cacheJob = SupervisorJob()
-    private val cacheScope = CoroutineScope(cacheJob)
+    private val cacheScope = CoroutineScope(SupervisorJob())
     private val mutex = Mutex()
-    private val cache = mutableMapOf<K, Deferred<V>>()
+    private val cache = mutableMapOf<K, SharedRequest<V>>()
+
+    private class SharedRequest<V>(val deferred: Deferred<V>) {
+        var listenersCount = 0
+    }
 
     init {
         ResourceCaches.registerCache(this)
     }
 
-    private val currentJobs get() = cacheJob.children.toList()
+    private suspend fun getAllActiveJobs(): List<Job> = mutex.withLock {
+        cache.values.map { it.deferred }.filter { it.isActive }
+    }
 
     suspend fun getOrLoad(key: K, load: suspend () -> V): V {
-        val deferred = mutex.withLock {
+        val request = mutex.withLock {
             var cached = cache[key]
-            if (cached == null || cached.isCancelled) {
-                cached = cacheScope.async { load() }
+            if (cached == null || cached.deferred.isCancelled) {
+                cached = SharedRequest(cacheScope.async { load() })
                 cache[key] = cached
             }
+            cached.listenersCount++
             cached
         }
-        return deferred.await()
+         return try {
+             request.deferred.await()
+         } finally {
+             mutex.withLock {
+                 request.listenersCount--
+                 if (request.listenersCount == 0 && request.deferred.isActive) {
+                     request.deferred.cancel()
+                 }
+             }
+         }
     }
 
     suspend fun waitAllJobs() {
-        currentJobs.joinAll()
+        getAllActiveJobs().joinAll()
     }
 
     suspend fun clear() {
         mutex.withLock {
+            cache.forEach { (_, v) -> v.deferred.cancel() }
             cache.clear()
-            currentJobs.forEach { it.cancelAndJoin() }
         }
     }
 }

--- a/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceCaches.kt
+++ b/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/ResourceCaches.kt
@@ -14,6 +14,8 @@ internal class AsyncCache<K, V> {
         ResourceCaches.registerCache(this)
     }
 
+    private val currentJobs get() = cacheJob.children.toList()
+
     suspend fun getOrLoad(key: K, load: suspend () -> V): V {
         val deferred = mutex.withLock {
             var cached = cache[key]
@@ -27,15 +29,13 @@ internal class AsyncCache<K, V> {
     }
 
     suspend fun waitAllJobs() {
-        mutex.withLock {
-            cacheJob.children.forEach { it.join() }
-        }
+        currentJobs.joinAll()
     }
 
     suspend fun clear() {
         mutex.withLock {
-            cacheJob.children.forEach { it.cancel() }
             cache.clear()
+            currentJobs.forEach { it.cancelAndJoin() }
         }
     }
 }
@@ -53,7 +53,7 @@ object ResourceCaches {
      * that resources are fully loaded before further actions are taken.
      */
     internal suspend fun waitAllJobs() {
-        caches.forEach { it.waitAllJobs() }
+        caches.toList().forEach { it.waitAllJobs() }
     }
 
     /**
@@ -63,6 +63,6 @@ object ResourceCaches {
      * may be changed or no longer be required.
      */
     internal suspend fun clear() {
-        caches.forEach { it.clear() }
+        caches.toList().forEach { it.clear() }
     }
 }

--- a/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.kt
+++ b/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
 
+internal expect val RESOURCE_RECOMPOSITIONS: Int
+
 @OptIn(ExperimentalTestApi::class, InternalResourceApi::class)
 class ComposeResourceTest {
 
@@ -26,10 +28,10 @@ class ComposeResourceTest {
                 }
             }
         }
-        waitForIdle()
+        waitResources()
         res = TestDrawableResource("2.png")
-        waitForIdle()
-        assertEquals(2, recompositionsCounter.count)
+        waitResources()
+        assertEquals(2 * RESOURCE_RECOMPOSITIONS, recompositionsCounter.count)
     }
 
     @Test
@@ -44,11 +46,11 @@ class ComposeResourceTest {
                 Image(painterResource(res), null)
             }
         }
-        waitForIdle()
+        waitResources()
         res = TestDrawableResource("2.png")
-        waitForIdle()
+        waitResources()
         res = TestDrawableResource("1.png")
-        waitForIdle()
+        waitResources()
 
         assertEquals(
             expected = listOf("1.png", "2.png"), //no second read of 1.png
@@ -58,9 +60,9 @@ class ComposeResourceTest {
         ResourceCaches.clear()
 
         res = TestDrawableResource("2.png")
-        waitForIdle()
+        waitResources()
         res = TestDrawableResource("1.png")
-        waitForIdle()
+        waitResources()
 
         assertEquals(
             expected = listOf("1.png", "2.png", "2.png", "1.png"), // read images again
@@ -96,9 +98,9 @@ class ComposeResourceTest {
                 Image(painterResource(imgRes), null)
             }
         }
-        waitForIdle()
+        waitResources()
         environment = mdpiEnvironment
-        waitForIdle()
+        waitResources()
 
         assertEquals(
             expected = listOf("2.png", "1.png"), //XXXHDPI - fist, MDPI - next
@@ -122,25 +124,25 @@ class ComposeResourceTest {
                 Text(stringArrayResource(TestStringArrayResource("str_arr")).joinToString())
             }
         }
-        waitForIdle()
+        waitResources()
         assertEquals(str, "Compose Resources App")
         res = TestStringResource("hello")
-        waitForIdle()
+        waitResources()
         assertEquals(str, "\uD83D\uDE0A Hello world!")
         res = TestStringResource("app_name")
-        waitForIdle()
+        waitResources()
         assertEquals(str, "Compose Resources App")
         res = TestStringResource("hello")
-        waitForIdle()
+        waitResources()
         assertEquals(str, "\uD83D\uDE0A Hello world!")
         res = TestStringResource("app_name")
-        waitForIdle()
+        waitResources()
         assertEquals(str, "Compose Resources App")
         res = TestStringResource("hello")
-        waitForIdle()
+        waitResources()
         assertEquals(str, "\uD83D\uDE0A Hello world!")
         res = TestStringResource("app_name")
-        waitForIdle()
+        waitResources()
         assertEquals(str, "Compose Resources App")
 
         assertEquals(
@@ -155,7 +157,7 @@ class ComposeResourceTest {
         ResourceCaches.clear()
 
         res = TestStringResource("hello")
-        waitForIdle()
+        waitResources()
         assertEquals(str, "\uD83D\uDE0A Hello world!")
         assertEquals(
             expected = listOf(
@@ -183,7 +185,7 @@ class ComposeResourceTest {
                 str_arr = stringArrayResource(TestStringArrayResource("str_arr"))
             }
         }
-        waitForIdle()
+        waitResources()
 
         assertEquals("Compose Resources App", app_name)
         assertEquals("Créer une table", accentuated_characters)
@@ -204,12 +206,12 @@ class ComposeResourceTest {
             }
         }
 
-        waitForIdle()
+        waitResources()
         assertEquals("Hello, test1! You have 42 new messages.", str1)
         assertEquals("Hello, test2! You have 42 new messages.", str2)
 
         arg = 31415
-        waitForIdle()
+        waitResources()
         assertEquals("Hello, test1! You have 31415 new messages.", str1)
         assertEquals("Hello, test2! You have 31415 new messages.", str2)
     }
@@ -239,31 +241,31 @@ class ComposeResourceTest {
             }
         }
 
-        waitForIdle()
+        waitResources()
         assertEquals("other", str)
 
         quantity = 1
-        waitForIdle()
+        waitResources()
         assertEquals("one", str)
         assertEquals(1, quantity)
 
         quantity = 2
-        waitForIdle()
+        waitResources()
         assertEquals("other", str)
         assertEquals(2, quantity)
 
         quantity = 3
-        waitForIdle()
+        waitResources()
         assertEquals("other", str)
         assertEquals(3, quantity)
 
         res = TestPluralStringResource("another_plurals")
         quantity = 0
-        waitForIdle()
+        waitResources()
         assertEquals("another other", str)
 
         quantity = 1
-        waitForIdle()
+        waitResources()
         assertEquals("another one", str)
     }
 
@@ -277,7 +279,7 @@ class ComposeResourceTest {
                 another_plurals = pluralStringResource(TestPluralStringResource("another_plurals"), 1)
             }
         }
-        waitForIdle()
+        waitResources()
 
         assertEquals("one", plurals)
         assertEquals("another one", another_plurals)
@@ -297,17 +299,17 @@ class ComposeResourceTest {
                 str2 = pluralStringResource(TestPluralStringResource("messages"), quantity, 5, arg)
             }
         }
-        waitForIdle()
+        waitResources()
         assertEquals("3 messages for me", str1)
         assertEquals("5 messages for me", str2)
 
         arg = "you"
-        waitForIdle()
+        waitResources()
         assertEquals("3 messages for you", str1)
         assertEquals("5 messages for you", str2)
 
         quantity = 1
-        waitForIdle()
+        waitResources()
         assertEquals("3 message for you", str1)
         assertEquals("5 message for you", str2)
     }
@@ -362,7 +364,7 @@ class ComposeResourceTest {
                 uri2 = resourceReader.getUri("2.png")
             }
         }
-        waitForIdle()
+        waitResources()
 
         assertTrue(uri1.endsWith("/1.png"))
         assertTrue(uri2.endsWith("/2.png"))
@@ -387,7 +389,7 @@ class ComposeResourceTest {
                 environment = rememberResourceEnvironment()
             }
         }
-        waitForIdle()
+        waitResources()
 
         val systemEnvironment = getSystemResourceEnvironment()
         assertEquals(systemEnvironment, environment)
@@ -431,7 +433,7 @@ class ComposeResourceTest {
             override fun rememberEnvironment() = env2
         }
         envState.value = testEnv2
-        waitForIdle()
+        waitResources()
 
         assertEquals(env2, lastEnv1)
         assertEquals(env2, lastEnv2)

--- a/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/TestUtils.kt
+++ b/components/resources/library/src/commonTest/kotlin/org/jetbrains/compose/resources/TestUtils.kt
@@ -3,6 +3,7 @@ package org.jetbrains.compose.resources
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.coroutines.yield
 import org.jetbrains.compose.resources.plural.PluralCategory
 import org.jetbrains.compose.resources.plural.PluralRule
 import org.jetbrains.compose.resources.plural.PluralRuleList
@@ -79,6 +80,13 @@ internal fun pluralRuleListOf(vararg rules: Pair<PluralCategory, String>): Plura
 fun clearResourceCachesAndRunUiTest(block: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
     ResourceCaches.clear()
     block()
+}
+
+@OptIn(ExperimentalTestApi::class)
+internal suspend fun ComposeUiTest.waitResources() {
+    waitForIdle()
+    ResourceCaches.waitAllJobs()
+    waitForIdle()
 }
 
 

--- a/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.js.kt
+++ b/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.js.kt
@@ -4,17 +4,12 @@ import kotlinx.browser.window
 import kotlinx.coroutines.await
 import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Int8Array
-import org.khronos.webgl.Uint8Array
 import org.w3c.fetch.Response
 import org.w3c.files.Blob
-import org.w3c.xhr.XMLHttpRequest
 import kotlin.js.Promise
 
 @ExperimentalResourceApi
-internal actual fun getPlatformResourceReader(): ResourceReader {
-    if (isInTestEnvironment()) return TestJsResourceReader
-    return DefaultJsResourceReader
-}
+internal actual fun getPlatformResourceReader(): ResourceReader = DefaultJsResourceReader
 
 @ExperimentalResourceApi
 internal object DefaultJsResourceReader : ResourceReader {
@@ -50,38 +45,3 @@ internal object DefaultJsResourceReader : ResourceReader {
         return Int8Array(buffer.await()).unsafeCast<ByteArray>()
     }
 }
-
-// It uses a synchronous XmlHttpRequest (blocking!!!)
-private object TestJsResourceReader : ResourceReader {
-    override suspend fun read(path: String): ByteArray {
-        return readByteArray(path)
-    }
-
-    override suspend fun readPart(path: String, offset: Long, size: Long): ByteArray {
-        return readByteArray(path).sliceArray(offset.toInt() until (offset + size).toInt())
-    }
-
-    override fun getUri(path: String): String {
-        val location = window.location
-        return getResourceUrl(location.origin, location.pathname, path)
-    }
-
-    private fun readByteArray(path: String): ByteArray {
-        val resPath = WebResourcesConfiguration.getResourcePath(path)
-        val request = XMLHttpRequest()
-        request.open("GET", resPath, false)
-        request.overrideMimeType("text/plain; charset=x-user-defined")
-        request.send()
-        if (request.status == 200.toShort()) {
-            // For blocking XmlHttpRequest the response can be only in text form, so we convert it to bytes manually
-            val text = request.responseText
-            val bytes = Uint8Array(text.length)
-            js("for (var i = 0; i < text.length; i++) { bytes[i] = text.charCodeAt(i) & 0xFF; }")
-            return bytes.unsafeCast<ByteArray>()
-        }
-        throw MissingResourceException("$resPath")
-    }
-}
-
-private fun isInTestEnvironment(): Boolean =
-    js("window.composeResourcesTesting == true")

--- a/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.js.kt
+++ b/components/resources/library/src/jsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.js.kt
@@ -2,11 +2,34 @@ package org.jetbrains.compose.resources
 
 import kotlinx.browser.window
 import kotlinx.coroutines.await
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Int8Array
 import org.w3c.fetch.Response
 import org.w3c.files.Blob
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.js.Promise
+
+private external interface AbortSignal
+private external class AbortController {
+    val signal: AbortSignal
+    fun abort()
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun("(url, signal) => window.fetch(url, { signal })")
+private external fun jsFetchWithSignal(url: String, signal: AbortSignal): Promise<Response>
+
+@Suppress("UNCHECKED_CAST")
+private suspend fun <T> cancellableFetch(url: String): T = suspendCancellableCoroutine { cont ->
+    val ac = AbortController()
+    jsFetchWithSignal(url, ac.signal).then(
+        onFulfilled = { cont.resume(it as T) },
+        onRejected = { cont.resumeWithException(it) }
+    )
+    cont.invokeOnCancellation { ac.abort() }
+}
 
 @ExperimentalResourceApi
 internal actual fun getPlatformResourceReader(): ResourceReader = DefaultJsResourceReader
@@ -30,8 +53,7 @@ internal object DefaultJsResourceReader : ResourceReader {
     private suspend fun readAsBlob(path: String): Blob {
         val resPath = WebResourcesConfiguration.getResourcePath(path)
         val response =  ResourceWebCache.load(resPath) {
-            // TODO: avoid js(...) calls here after https://github.com/Kotlin/kotlinx-browser/issues/24
-            js("window.fetch(resPath)").unsafeCast<Promise<Response>>().await()
+            cancellableFetch(resPath)
         }
         if (!response.ok) {
             throw MissingResourceException(resPath)

--- a/components/resources/library/src/skikoTest/kotlin/org/jetbrains/compose/resources/FontCacheTest.kt
+++ b/components/resources/library/src/skikoTest/kotlin/org/jetbrains/compose/resources/FontCacheTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.platform.LoadedFont
+import androidx.compose.ui.text.platform.PlatformFont
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -33,11 +33,11 @@ class FontCacheTest {
                 )
             }
         }
-        waitForIdle()
+        waitResources()
         res = TestFontResource(font2)
-        waitForIdle()
+        waitResources()
         res = TestFontResource(font1)
-        waitForIdle()
+        waitResources()
 
         assertEquals(
             expected = listOf(font1, font2), //no second read of font_awesome.otf
@@ -47,9 +47,9 @@ class FontCacheTest {
         ResourceCaches.clear()
 
         res = TestFontResource(font2)
-        waitForIdle()
+        waitResources()
         res = TestFontResource(font1)
-        waitForIdle()
+        waitResources()
 
         assertEquals(
             expected = listOf(font1, font2, font2, font1), //read fonts again
@@ -71,18 +71,18 @@ class FontCacheTest {
                 LocalComposeEnvironment provides TestComposeEnvironment
             ) {
                 val font = Font(res)
-                fontIdentity = (font as LoadedFont).identity
+                fontIdentity = (font as PlatformFont).identity
                 Text(
                     fontFamily = FontFamily(font),
                     text = "Hello"
                 )
             }
         }
-        waitForIdle()
+        waitResources()
         val id1 = fontIdentity
 
         res = TestFontResource(font2)
-        waitForIdle()
+        waitResources()
 
         val id2 = fontIdentity
 
@@ -92,7 +92,7 @@ class FontCacheTest {
 
         testResourceReader.replaceNextReadWith(font2)
         res = TestFontResource(font1)
-        waitForIdle()
+        waitResources()
 
         val id3 = fontIdentity
         assertNotEquals(id1, id3)

--- a/components/resources/library/src/wasmJsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.wasmJs.kt
+++ b/components/resources/library/src/wasmJsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.wasmJs.kt
@@ -3,28 +3,14 @@ package org.jetbrains.compose.resources
 import kotlinx.browser.window
 import kotlinx.coroutines.await
 import org.khronos.webgl.ArrayBuffer
-import org.khronos.webgl.Int8Array
 import org.w3c.files.Blob
-import org.w3c.xhr.XMLHttpRequest
 import kotlin.js.Promise
-
-@JsFun(
-    """ (src, size, dstAddr) => {
-        const mem8 = new Int8Array(wasmExports.memory.buffer, dstAddr, size);
-        mem8.set(src);
-    }
-"""
-)
-private external fun jsExportInt8ArrayToWasm(src: Int8Array, size: Int, dstAddr: Int)
 
 @JsFun("(blob) => blob.arrayBuffer()")
 private external fun jsExportBlobAsArrayBuffer(blob: Blob): Promise<ArrayBuffer>
 
 @ExperimentalResourceApi
-internal actual fun getPlatformResourceReader(): ResourceReader {
-    if (isInTestEnvironment()) return TestWasmResourceReader
-    return DefaultWasmResourceReader
-}
+internal actual fun getPlatformResourceReader(): ResourceReader = DefaultWasmResourceReader
 
 @ExperimentalResourceApi
 @OptIn(ExperimentalWasmJsInterop::class)
@@ -59,46 +45,3 @@ internal object DefaultWasmResourceReader : ResourceReader {
         return fastArrayBufferToByteArray(buffer)
     }
 }
-
-// It uses a synchronous XmlHttpRequest (blocking!!!)
-private object TestWasmResourceReader : ResourceReader {
-    override suspend fun read(path: String): ByteArray {
-        return readByteArray(path)
-    }
-
-    override suspend fun readPart(path: String, offset: Long, size: Long): ByteArray {
-        return readByteArray(path).sliceArray(offset.toInt() until (offset + size).toInt())
-    }
-
-    override fun getUri(path: String): String {
-        val location = window.location
-        return getResourceUrl(location.origin, location.pathname, path)
-    }
-
-    private fun readByteArray(path: String): ByteArray {
-        val resPath = WebResourcesConfiguration.getResourcePath(path)
-        val request = XMLHttpRequest()
-        request.open("GET", resPath, false)
-        request.overrideMimeType("text/plain; charset=x-user-defined")
-        request.send()
-        if (request.status == 200.toShort()) {
-            return fastArrayBufferToByteArray(requestResponseAsByteArray(request).buffer)
-        }
-        println("Request status is not 200 - $resPath, status: ${request.status}")
-        throw MissingResourceException(resPath)
-    }
-}
-
-// For blocking XmlHttpRequest the response can be only in text form, so we convert it to bytes manually
-private fun requestResponseAsByteArray(req: XMLHttpRequest): Int8Array =
-    js(""" {
-        var text = req.responseText;
-        var int8Arr = new Int8Array(text.length);
-        for (var i = 0; i < text.length; i++) {
-            int8Arr[i] = text.charCodeAt(i) & 0xFF;
-        }
-        return int8Arr;
-    }""")
-
-private fun isInTestEnvironment(): Boolean =
-    js("window.composeResourcesTesting == true")

--- a/components/resources/library/src/wasmJsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.wasmJs.kt
+++ b/components/resources/library/src/wasmJsMain/kotlin/org/jetbrains/compose/resources/ResourceReader.wasmJs.kt
@@ -1,13 +1,40 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
 package org.jetbrains.compose.resources
 
 import kotlinx.browser.window
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.await
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.khronos.webgl.ArrayBuffer
+import org.w3c.fetch.Response
 import org.w3c.files.Blob
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.js.Promise
+import kotlin.js.unsafeCast
 
 @JsFun("(blob) => blob.arrayBuffer()")
 private external fun jsExportBlobAsArrayBuffer(blob: Blob): Promise<ArrayBuffer>
+
+private external interface AbortSignal
+private external class AbortController {
+    val signal: AbortSignal
+    fun abort()
+}
+
+@JsFun("(url, signal) => window.fetch(url, { signal })")
+private external fun jsFetchWithSignal(url: String, signal: AbortSignal): Promise<Response>
+
+@Suppress("UNCHECKED_CAST")
+private suspend fun <T> cancellableFetch(url: String): T = suspendCancellableCoroutine { cont ->
+    val ac = AbortController()
+    jsFetchWithSignal(url, ac.signal).then(
+        onFulfilled = { cont.resume(it as T); null },
+        onRejected = { cont.resumeWithException(it.toThrowableOrNull() ?: error("Unexpected non-Kotlin exception $it")); null }
+    )
+    cont.invokeOnCancellation { ac.abort() }
+}
 
 @ExperimentalResourceApi
 internal actual fun getPlatformResourceReader(): ResourceReader = DefaultWasmResourceReader
@@ -32,7 +59,7 @@ internal object DefaultWasmResourceReader : ResourceReader {
     private suspend fun readAsBlob(path: String): Blob {
         val resPath = WebResourcesConfiguration.getResourcePath(path)
         val response = ResourceWebCache.load(resPath) {
-            window.fetch(resPath).await()
+            cancellableFetch(resPath)
         }
         if (!response.ok) {
             throw MissingResourceException(resPath)

--- a/components/resources/library/src/webTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.web.kt
+++ b/components/resources/library/src/webTest/kotlin/org/jetbrains/compose/resources/ComposeResourceTest.web.kt
@@ -1,0 +1,3 @@
+package org.jetbrains.compose.resources
+
+internal actual const val RESOURCE_RECOMPOSITIONS: Int = 2

--- a/components/resources/library/src/webTest/kotlin/org/jetbrains/compose/resources/TestResourcePreloading.kt
+++ b/components/resources/library/src/webTest/kotlin/org/jetbrains/compose/resources/TestResourcePreloading.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.font.Font
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.yield
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,7 +21,7 @@ import kotlin.test.assertTrue
 class TestResourcePreloading {
 
     @Test
-    fun testPreloadFont() = runComposeUiTest {
+    fun testPreloadFont() = clearResourceCachesAndRunUiTest {
         var loadContinuation: CancellableContinuation<ByteArray>? = null
 
         val resLoader = object : ResourceReader {
@@ -60,8 +61,10 @@ class TestResourcePreloading {
         assertEquals(null, font)
         assertEquals(null, font2)
 
+        yield()
         assertNotEquals(null, loadContinuation)
         loadContinuation!!.resumeWith(Result.success(ByteArray(0)))
+        yield()
         loadContinuation = null
 
         waitForIdle()

--- a/components/resources/library/src/webTest/kotlin/org/jetbrains/compose/resources/TestWebResourceCache.kt
+++ b/components/resources/library/src/webTest/kotlin/org/jetbrains/compose/resources/TestWebResourceCache.kt
@@ -1,0 +1,84 @@
+package org.jetbrains.compose.resources
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.test.ExperimentalTestApi
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.yield
+import kotlin.coroutines.resume
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class TestWebResourceCache {
+
+    //https://youtrack.jetbrains.com/issue/CMP-10137
+    @Test
+    fun testPoisonedCache() = clearResourceCachesAndRunUiTest {
+        val res = TestStringResource("app_name")
+
+        var showBranchB by mutableStateOf(false)
+        var branchAText = ""
+        var branchBText = ""
+        var branchACancelled = false
+        var branchBStartedBeforeBranchACancelled = false
+        var resourceLoadingWasCancelled = false
+
+        val testResourceReader = object : ResourceReader {
+            lateinit var loadContinuation: CancellableContinuation<ByteArray>
+            override suspend fun readPart(
+                path: String,
+                offset: Long,
+                size: Long
+            ): ByteArray = suspendCancellableCoroutine {
+                loadContinuation = it
+                it.invokeOnCancellation { resourceLoadingWasCancelled = true }
+            }
+
+            suspend fun provideData(str: String) {
+                yield()
+                loadContinuation.resume(Base64.encodeToByteArray(str.encodeToByteArray()))
+                yield()
+            }
+
+            override suspend fun read(path: String) = TODO()
+            override fun getUri(path: String) = TODO()
+        }
+
+        setContent {
+            CompositionLocalProvider(
+                LocalResourceReader provides testResourceReader,
+                LocalComposeEnvironment provides TestComposeEnvironment
+            ) {
+                if (!showBranchB) {
+                    branchAText = stringResource(res)
+                    Text(branchAText)
+                    LaunchedEffect(Unit) { showBranchB = true }
+                    DisposableEffect(Unit) {
+                        onDispose {
+                            branchACancelled = true
+                        }
+                    }
+                } else {
+                    branchBStartedBeforeBranchACancelled = branchACancelled == false
+                    branchBText = stringResource(res)
+                    Text(branchBText)
+                }
+            }
+        }
+
+        waitForIdle()
+        assertTrue(branchBStartedBeforeBranchACancelled, "Branch B should start before Branch A is cancelled")
+        assertEquals("", branchAText, "Branch A text should be empty when Branch A is cancelled")
+
+        testResourceReader.provideData("Compose Resources App")
+
+        waitForIdle()
+        assertFalse(resourceLoadingWasCancelled, "Resource loading should not be cancelled")
+        assertEquals("Compose Resources App", branchBText)
+    }
+}

--- a/components/resources/library/src/webTest/resources/test_setup.js
+++ b/components/resources/library/src/webTest/resources/test_setup.js
@@ -1,2 +1,0 @@
-// Setting this will make the tests use a blocking XMLHttpRequest instead of the asynchronous 'fetch'
-window.composeResourcesTesting = true;


### PR DESCRIPTION
Extract the loading job out of the UI scope

Fixes https://youtrack.jetbrains.com/issue/CMP-10137

## Testing
Added unit tests

## Release Notes
### Fixes - Resources
- Fix an issue when resource loading might be cancelled and UI became empty
