### PR TITLE
Bump CHR version to 1.2.0-beta01

### DIFF
--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ plugin-android = "8.10.1"
 shadow-jar = "9.1.0"
 publish-plugin = "1.2.1"
 # we use "prefer" here for the strategy: "explicitly specified hot reload plugin always wins".
-plugin-hot-reload = { prefer = "1.2.0-alpha02" }
+plugin-hot-reload = { prefer = "1.2.0-beta01" }
 
 [libraries]
 download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }


### PR DESCRIPTION
Fixes [CMP-10379](https://youtrack.jetbrains.com/issue/CMP-10379)

## Release Notes
### Features - Desktop
- _(prerelease fix)_ Bump Compose Hot Reload to [1.2.0-beta01](https://github.com/JetBrains/compose-hot-reload/releases/tag/v1.2.0-beta01)