### PR TITLE
Exclude incompatible Windows-Gradle-AGP matrix combination

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -19,6 +19,11 @@ jobs:
         os: ['ubuntu-24.04', 'macos-26-xlarge', 'windows-2022']
         gradle: ['9.3.1', '9.5.0']
         agp: ['9.1.1', '9.2.0']
+        # muted due https://youtrack.jetbrains.com/issue/KT-82693
+        exclude:
+          - os: 'windows-2022'
+            gradle: '9.5.0'
+            agp: '9.1.1'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Exclude incompatible Windows-Gradle-AGP matrix combination in Gradle …plugin workflow due to [KT-82693](https://youtrack.jetbrains.com/issue/KT-82693)

## Release Notes
N/A