### PR TITLE
[benchmarks] CMP-10298: Extract Compose scene API into versioned modules for cross-version compatibility

### DIFF
--- a/benchmarks/multiplatform/benchmarks/build.gradle.kts
+++ b/benchmarks/multiplatform/benchmarks/build.gradle.kts
@@ -79,6 +79,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                implementation(project(":compose-scene-impl"))
                 implementation(compose.ui)
                 implementation(compose.foundation)
                 implementation(compose.material)

--- a/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
+++ b/benchmarks/multiplatform/benchmarks/src/commonMain/kotlin/MeasureComposable.kt
@@ -1,9 +1,5 @@
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.asComposeCanvas
-import androidx.compose.ui.scene.CanvasLayersComposeScene
-import androidx.compose.ui.scene.ComposeScene
-import androidx.compose.ui.unit.IntSize
 import org.jetbrains.skia.Surface
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.nanoseconds
@@ -53,7 +49,7 @@ private suspend inline fun yieldEventLoop() {
     yield()
 }
 
-@OptIn(ExperimentalTime::class, InternalComposeUiApi::class)
+@OptIn(ExperimentalTime::class)
 internal suspend fun measureComposable(
     name: String,
     warmupCount: Int,
@@ -65,7 +61,7 @@ internal suspend fun measureComposable(
     content: @Composable () -> Unit
 ): BenchmarkResult  {
     val surface = graphicsContext?.surface(width, height) ?: Surface.makeNull(width, height)
-    val scene = CanvasLayersComposeScene(size = IntSize(width, height))
+    val scene = createBenchmarkComposeScene(width, height)
     try {
         val nanosPerFrame = (1.0 / targetFps.toDouble() * nanosPerSecond).toLong()
         scene.setContent(content)
@@ -167,8 +163,7 @@ private val pictureRecorder = PictureRecorder()
  * Beware that this logic can be changed in some new version of Skiko.
  * If Skiko stops using `picture`, we need to remove it here too.
  */
-@OptIn(InternalComposeUiApi::class)
-fun ComposeScene.mimicSkikoRender(surface: Surface, time: Long, width: Int, height: Int) {
+fun BenchmarkComposeScene.mimicSkikoRender(surface: Surface, time: Long, width: Int, height: Int) {
     val pictureCanvas = pictureRecorder.beginRecording(Rect(0f, 0f, width.toFloat(), height.toFloat()))
     render(pictureCanvas.asComposeCanvas(), time)
     val picture = pictureRecorder.finishRecordingAsPicture()

--- a/benchmarks/multiplatform/compose-scene-api/build.gradle.kts
+++ b/benchmarks/multiplatform/compose-scene-api/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.composeCompiler)
+}
+
+kotlin {
+    jvm("desktop")
+
+    iosArm64()
+    iosSimulatorArm64()
+
+    macosArm64()
+
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmJs()
+
+    js()
+
+    applyDefaultHierarchyTemplate()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.ui)
+                implementation(compose.runtime)
+            }
+        }
+    }
+}

--- a/benchmarks/multiplatform/compose-scene-api/src/commonMain/kotlin/BenchmarkComposeScene.kt
+++ b/benchmarks/multiplatform/compose-scene-api/src/commonMain/kotlin/BenchmarkComposeScene.kt
@@ -1,0 +1,18 @@
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Canvas
+
+/**
+ * An abstraction over Compose internal scene API used by benchmarks.
+ *
+ * Different Compose versions may change the internal API surface
+ * (e.g. [androidx.compose.ui.scene.CanvasLayersComposeScene] or
+ * [androidx.compose.ui.scene.ComposeScene.render]).
+ * Implementations of this interface encapsulate those version-specific
+ * details so the benchmark code depends only on the stable contract
+ * defined here.
+ */
+interface BenchmarkComposeScene {
+    fun setContent(content: @Composable () -> Unit)
+    fun render(canvas: Canvas, nanoTime: Long)
+    fun close()
+}

--- a/benchmarks/multiplatform/compose-scene-impl-1/build.gradle.kts
+++ b/benchmarks/multiplatform/compose-scene-impl-1/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.composeCompiler)
+}
+
+kotlin {
+    jvm("desktop")
+
+    iosArm64()
+    iosSimulatorArm64()
+
+    macosArm64()
+
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmJs()
+
+    js()
+
+    applyDefaultHierarchyTemplate()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":compose-scene-api"))
+                implementation(compose.ui)
+                implementation(compose.runtime)
+            }
+        }
+    }
+}

--- a/benchmarks/multiplatform/compose-scene-impl-1/src/commonMain/kotlin/BenchmarkComposeSceneImpl.kt
+++ b/benchmarks/multiplatform/compose-scene-impl-1/src/commonMain/kotlin/BenchmarkComposeSceneImpl.kt
@@ -1,0 +1,32 @@
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.scene.CanvasLayersComposeScene
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * Implementation of [BenchmarkComposeScene] for Compose Multiplatform versions before
+ * the shared FrameRecomposer PR (compose-multiplatform-core#3012), i.e. ≤ 1.11.x.
+ *
+ * Uses [CanvasLayersComposeScene] and
+ * [androidx.compose.ui.scene.ComposeScene.render] which are internal Compose UI API.
+ */
+@OptIn(InternalComposeUiApi::class)
+class BenchmarkComposeSceneImpl(width: Int, height: Int) : BenchmarkComposeScene {
+    private val scene = CanvasLayersComposeScene(size = IntSize(width, height))
+
+    override fun setContent(content: @Composable () -> Unit) {
+        scene.setContent(content)
+    }
+
+    override fun render(canvas: Canvas, nanoTime: Long) {
+        scene.render(canvas, nanoTime)
+    }
+
+    override fun close() {
+        scene.close()
+    }
+}
+
+fun createBenchmarkComposeScene(width: Int, height: Int): BenchmarkComposeScene =
+    BenchmarkComposeSceneImpl(width, height)

--- a/benchmarks/multiplatform/compose-scene-impl-2/build.gradle.kts
+++ b/benchmarks/multiplatform/compose-scene-impl-2/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.composeCompiler)
+}
+
+kotlin {
+    jvm("desktop")
+
+    iosArm64()
+    iosSimulatorArm64()
+
+    macosArm64()
+
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    wasmJs()
+
+    js()
+
+    applyDefaultHierarchyTemplate()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":compose-scene-api"))
+                implementation(compose.ui)
+                implementation(compose.runtime)
+            }
+        }
+    }
+}

--- a/benchmarks/multiplatform/compose-scene-impl-2/src/commonMain/kotlin/BenchmarkComposeSceneImpl.kt
+++ b/benchmarks/multiplatform/compose-scene-impl-2/src/commonMain/kotlin/BenchmarkComposeSceneImpl.kt
@@ -1,0 +1,42 @@
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.platform.FrameRecomposer
+import androidx.compose.ui.scene.CanvasLayersComposeScene
+import androidx.compose.ui.unit.IntSize
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Implementation of [BenchmarkComposeScene] for Compose Multiplatform versions after
+ * the shared FrameRecomposer PR (compose-multiplatform-core#3012), i.e. ≥ 1.12.0.
+ *
+ * Uses [FrameRecomposer] + [CanvasLayersComposeScene] with explicit
+ * [FrameRecomposer.performFrame], [ComposeScene.measureAndLayout], and [ComposeScene.draw]
+ * phase calls which replaced the old single [ComposeScene.render] method.
+ */
+@OptIn(InternalComposeUiApi::class)
+class BenchmarkComposeSceneImpl(width: Int, height: Int) : BenchmarkComposeScene {
+    private val frameRecomposer = FrameRecomposer(Dispatchers.Unconfined)
+    private val scene = CanvasLayersComposeScene(
+        frameRecomposer = frameRecomposer,
+        size = IntSize(width, height)
+    )
+
+    override fun setContent(content: @Composable () -> Unit) {
+        scene.setContent(content = content)
+    }
+
+    override fun render(canvas: Canvas, nanoTime: Long) {
+        frameRecomposer.performFrame(nanoTime)
+        scene.measureAndLayout()
+        scene.draw(canvas)
+    }
+
+    override fun close() {
+        scene.close()
+        frameRecomposer.close()
+    }
+}
+
+fun createBenchmarkComposeScene(width: Int, height: Int): BenchmarkComposeScene =
+    BenchmarkComposeSceneImpl(width, height)

--- a/benchmarks/multiplatform/settings.gradle.kts
+++ b/benchmarks/multiplatform/settings.gradle.kts
@@ -28,4 +28,97 @@ dependencyResolutionManagement {
     }
 }
 
+include(":compose-scene-api")
+
+/**
+ * Selects the appropriate compose-scene-impl module based on the Compose Multiplatform version.
+ *
+ * - compose-scene-impl-1: for versions before compose-multiplatform-core#3012
+ *   Uses CanvasLayersComposeScene and ComposeScene.render(canvas, nanoTime)
+ *
+ * - compose-scene-impl-2: for versions after compose-multiplatform-core#3012
+ *   Uses FrameRecomposer + ComposeScene.measureAndLayout() + ComposeScene.draw(canvas)
+ *
+ * The breaking change (PR #3012) was introduced between dev builds 4213 and 4221
+ * of 1.12.0-alpha02, so dev builds before dev4221 still use the old API.
+ * 1.12.0-alpha01 also uses the old API (before the PR).
+ *
+ * The selected module is included as ":compose-scene-impl" so that the benchmarks module
+ * always depends on ":compose-scene-impl" regardless of which actual module is used.
+ */
+fun resolveComposeVersion(): String {
+    // Check Gradle property override first, then fall back to libs.versions.toml
+    val override = providers.gradleProperty("compose.version")
+    if (override.isPresent) return override.get()
+
+    val tomlFile = file("gradle/libs.versions.toml")
+    val versionRegex = Regex("""compose-multiplatform\s*=\s*"(.+?)"""")
+    tomlFile.useLines { lines ->
+        for (line in lines) {
+            val match = versionRegex.find(line)
+            if (match != null) return match.groupValues[1]
+        }
+    }
+    error("Could not find compose-multiplatform version in gradle/libs.versions.toml")
+}
+
+fun isAfterPR3012(version: String): Boolean {
+    // Version format examples:
+    //   "1.11.1"
+    //   "1.12.0-alpha01"              (before PR #3012)
+    //   "1.12.0-alpha02+dev4213"      (before PR #3012)
+    //   "1.12.0-alpha02+dev4221"      (after PR #3012)
+    //   "1.12.0-alpha02+dev4236"
+    //   "1.12.0-beta01"
+    //   "1.12.0"
+
+    val parts = version.split(".")
+    if (parts.size < 2) return false
+    val major = parts[0].toIntOrNull() ?: return false
+    val minor = parts[1].toIntOrNull() ?: return false
+
+    // Versions before 1.12 definitely use the old API
+    if (major < 1 || (major == 1 && minor < 12)) return false
+    // Versions after 1.12.x definitely use the new API
+    if (major > 1 || (major == 1 && minor > 12)) return true
+
+    // major == 1, minor == 12: check pre-release tag and dev build number.
+    // The PR #3012 landed between dev4213 and dev4221 of 1.12.0-alpha02.
+    // 1.12.0-alpha01 still uses the old API.
+
+    // Extract pre-release tag (e.g. "alpha01", "alpha02", "beta01") if present
+    val preReleaseRegex = Regex("""-(alpha|beta|rc)(\d+)""")
+    val preReleaseMatch = preReleaseRegex.find(version)
+    if (preReleaseMatch != null) {
+        val preReleaseType = preReleaseMatch.groupValues[1]  // "alpha", "beta", or "rc"
+        val preReleaseNum = preReleaseMatch.groupValues[2].toIntOrNull() ?: 0
+
+        // alpha01 and earlier are before the PR
+        if (preReleaseType == "alpha" && preReleaseNum < 2) return false
+
+        // beta and rc are after the PR
+        if (preReleaseType != "alpha") return true
+
+        // alpha02+: check dev build number
+        val devBuildRegex = Regex("""\+dev(\d+)""")
+        val devMatch = devBuildRegex.find(version)
+        if (devMatch != null) {
+            val devBuild = devMatch.groupValues[1].toIntOrNull() ?: return true
+            return devBuild >= 4221
+        }
+
+        // alpha02 without +devNNNN suffix — released alpha02 includes PR #3012
+        return true
+    }
+
+    // No pre-release tag means a final release (e.g. "1.12.0") — includes PR #3012
+    return true
+}
+
+val composeVersion = resolveComposeVersion()
+val implDir = if (isAfterPR3012(composeVersion)) "compose-scene-impl-2" else "compose-scene-impl-1"
+
+include(":compose-scene-impl")
+project(":compose-scene-impl").projectDir = file(implDir)
+
 include(":benchmarks")

--- a/benchmarks/multiplatform/settings.gradle.kts
+++ b/benchmarks/multiplatform/settings.gradle.kts
@@ -31,6 +31,51 @@ dependencyResolutionManagement {
 include(":compose-scene-api")
 
 /**
+ * Semver version parser, taken from compose-multiplatform-core:
+ * buildSrc/public/src/main/kotlin/androidx/build/Version.kt
+ *
+ * Supports format: major.minor.patch[-preRelease][+buildMetadata]
+ * Examples: "1.11.1", "1.12.0-alpha02+dev4221", "1.12.0-beta01", "1.12.0"
+ */
+data class Version(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+    val preRelease: String? = null,
+    val buildMetadata: String? = null,
+) : Comparable<Version> {
+    override fun compareTo(other: Version) = compareValuesBy(
+        this, other,
+        { it.major },
+        { it.minor },
+        { it.patch },
+        { it.preRelease == null },  // no pre-release (stable) sorts after pre-release
+        { it.preRelease },          // lexicographic ordering (alpha < beta < rc)
+    )
+
+    companion object {
+        // Semver regex from https://semver.org
+        private val SEMVER_REGEX = Regex(
+            """^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)""" +
+            """(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?""" +
+            """(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"""
+        )
+
+        fun parse(versionString: String): Version {
+            val match = SEMVER_REGEX.matchEntire(versionString)
+                ?: error("Cannot parse version: $versionString")
+            return Version(
+                major = match.groupValues[1].toInt(),
+                minor = match.groupValues[2].toInt(),
+                patch = match.groupValues[3].toInt(),
+                preRelease = match.groupValues[4].ifEmpty { null },
+                buildMetadata = match.groupValues[5].ifEmpty { null },
+            )
+        }
+    }
+}
+
+/**
  * Selects the appropriate compose-scene-impl module based on the Compose Multiplatform version.
  *
  * - compose-scene-impl-1: for versions before compose-multiplatform-core#3012
@@ -62,60 +107,21 @@ fun resolveComposeVersion(): String {
     error("Could not find compose-multiplatform version in gradle/libs.versions.toml")
 }
 
-fun isAfterPR3012(version: String): Boolean {
-    // Version format examples:
-    //   "1.11.1"
-    //   "1.12.0-alpha01"              (before PR #3012)
-    //   "1.12.0-alpha02+dev4213"      (before PR #3012)
-    //   "1.12.0-alpha02+dev4221"      (after PR #3012)
-    //   "1.12.0-alpha02+dev4236"
-    //   "1.12.0-beta01"
-    //   "1.12.0"
+// The PR #3012 landed between dev4213 and dev4221 of 1.12.0-alpha02.
+// buildMetadata ("+devNNNN") is not part of semver comparison, so we handle it explicitly.
+val PR_3012_VERSION_BARRIER = Version.parse("1.12.0-alpha02")
+val PR_3012_MIN_DEV_BUILD = 4221
 
-    val parts = version.split(".")
-    if (parts.size < 2) return false
-    val major = parts[0].toIntOrNull() ?: return false
-    val minor = parts[1].toIntOrNull() ?: return false
-
-    // Versions before 1.12 definitely use the old API
-    if (major < 1 || (major == 1 && minor < 12)) return false
-    // Versions after 1.12.x definitely use the new API
-    if (major > 1 || (major == 1 && minor > 12)) return true
-
-    // major == 1, minor == 12: check pre-release tag and dev build number.
-    // The PR #3012 landed between dev4213 and dev4221 of 1.12.0-alpha02.
-    // 1.12.0-alpha01 still uses the old API.
-
-    // Extract pre-release tag (e.g. "alpha01", "alpha02", "beta01") if present
-    val preReleaseRegex = Regex("""-(alpha|beta|rc)(\d+)""")
-    val preReleaseMatch = preReleaseRegex.find(version)
-    if (preReleaseMatch != null) {
-        val preReleaseType = preReleaseMatch.groupValues[1]  // "alpha", "beta", or "rc"
-        val preReleaseNum = preReleaseMatch.groupValues[2].toIntOrNull() ?: 0
-
-        // alpha01 and earlier are before the PR
-        if (preReleaseType == "alpha" && preReleaseNum < 2) return false
-
-        // beta and rc are after the PR
-        if (preReleaseType != "alpha") return true
-
-        // alpha02+: check dev build number
-        val devBuildRegex = Regex("""\+dev(\d+)""")
-        val devMatch = devBuildRegex.find(version)
-        if (devMatch != null) {
-            val devBuild = devMatch.groupValues[1].toIntOrNull() ?: return true
-            return devBuild >= 4221
-        }
-
-        // alpha02 without +devNNNN suffix — released alpha02 includes PR #3012
-        return true
-    }
-
-    // No pre-release tag means a final release (e.g. "1.12.0") — includes PR #3012
-    return true
+fun isAfterPR3012(version: Version): Boolean {
+    if (version > PR_3012_VERSION_BARRIER) return true
+    if (version < PR_3012_VERSION_BARRIER) return false
+    // Exact match on 1.12.0-alpha02: check dev build number
+    val devBuild = version.buildMetadata?.removePrefix("dev")?.toIntOrNull()
+    // No +devNNNN suffix means released alpha02 which includes PR #3012
+    return devBuild == null || devBuild >= PR_3012_MIN_DEV_BUILD
 }
 
-val composeVersion = resolveComposeVersion()
+val composeVersion = Version.parse(resolveComposeVersion())
 val implDir = if (isAfterPR3012(composeVersion)) "compose-scene-impl-2" else "compose-scene-impl-1"
 
 include(":compose-scene-impl")


### PR DESCRIPTION
Benchmarks used internal Compose UI API (`CanvasLayersComposeScene`,
`ComposeScene.render`) directly in `MeasureComposable.kt`, which broke
when [compose-multiplatform-core#3012](https://github.com/JetBrains/compose-multiplatform-core/pull/3012) replaced the single `render()`
method with `FrameRecomposer` + `measureAndLayout()` + `draw()` phases.

Introduce a versioned abstraction layer:

- `:compose-scene-api` — BenchmarkComposeScene interface (`setContent`,
  `render`, `close`) depending only on public Compose API.
- `:compose-scene-impl-1` — implementation for Compose versions before
  PR [compose-multiplatform-core#3012](https://github.com/JetBrains/compose-multiplatform-core/pull/3012) (≤1.11.x, `1.12.0-alpha01`, `alpha02` dev builds <4221),
  using ComposeScene.render(canvas, nanoTime).
- `:compose-scene-impl-2` — implementation for Compose versions after
  PR [compose-multiplatform-core#3012](https://github.com/JetBrains/compose-multiplatform-core/pull/3012) (`1.12.0-alpha02+dev4221+`), using `FrameRecomposer` with
  `performFrame()`, `measureAndLayout()`, and `draw()`.

The correct impl module is auto-selected in `settings.gradle.kts`
based on the Compose version (from `libs.versions.toml` or
`-Pcompose.version`), and mapped as `:compose-scene-impl` so
`MeasureComposable.kt` uses only the stable `BenchmarkComposeScene`
interface without any `@InternalComposeUiApi` usage.


Fixes [CMP-10298](https://youtrack.jetbrains.com/issue/CMP-10298)

## Testing
Tested manually.

## Release Notes
N/A