### PR TITLE
Benchmarks: use cache-redirector for Google Maven repository

### DIFF
--- a/benchmarks/multiplatform/benchmarks/build.gradle.kts
+++ b/benchmarks/multiplatform/benchmarks/build.gradle.kts
@@ -15,7 +15,9 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenLocal()
-    google()
+    google {
+        url = uri("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2")
+    }
     mavenCentral {
         url = uri("https://cache-redirector.jetbrains.com/maven-central")
     }

--- a/benchmarks/multiplatform/build.gradle.kts
+++ b/benchmarks/multiplatform/build.gradle.kts
@@ -11,7 +11,9 @@ plugins {
 
 allprojects {
     repositories {
-        google()
+        google {
+            url = uri("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2")
+        }
         mavenCentral {
             url = uri("https://cache-redirector.jetbrains.com/maven-central")
         }

--- a/benchmarks/multiplatform/settings.gradle.kts
+++ b/benchmarks/multiplatform/settings.gradle.kts
@@ -6,7 +6,9 @@ pluginManagement {
         }
         gradlePluginPortal()
         maven("https://packages.jetbrains.team/maven/p/cmp/dev")
-        google()
+        google {
+            url = uri("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2")
+        }
     }
 }
 


### PR DESCRIPTION
Use JetBrains cache-redirector to stabilize CI execution

## Testing
CI testing

## Release Notes
N/A
