### PR TITLE
Run full Gradle checks

### DIFF
--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -60,9 +60,14 @@ jobs:
 
       - name: Print summary
         shell: bash
-        working-directory: gradle-plugins/compose/build/test-summary
+        working-directory: gradle-plugins
         if: always()
         run: |
+          if [[ ! -d compose/build/test-summary ]]; then
+            exit 0
+          fi
+
+          cd compose/build/test-summary
           for SUMMARY_FILE in `find . -name "*.md"`; do
             FILE_NAME=`basename $SUMMARY_FILE`
             echo "## $FILE_NAME" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/gradle-plugin.yml
+++ b/.github/workflows/gradle-plugin.yml
@@ -54,8 +54,7 @@ jobs:
         shell: bash
         working-directory: gradle-plugins
         run: |
-          ./gradlew assemble
-          ./gradlew --continue :preview-rpc:test :compose:test ':compose:test-Gradle(${{ matrix.gradle }})-Agp(${{ matrix.agp }})'
+          ./gradlew check -Pcompose.tests.gradle.versions=${{ matrix.gradle }} -Pcompose.tests.agp.versions=${{ matrix.agp }}
 
       - name: Upload Reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
GitHub checks miss validation issues because they don't call `validatePlugins`:
```
Configuration cache entry stored.
Execution failed for task ':compose:validatePlugins' (registered by plugin 'org.gradle.java-gradle-plugin').
> Plugin validation failed with 1 problem:
    - Error: Type 'org.jetbrains.compose.desktop.application.tasks.AbstractCreateAotArchiveTask' property 'dependencyFiles$compose' is annotated with @InputFiles but missing a normalization strategy.
```
(The fix in https://github.com/JetBrains/compose-multiplatform/pull/5657)
## Release Notes
N/A
