### PR TITLE
[cherry-pick] Bump CHR version to 1.2.0

### DIFF
--- a/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle-plugins/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ plugin-android = "8.10.1"
 shadow-jar = "9.1.0"
 publish-plugin = "1.2.1"
 # we use "prefer" here for the strategy: "explicitly specified hot reload plugin always wins".
-plugin-hot-reload = { prefer = "1.2.0-rc01" }
+plugin-hot-reload = { prefer = "1.2.0" }
 
 [libraries]
 download-task = { module = "de.undercouch:gradle-download-task", version.ref = "gradle-download-plugin" }


### PR DESCRIPTION
Fixes: [CMP-10563](https://youtrack.jetbrains.com/issue/CMP-10563)

## Release Notes
### Highlights - Desktop
- MCP server was introduced for Compose Hot Reload that enables AI agents to interact with a running Compose application in real time

### Features - Desktop
- Update bundled Compose Hot Reload version to [1.2.0](https://github.com/JetBrains/compose-hot-reload/releases/tag/v1.2.0)