### PR TITLE
Add Compose Resources consumer R8 rule

### DIFF
--- a/components/resources/demo/androidApp/build.gradle.kts
+++ b/components/resources/demo/androidApp/build.gradle.kts
@@ -14,6 +14,12 @@ android {
         versionCode = 1
         versionName = "1.0"
     }
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            setProguardFiles(files("proguard-rules.pro"))
+        }
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/components/resources/demo/androidApp/proguard-rules.pro
+++ b/components/resources/demo/androidApp/proguard-rules.pro
@@ -1,0 +1,3 @@
+# AndroidX Window references optional OEM extension and legacy sidecar APIs.
+-dontwarn androidx.window.extensions.**
+-dontwarn androidx.window.sidecar.**

--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -23,6 +23,13 @@ kotlin {
 
         androidResources.enable = true
 
+        optimization {
+            consumerKeepRules.apply {
+                publish = true
+                file("consumer-rules.pro")
+            }
+        }
+
         withHostTest {
             isIncludeAndroidResources = true
         }

--- a/components/resources/library/consumer-rules.pro
+++ b/components/resources/library/consumer-rules.pro
@@ -1,0 +1,3 @@
+# Android Test Monitor is a compile-only dependency used when an instrumentation context exists.
+# The resource reader handles its absence at runtime.
+-dontwarn androidx.test.platform.app.InstrumentationRegistry


### PR DESCRIPTION
Add a consumer R8 rule for the optional Android Test Monitor reference in Compose Resources.

The Android artifact declares Android Test Monitor as a compile-only dependency, and the resource reader already handles its absence at runtime by catching `NoClassDefFoundError`. Without a consumer rule, applications that replace AGP's default ProGuard files can fail because `InstrumentationRegistry` is unavailable.

This change also enables minification for the Resources Android demo. The demo uses a dedicated ProGuard file because AGP's default rules suppress all `androidx.**` warnings. Unrelated optional AndroidX Window APIs are ignored so the build specifically verifies the Compose Resources consumer rule.

Fixes https://youtrack.jetbrains.com/issue/CMP-7875

## Testing

- Confirmed `:resources:demo:androidApp:minifyReleaseWithR8` fails with the missing `InstrumentationRegistry` class before the change and succeeds afterward.
- Ran `./gradlew :resources:library:assembleRelease :resources:demo:androidApp:assembleRelease -Pcompose.version=1.11.1`.
- Verified that the generated AAR contains the consumer rule in `proguard.txt`.
- Verified with an independent AGP 9.3 / Gradle 9.6.1 consumer project that R8 fails before the change and succeeds with the updated AAR.

## Release Notes
### Fixes - Resources
- Fix R8 release builds failing because the optional Android test instrumentation API is unavailable.
