### PR TITLE
Fix "Desktop release build fails with VerifyError: Bad return type"

### DIFF
--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -64,7 +64,9 @@
 -dontwarn org.graalvm.compiler.core.aarch64.AArch64NodeMatchRules_MatchStatementSet*
 
 # Androidx
--keep,allowshrinking,allowobfuscation class androidx.compose.runtime.SnapshotStateKt__DerivedStateKt { *; }
+# Prevent ProGuard from specializing return types of @JvmMultifileClass implementation classes
+# https://github.com/Guardsquare/proguard/issues/533
+-keep,allowshrinking,allowobfuscation class **Kt__* { *; }
 -keep class androidx.compose.material3.SliderDefaults { *; }
 -dontnote androidx.**
 

--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -64,6 +64,7 @@
 -dontwarn org.graalvm.compiler.core.aarch64.AArch64NodeMatchRules_MatchStatementSet*
 
 # Androidx
+# TODO https://youtrack.jetbrains.com/issue/CMP-10503/Revert-ProGuard-rule-for-JvmMultifileClass
 # Prevent ProGuard from specializing return types of @JvmMultifileClass implementation classes
 # https://github.com/Guardsquare/proguard/issues/533
 -keep,allowshrinking,allowobfuscation class **Kt__* { *; }

--- a/gradle-plugins/compose/src/test/test-projects/application/proguard/src/main/kotlin/Main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/proguard/src/main/kotlin/Main.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.material3.Text
 import androidx.compose.ui.renderComposeScene
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
@@ -39,6 +40,9 @@ object Main {
         workingDir.resolve("main-methods.actual.txt").writeText(mainMethods)
 
         serializer()
+
+        // https://youtrack.jetbrains.com/issue/CMP-10488/Desktop-release-build-fails-with-VerifyError-Bad-return-type
+        renderComposeScene(height = 10, width = 200) { Text("internals with JvmMultifileClass") }
     }
 
     @Composable


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10488/Desktop-release-build-fails-with-VerifyError-Bad-return-type

## Testing
The proguard test passes with the new fix

## Release Notes
### Fixes - Desktop
- _(prelease fix)_ Fix "Desktop release build fails with VerifyError: Bad return type"