### PR TITLE
Benchmarks: set the order of the plugin reporsitories

### DIFF
--- a/benchmarks/multiplatform/settings.gradle.kts
+++ b/benchmarks/multiplatform/settings.gradle.kts
@@ -1,14 +1,20 @@
+@file:Suppress("UnstableApiUsage")
+
 pluginManagement {
     repositories {
         mavenLocal()
+        google {
+            url = uri("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2")
+            content {
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("androidx")
+            }
+        }
         mavenCentral {
             url = uri("https://cache-redirector.jetbrains.com/maven-central")
         }
         gradlePluginPortal()
         maven("https://packages.jetbrains.team/maven/p/cmp/dev")
-        google {
-            url = uri("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2")
-        }
     }
 }
 


### PR DESCRIPTION
Google repository should go before the Maven Central and Gradle and include only the necessary groups for Android Gradle Plugin.
Otherwise Gradle fails to resolve the plugin and dependencies, not searching it in Google's repositories. 

## Testing
Performance CI automated  testing 

## Release Notes
N/A