### PR TITLE
Add a karma.config.d/config.js to the jsNoExecutableTests test

### DIFF
--- a/gradle-plugins/compose/src/test/test-projects/misc/jsNoExecutableTests/karma.config.d/config.js
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jsNoExecutableTests/karma.config.d/config.js
@@ -1,0 +1,9 @@
+config.set({
+    browsers: ["ChromeHeadless_ComposeCI"],
+    customLaunchers: {
+        ChromeHeadless_ComposeCI: {
+            base: "ChromeHeadless",
+            flags: ["--no-sandbox"]
+        }
+    }
+});


### PR DESCRIPTION
## Problem

`testJsNoExecutableTests` fails in CI when the build runs as root:

```
Cannot start ChromeHeadless
Running as root without --no-sandbox is not supported.
```

This is the only integration test in `gradle-plugins` that actually launches a browser (it's the only one invoking `jsBrowserTest` with a real Compose UI test). All other test projects declaring `js { browser() }` are driven through compile/packaging tasks only and never start Chrome, so they're unaffected. Other browser test suites in the repo (`html/`, `components/resources/`) already ship their own `--no-sandbox` karma patch — this test project was the only browser-launching one without one.

## Fix

Add a `karma.config.d/config.js` to the `jsNoExecutableTests` test project that runs ChromeHeadless with `--no-sandbox`.

## Release Notes
N/A