### PR TITLE
Update currentOs deprecation warning

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -132,11 +132,7 @@ abstract class ComposePlugin : Plugin<Project> {
         @Deprecated("Specify dependency directly", replaceWith = ReplaceWith("\"org.jetbrains.compose.ui:ui-test-junit4:${ComposeBuildConfig.composeVersion}\""))
         val uiTestJUnit4 get() = composeDependency("org.jetbrains.compose.ui:ui-test-junit4")
 
-        @Deprecated(
-            "Use org.jetbrains.compose.desktop:desktop-jvm-all instead. " +
-                "It works for every desktop OS; packaging drops unrelated OS binaries.",
-            replaceWith = ReplaceWith("\"org.jetbrains.compose.desktop:desktop-jvm-all:${ComposeBuildConfig.composeVersion}\"")
-        )
+        @Deprecated("currentOs is deprecated and will be removed in next releases.")
         val currentOs by lazy {
             composeDependency("org.jetbrains.compose.desktop:desktop-jvm-${currentTarget.id}")
         }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -132,7 +132,12 @@ abstract class ComposePlugin : Plugin<Project> {
         @Deprecated("Specify dependency directly", replaceWith = ReplaceWith("\"org.jetbrains.compose.ui:ui-test-junit4:${ComposeBuildConfig.composeVersion}\""))
         val uiTestJUnit4 get() = composeDependency("org.jetbrains.compose.ui:ui-test-junit4")
 
-        @Deprecated("currentOs is deprecated and will be removed in next releases.")
+        @Deprecated(
+            "currentOs is deprecated and will be removed in a future release. " +
+                    "It has no replacement and can be safely removed. " +
+                    "Compose now publishes an artifact containing binaries for all supported desktop operating systems. " +
+                    "During packaging, binaries for non-target operating systems are automatically removed."
+        )
         val currentOs by lazy {
             composeDependency("org.jetbrains.compose.desktop:desktop-jvm-${currentTarget.id}")
         }


### PR DESCRIPTION
This PR updates the deprecation warning for `currentOs` as the `desktop-jvm-all` artifact will no longer exist. Instead, `ui-skiko` will provide the Skiko runtime fat jar. As a result, the deprecation message should only communicate that `currentOs` is going to be removed

## Release Notes
N/A