### PR TITLE
Add duplicatesStrategy to unpackSkikoRuntimeFor

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -13,6 +13,7 @@ import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.artifacts.UnresolvedDependency
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.Usage
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Input
@@ -61,6 +62,7 @@ private fun configureSkikoWebRuntime(
 
     val unpackRuntime = project.registerTask<Copy>("unpackSkikoRuntimeFor$titledTargetName") {
         destinationDir = project.file(unpackedRuntimeDir)
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         from(
             skikoWebRuntimeJarFiles.map { artifact -> project.zipTree(artifact) }
         )


### PR DESCRIPTION
Additional unpacking of skiko skottie module web runtime jars makes the `unpackSkikoRuntimeForJs` fail because of duplicate `META-INF/MANIFEST.MF` entry. This PR adds a `duplicatesStrategy` to fix it

Full error:
```
Execution failed for task ':webApp:unpackSkikoRuntimeForJs'.
> Entry META-INF/MANIFEST.MF is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/9.1.0/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
```

## Release Notes
N/A