### PR TITLE
Proguard - exclude notes for Kt__ classes

### DIFF
--- a/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+++ b/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
@@ -1,6 +1,10 @@
+# Kotlin
 -keep class kotlin.** { *; }
+
+# Skiko
 -keep class org.jetbrains.skia.** { *; }
 -keep class org.jetbrains.skiko.** { *; }
+-dontnote org.jetbrains.skiko.swing.JbrSharedTexturesAdapter
 
 -assumenosideeffects public class androidx.compose.runtime.ComposerKt {
     void sourceInformation(androidx.compose.runtime.Composer,java.lang.String);
@@ -64,10 +68,13 @@
 -dontwarn org.graalvm.compiler.core.aarch64.AArch64NodeMatchRules_MatchStatementSet*
 
 # Androidx
+
 # TODO https://youtrack.jetbrains.com/issue/CMP-10503/Revert-ProGuard-rule-for-JvmMultifileClass
 # Prevent ProGuard from specializing return types of @JvmMultifileClass implementation classes
 # https://github.com/Guardsquare/proguard/issues/533
 -keep,allowshrinking,allowobfuscation class **Kt__* { *; }
+-dontnote **Kt__*
+
 -keep class androidx.compose.material3.SliderDefaults { *; }
 -dontnote androidx.**
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -137,9 +137,34 @@ class DesktopApplicationTest : GradlePluginTestBase() {
             }
         }
 
+        fun checkNoUnexpectedProguardDiagnostics(log: String) {
+            // TODO https://youtrack.jetbrains.com/issue/CMP-7778/Fix-Proguard-note-Note-duplicate-definition-of-resource-file-META-INF-MANIFEST.MF
+            val expectedNotes = setOf(
+                "Note: duplicate definition of resource file [META-INF/MANIFEST.MF]",
+                "Note: duplicate definition of resource file [META-INF/androidx/navigationevent/navigationevent-compose/LICENSE.txt]",
+                "Note: duplicate definition of resource file [META-INF/lifecycle-runtime-compose.kotlin_module]",
+                "Note: duplicate definition of resource file [META-INF/navigationevent-compose.kotlin_module]",
+                "Note: duplicate definition of resource file [META-INF/runtime-saveable.kotlin_module]",
+                "Note: duplicate definition of resource file [META-INF/runtime.kotlin_module]",
+                "Note: duplicate definition of resource file [META-INF/savedstate-compose.kotlin_module]",
+            )
+            val expectedNotePatterns = listOf(
+                Regex("""Note: there were \d+ duplicate class definitions\."""),
+            )
+            val unexpectedDiagnostics = log.lineSequence()
+                .filter { it.startsWith("Warning:") || it.startsWith("Note:") }
+                .filterNot { diagnostic ->
+                    diagnostic in expectedNotes || expectedNotePatterns.any { it.matches(diagnostic) }
+                }
+                .toList()
+
+            assertEquals(emptyList<String>(), unexpectedDiagnostics, "Unexpected ProGuard diagnostics")
+        }
+
         checkImageBeforeBuild()
         gradle(":runReleaseDistributable").checks {
             check.taskSuccessful(":proguardReleaseJars")
+            checkNoUnexpectedProguardDiagnostics(check.log)
             checkImageAfterBuild()
             assertEqualTextFiles(file("main-methods.actual.txt"), file("main-methods.expected.txt"))
         }
@@ -149,6 +174,7 @@ class DesktopApplicationTest : GradlePluginTestBase() {
         checkImageBeforeBuild()
         gradle(":runReleaseDistributable").checks {
             check.taskSuccessful(":proguardReleaseJars")
+            checkNoUnexpectedProguardDiagnostics(check.log)
             checkImageAfterBuild()
             assertNotEqualTextFiles(file("main-methods.actual.txt"), file("main-methods.expected.txt"))
         }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10488/Desktop-release-build-fails-with-VerifyError-Bad-return-type

Regression is added in https://github.com/JetBrains/compose-multiplatform/pull/5652

## Release Notes
N/A