### PR TITLE
Fix CMP-6819 by properly setting previousDrawSize

### DIFF
--- a/components/resources/library/src/desktopTest/kotlin/org/jetbrains/compose/resources/SvgPainterTest.kt
+++ b/components/resources/library/src/desktopTest/kotlin/org/jetbrains/compose/resources/SvgPainterTest.kt
@@ -1,0 +1,79 @@
+package org.jetbrains.compose.resources
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class SvgPainterTest {
+
+    @Test
+    fun svgPainterCachesByDrawSizeWithSizeAndScaleModifiers() = clearResourceCachesAndRunUiTest {
+        val imageSize = mutableStateOf(24.dp)
+        val imageScale = mutableStateOf(1f)
+        lateinit var painter: SvgPainter
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                painter = remember { testSvgPainter() }
+                Image(
+                    painter = painter,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(imageSize.value)
+                        .scale(imageScale.value)
+                )
+            }
+        }
+
+        waitForIdle()
+        assertEquals(
+            expected = Size(24f, 24f),
+            actual = painter.currentDrawSize
+        )
+
+        imageScale.value = 2f
+        waitForIdle()
+        assertEquals(
+            expected = Size(24f, 24f),
+            actual = painter.currentDrawSize
+        )
+
+        imageScale.value = 1f
+        imageSize.value = 48.dp
+        waitForIdle()
+        assertEquals(
+            expected = Size(48f, 48f),
+            actual = painter.currentDrawSize
+        )
+
+        imageScale.value = 0.5f
+        waitForIdle()
+        assertEquals(
+            expected = Size(48f, 48f),
+            actual = painter.currentDrawSize
+        )
+    }
+
+    private fun testSvgPainter(): SvgPainter =
+        TestSvg.encodeToByteArray().decodeToSvgPainter(Density(1f)) as SvgPainter
+
+    private companion object {
+        private val TestSvg = """
+            <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+                <rect width="24" height="24" fill="red"/>
+            </svg>
+        """.trimIndent()
+    }
+}

--- a/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/SvgPainter.kt
+++ b/components/resources/library/src/skikoMain/kotlin/org/jetbrains/compose/resources/SvgPainter.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.compose.resources
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.graphics.ColorFilter
@@ -48,7 +49,10 @@ internal class SvgPainter(
         }
     }
 
-    private var previousDrawSize: Size = Size.Unspecified
+    private var cachedDrawSize: Size = Size.Unspecified
+    @VisibleForTesting
+    internal val currentDrawSize: Size get() = cachedDrawSize
+
     private var alpha: Float = 1.0f
     private var colorFilter: ColorFilter? = null
 
@@ -66,7 +70,7 @@ internal class SvgPainter(
     }
 
     override fun DrawScope.onDraw() {
-        if (previousDrawSize != size) {
+        if (cachedDrawSize != size) {
             drawCache.drawCachedImage(
                 ImageBitmapConfig.Argb8888,
                 IntSize(ceil(size.width).toInt(), ceil(size.height).toInt()),
@@ -75,6 +79,7 @@ internal class SvgPainter(
             ) {
                 drawSvg(size)
             }
+            cachedDrawSize = size
         }
 
         drawCache.drawInto(this, alpha, colorFilter)


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-6819/Too-much-rendering-in-SvgPainter

The SvgPainter was supposed to be caching the rasterised SVGs, but it failed to properly update the size it was rasterised at. As a result, the cached bitmap was never used even if the size had not changed.

This fixes it by saving the cached draw size, so that it can actually be reused as it was originally intended. It also adds a test that verifies the behaviour with the size and scale modifiers is correct.

Fixes CMP-6819

## Testing
Added test as per above.

## Release Notes
### Fixes - Desktop
- Fixed SVG rasterization caching to properly reuse cached bitmap unless size changes.
