### PR TITLE
Increase load on the CanvasDrawing test

### DIFF
--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/Benchmarks.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/Benchmarks.kt
@@ -17,6 +17,7 @@ import benchmarks.lazygrid.LazyGrid
 import benchmarks.visualeffects.NYContent
 import benchmarks.textlayout.TextLayout
 import benchmarks.canvasdrawing.CanvasDrawing
+import benchmarks.canvasdrawing.CanvasDrawingComplexity
 import benchmarks.heavyshader.HeavyShader
 import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
@@ -347,7 +348,8 @@ fun getBenchmarks(): List<Benchmark> = listOf(
         MultipleComponentsExample(isVectorGraphicsSupported = false)
     },
     Benchmark("TextLayout") { TextLayout() },
-    Benchmark("CanvasDrawing") { CanvasDrawing() },
+    Benchmark("CanvasDrawing") { CanvasDrawing(CanvasDrawingComplexity.easy) },
+    Benchmark("CanvasDrawing-Medium") { CanvasDrawing(CanvasDrawingComplexity.medium) },
     Benchmark("HeavyShader") { HeavyShader() }
 ).sortedBy { it.name }
 

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/benchmarks/canvasdrawing/CanvasDrawing.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/benchmarks/canvasdrawing/CanvasDrawing.kt
@@ -95,7 +95,7 @@ private fun CanvasDrawingItem(index: Int) {
             )
         )
 
-        repeat(200) { i ->
+        repeat(400) { i ->
             val angle = animatedValue + i * 7.2f
             val radius = size.minDimension / 4f
             val x = size.width / 2 + cos(angle * PI / 180.0).toFloat() * radius * random.nextFloat()
@@ -103,7 +103,7 @@ private fun CanvasDrawingItem(index: Int) {
 
             val path = Path().apply {
                 moveTo(x, y)
-                repeat(40) { j ->
+                repeat(50) { j ->
                     val pointAngle = angle + j * 45f + animatedValue
                     val pointRadius = 20f + random.nextFloat() * 30f
                     val px = x + cos(pointAngle * PI / 180.0).toFloat() * pointRadius
@@ -131,22 +131,53 @@ private fun CanvasDrawingItem(index: Int) {
                     center = Offset(x, y)
                 )
             )
+
+            val path2 = Path().apply {
+                moveTo(x, y)
+                repeat(50) { j ->
+                    val pointAngle = angle + j * 45f + animatedValue
+                    val pointRadius = 20f + random.nextFloat() * 30f
+                    val px = x + cos(pointAngle * PI / 180.0).toFloat() * pointRadius
+                    val py = y + sin(pointAngle * PI / 180.0).toFloat() * pointRadius
+                    if (j % 2 == 0) {
+                        lineTo(px, py)
+                    } else {
+                        quadraticBezierTo(
+                            x + random.nextFloat() * 50f - 25f,
+                            y + random.nextFloat() * 50f - 25f,
+                            px, py
+                        )
+                    }
+                }
+                close()
+            }
+
+            drawPath(
+                path = path2,
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        Color(random.nextInt(0xFFFFFF) or 0x80000000.toInt()),
+                        Color(random.nextInt(0xFFFFFF) or 0x40000000.toInt())
+                    ),
+                    center = Offset(x, y)
+                )
+            )
         }
 
-        repeat(70) { i ->
+        repeat(300) { i ->
             val lineY = i * (size.height / 30)
             drawLine(
                 color = Color(random.nextInt(0xFFFFFF) or 0xFF000000.toInt()),
                 start = Offset(0f, lineY),
                 end = Offset(size.width, lineY + sin(animatedValue * i).toFloat() * 20f),
-                strokeWidth = 2f
+                strokeWidth = 5f
             )
         }
 
-        repeat(70) { i ->
+        repeat(300) { i ->
             val circleX = (i % 8) * (size.width / 8) + (size.width / 16)
             val circleY = (i / 8) * (size.height / 5) + (size.height / 10)
-            val circleRadius = 15f + sin(animatedValue + i).toFloat() * 10f
+            val circleRadius = 35f + sin(animatedValue + i).toFloat() * 10f
 
             drawCircle(
                 color = Color(random.nextInt(0xFFFFFF) or 0xFF000000.toInt()),

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/benchmarks/canvasdrawing/CanvasDrawing.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/benchmarks/canvasdrawing/CanvasDrawing.kt
@@ -95,7 +95,7 @@ private fun CanvasDrawingItem(index: Int) {
             )
         )
 
-        repeat(400) { i ->
+        repeat(300) { i ->
             val angle = animatedValue + i * 7.2f
             val radius = size.minDimension / 4f
             val x = size.width / 2 + cos(angle * PI / 180.0).toFloat() * radius * random.nextFloat()

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/benchmarks/canvasdrawing/CanvasDrawing.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/benchmarks/canvasdrawing/CanvasDrawing.kt
@@ -41,8 +41,12 @@ import kotlinx.coroutines.isActive
 
 private const val ITEM_COUNT = 1200
 
+enum class CanvasDrawingComplexity {
+    easy, medium
+}
+
 @Composable
-fun CanvasDrawing() {
+fun CanvasDrawing(complexity: CanvasDrawingComplexity) {
     val listState = rememberLazyListState()
     var scrollForward by remember { mutableStateOf(true) }
 
@@ -61,13 +65,108 @@ fun CanvasDrawing() {
         modifier = Modifier.fillMaxSize().background(Color.Black)
     ) {
         items(ITEM_COUNT) { index ->
-            CanvasDrawingItem(index)
+            when (complexity) {
+                CanvasDrawingComplexity.easy -> EasyCanvasDrawingItem(index)
+                CanvasDrawingComplexity.medium -> MediumCanvasDrawingItem(index)
+            }
         }
     }
 }
 
 @Composable
-private fun CanvasDrawingItem(index: Int) {
+private fun EasyCanvasDrawingItem(index: Int) {
+    val animatedValue by rememberInfiniteTransition().animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(3000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        )
+    )
+
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(300.dp)
+            .padding(8.dp)
+    ) {
+        val seed = index * 12345L
+        val random = Random(seed)
+
+        drawRect(
+            brush = Brush.verticalGradient(
+                colors = listOf(
+                    Color(random.nextInt(0xFFFFFF) or 0xFF000000.toInt()),
+                    Color(random.nextInt(0xFFFFFF) or 0xFF000000.toInt())
+                )
+            )
+        )
+
+        repeat(200) { i ->
+            val angle = animatedValue + i * 7.2f
+            val radius = size.minDimension / 4f
+            val x = size.width / 2 + cos(angle * PI / 180.0).toFloat() * radius * random.nextFloat()
+            val y = size.height / 2 + sin(angle * PI / 180.0).toFloat() * radius * random.nextFloat()
+
+            val path = Path().apply {
+                moveTo(x, y)
+                repeat(40) { j ->
+                    val pointAngle = angle + j * 45f + animatedValue
+                    val pointRadius = 20f + random.nextFloat() * 30f
+                    val px = x + cos(pointAngle * PI / 180.0).toFloat() * pointRadius
+                    val py = y + sin(pointAngle * PI / 180.0).toFloat() * pointRadius
+                    if (j % 2 == 0) {
+                        lineTo(px, py)
+                    } else {
+                        quadraticBezierTo(
+                            x + random.nextFloat() * 50f - 25f,
+                            y + random.nextFloat() * 50f - 25f,
+                            px, py
+                        )
+                    }
+                }
+                close()
+            }
+
+            drawPath(
+                path = path,
+                brush = Brush.radialGradient(
+                    colors = listOf(
+                        Color(random.nextInt(0xFFFFFF) or 0x80000000.toInt()),
+                        Color(random.nextInt(0xFFFFFF) or 0x40000000.toInt())
+                    ),
+                    center = Offset(x, y)
+                )
+            )
+        }
+
+        repeat(70) { i ->
+            val lineY = i * (size.height / 30)
+            drawLine(
+                color = Color(random.nextInt(0xFFFFFF) or 0xFF000000.toInt()),
+                start = Offset(0f, lineY),
+                end = Offset(size.width, lineY + sin(animatedValue * i).toFloat() * 20f),
+                strokeWidth = 2f
+            )
+        }
+
+        repeat(70) { i ->
+            val circleX = (i % 8) * (size.width / 8) + (size.width / 16)
+            val circleY = (i / 8) * (size.height / 5) + (size.height / 10)
+            val circleRadius = 15f + sin(animatedValue + i).toFloat() * 10f
+
+            drawCircle(
+                color = Color(random.nextInt(0xFFFFFF) or 0xFF000000.toInt()),
+                radius = circleRadius,
+                center = Offset(circleX, circleY),
+                alpha = 0.7f
+            )
+        }
+    }
+}
+
+@Composable
+private fun MediumCanvasDrawingItem(index: Int) {
     val animatedValue by rememberInfiniteTransition().animateFloat(
         initialValue = 0f,
         targetValue = 360f,

--- a/benchmarks/multiplatform/benchmarks/src/iosMain/kotlin/main.ios.kt
+++ b/benchmarks/multiplatform/benchmarks/src/iosMain/kotlin/main.ios.kt
@@ -3,6 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeUIViewController
 import kotlinx.coroutines.MainScope
@@ -35,6 +36,9 @@ actual val isIosTarget: Boolean = true
 @OptIn(ExperimentalComposeUiApi::class)
 fun MainViewController(): UIViewController {
     return ComposeUIViewController(configure = { parallelRendering = Config.parallelRendering }) {
+        LaunchedEffect(Unit) {
+            UIApplication.sharedApplication.setIdleTimerDisabled(true)
+        }
         BenchmarkRunner(getBenchmarks(), UIScreen.mainScreen.maximumFramesPerSecond.toInt(), { exitProcess(0) })
     }
 }


### PR DESCRIPTION
CanvasDrawing became too easy for 60 FPS devices and became less useful.
The MR increase number of draw calls during this tests to provide more versatile data.

Also, enable Always On screen on iOS to eliminate screen deeming issues during the tests.

## Release Notes
N/A