### PR TITLE
Resources: read resources on an interrupted thread without a crash

### DIFF
--- a/components/resources/library/src/blockingMain/kotlin/org/jetbrains/compose/resources/ResourceState.blocking.kt
+++ b/components/resources/library/src/blockingMain/kotlin/org/jetbrains/compose/resources/ResourceState.blocking.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.compose.resources
 
 import androidx.compose.runtime.*
-import kotlinx.coroutines.runBlocking
 
 @Composable
 internal actual fun <T> rememberResourceState(
@@ -12,7 +11,7 @@ internal actual fun <T> rememberResourceState(
     val environment = LocalComposeEnvironment.current.rememberEnvironment()
     return remember(key1, environment) {
         mutableStateOf(
-            runBlocking { block(environment) }
+            runResourceBlocking { block(environment) }
         )
     }
 }
@@ -27,7 +26,7 @@ internal actual fun <T> rememberResourceState(
     val environment = LocalComposeEnvironment.current.rememberEnvironment()
     return remember(key1, key2, environment) {
         mutableStateOf(
-            runBlocking { block(environment) }
+            runResourceBlocking { block(environment) }
         )
     }
 }
@@ -43,7 +42,7 @@ internal actual fun <T> rememberResourceState(
     val environment = LocalComposeEnvironment.current.rememberEnvironment()
     return remember(key1, key2, key3, environment) {
         mutableStateOf(
-            runBlocking { block(environment) }
+            runResourceBlocking { block(environment) }
         )
     }
 }
@@ -60,7 +59,24 @@ internal actual fun <T> rememberResourceState(
     val environment = LocalComposeEnvironment.current.rememberEnvironment()
     return remember(key1, key2, key3, key4, environment) {
         mutableStateOf(
-            runBlocking { block(environment) }
+            runResourceBlocking { block(environment) }
         )
     }
 }
+
+/**
+ * Executes the [block] on the current thread and returns its result.
+ *
+ * It is used to read a resource synchronously during a composition
+ * (see [rememberResourceState]).
+ *
+ * Unlike `kotlinx.coroutines.runBlocking` on the JVM it:
+ * - doesn't check the interruption flag of the calling thread, so a resource can be read even
+ *   when somebody has interrupted the thread which performs the composition;
+ * - executes a [block] which doesn't suspend (a cache hit, for example) without parking
+ *   the calling thread at all.
+ *
+ * The [block] must not wait for the calling thread itself: a `withContext(Dispatchers.Main)`
+ * inside a resource reader deadlocks a composition here in the same way as with `runBlocking`.
+ */
+internal expect fun <T> runResourceBlocking(block: suspend () -> T): T

--- a/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceCaches.desktop.kt
+++ b/components/resources/library/src/desktopMain/kotlin/org/jetbrains/compose/resources/ResourceCaches.desktop.kt
@@ -1,7 +1,5 @@
 package org.jetbrains.compose.resources
 
-import kotlinx.coroutines.runBlocking
-
 /**
  * Clears any cached resources maintained internally by the system.
  *
@@ -10,5 +8,5 @@ import kotlinx.coroutines.runBlocking
  */
 @ExperimentalResourceApi
 fun ResourceCaches.clearBlocking() {
-    runBlocking { clear() }
+    runResourceBlocking { clear() }
 }

--- a/components/resources/library/src/desktopTest/kotlin/org/jetbrains/compose/resources/InterruptedThreadResourceTest.kt
+++ b/components/resources/library/src/desktopTest/kotlin/org/jetbrains/compose/resources/InterruptedThreadResourceTest.kt
@@ -1,0 +1,42 @@
+package org.jetbrains.compose.resources
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class InterruptedThreadResourceTest {
+
+    init {
+        getResourceEnvironment = ::getTestEnvironment
+    }
+
+    @AfterTest
+    fun tearDown() {
+        //don't leak the interruption flag into other tests
+        Thread.interrupted()
+    }
+
+    @Test
+    fun testReadStringResourceOnAnInterruptedThread() = clearResourceCachesAndRunUiTest {
+        var str = ""
+        var interruptionFlagKept = false
+
+        setContent {
+            CompositionLocalProvider(LocalComposeEnvironment provides TestComposeEnvironment) {
+                Thread.currentThread().interrupt()
+                str = stringResource(TestStringResource("app_name"))
+                interruptionFlagKept = Thread.interrupted()
+                Text(str)
+            }
+        }
+        waitResources()
+
+        assertEquals("Compose Resources App", str)
+        assertTrue(interruptionFlagKept, "The interruption flag must be kept for its real addressee")
+    }
+}

--- a/components/resources/library/src/jvmAndAndroidMain/kotlin/org/jetbrains/compose/resources/ResourceState.jvmAndAndroid.kt
+++ b/components/resources/library/src/jvmAndAndroidMain/kotlin/org/jetbrains/compose/resources/ResourceState.jvmAndAndroid.kt
@@ -1,0 +1,62 @@
+package org.jetbrains.compose.resources
+
+import java.util.concurrent.locks.LockSupport
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+
+/**
+ * Starts the [block] on the calling thread. A block which doesn't suspend is completely executed
+ * here and its result is returned right away - without any waiting and, unlike `runBlocking`,
+ * without a single check of the interruption flag.
+ *
+ * If the [block] does suspend, the calling thread is parked by a [ResourceAwaiter]
+ * until another thread completes the block.
+ */
+internal actual fun <T> runResourceBlocking(block: suspend () -> T): T {
+    val awaiter = ResourceAwaiter<T>(Thread.currentThread())
+    val result = block.startCoroutineUninterceptedOrReturn(awaiter)
+    if (result !== COROUTINE_SUSPENDED) {
+        @Suppress("UNCHECKED_CAST")
+        return result as T
+    } else {
+        return awaiter.await()
+    }
+}
+
+/**
+ * A completion of a resource loading coroutine which parks the [thread] until a result arrives.
+ *
+ * It waits in [LockSupport.park] because, unlike `Object.wait` and the `runBlocking` loop,
+ * it never throws an `InterruptedException`. But `park` returns immediately while the interruption
+ * flag is set, so the flag is taken away for the time of waiting - otherwise the waiting turns
+ * into a busy spin - and it is given back to its real addressee at the end.
+ */
+private class ResourceAwaiter<T>(
+    private val thread: Thread
+) : Continuation<T> {
+    override val context: CoroutineContext get() = EmptyCoroutineContext
+
+    @Volatile
+    private var result: Result<T>? = null
+
+    override fun resumeWith(result: Result<T>) {
+        this.result = result
+        LockSupport.unpark(thread)
+    }
+
+    fun await(): T {
+        var interrupted = Thread.interrupted()
+        try {
+            while (true) {
+                result?.let { return it.getOrThrow() }
+                LockSupport.park(this)
+                if (Thread.interrupted()) interrupted = true
+            }
+        } finally {
+            if (interrupted) thread.interrupt()
+        }
+    }
+}

--- a/components/resources/library/src/jvmAndAndroidTest/kotlin/org/jetbrains/compose/resources/RunResourceBlockingTest.kt
+++ b/components/resources/library/src/jvmAndAndroidTest/kotlin/org/jetbrains/compose/resources/RunResourceBlockingTest.kt
@@ -1,0 +1,100 @@
+package org.jetbrains.compose.resources
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlin.concurrent.thread
+import kotlin.test.*
+
+class RunResourceBlockingTest {
+
+    @AfterTest
+    fun tearDown() {
+        //don't leak the interruption flag into other tests
+        Thread.interrupted()
+    }
+
+    @Test
+    fun testNullResultOfBlockWithoutSuspension() {
+        assertEquals(null, runResourceBlocking<String?> { null })
+    }
+
+    @Test
+    fun testInterruptedThreadCanReadWithoutSuspension() {
+        Thread.currentThread().interrupt()
+
+        assertEquals("a value", runResourceBlocking { "a value" })
+
+        assertTrue(Thread.interrupted(), "The interruption flag must be kept for its real addressee")
+    }
+
+    @Test
+    fun testInterruptionDuringWaitingIsNotLost() {
+        val callerThread = Thread.currentThread()
+        val handoff = ValueHandoff("a value")
+        //the thread is interrupted when it is already parked inside `runResourceBlocking`
+        handoff.completeWhenCallerIsParked(callerThread, beforeComplete = { callerThread.interrupt() })
+
+        assertEquals("a value", runResourceBlocking { handoff.await() })
+
+        assertTrue(Thread.interrupted(), "The interruption flag must be kept for its real addressee")
+    }
+
+    @Test
+    fun testWithContextInsideTheBlock() {
+        assertEquals("a value", runResourceBlocking { withContext(Dispatchers.Default) { "a value" } })
+    }
+
+    @Test
+    fun testDelayInsideTheBlock() {
+        assertEquals("a value", runResourceBlocking { delay(100); "a value" })
+    }
+
+    @Test
+    fun testExceptionWithoutSuspensionIsRethrown() {
+        val error = assertFailsWith<MissingResourceException> {
+            runResourceBlocking { throw MissingResourceException("1.png") }
+        }
+        assertTrue(error.message.orEmpty().contains("1.png"))
+    }
+
+    @Test
+    fun testExceptionAfterSuspensionIsRethrown() {
+        val handoff = ValueHandoff("a value")
+        handoff.completeWhenCallerIsParked(Thread.currentThread())
+
+        val error = assertFailsWith<MissingResourceException> {
+            runResourceBlocking {
+                handoff.await()
+                throw MissingResourceException("1.png")
+            }
+        }
+        assertTrue(error.message.orEmpty().contains("1.png"))
+    }
+}
+
+/**
+ * Provides a [value] from another thread strictly after the calling thread is parked,
+ * so `runResourceBlocking` is guaranteed to go through its waiting path.
+ */
+private class ValueHandoff<T>(private val value: T) {
+    private val deferred = CompletableDeferred<T>()
+
+    fun completeWhenCallerIsParked(caller: Thread, beforeComplete: () -> Unit = {}) {
+        thread(name = "resource-value-handoff", isDaemon = true) {
+            val deadline = System.nanoTime() + 10L * 1_000_000_000
+            while (caller.state !in PARKED_STATES && System.nanoTime() < deadline) {
+                Thread.yield()
+            }
+            beforeComplete()
+            deferred.complete(value)
+        }
+    }
+
+    suspend fun await(): T = deferred.await()
+
+    private companion object {
+        val PARKED_STATES = setOf(Thread.State.WAITING, Thread.State.TIMED_WAITING)
+    }
+}

--- a/components/resources/library/src/nativeMain/kotlin/org/jetbrains/compose/resources/ResourceState.native.kt
+++ b/components/resources/library/src/nativeMain/kotlin/org/jetbrains/compose/resources/ResourceState.native.kt
@@ -1,0 +1,6 @@
+package org.jetbrains.compose.resources
+
+import kotlinx.coroutines.runBlocking
+
+//there is no thread interruption on native targets, so the standard `runBlocking` is enough here
+internal actual fun <T> runResourceBlocking(block: suspend () -> T): T = runBlocking { block() }


### PR DESCRIPTION
`stringResource` and other composable resource getters bridge a suspend loading function to a synchronous call. `runBlocking` did that bridging, but `BlockingCoroutine.joinBlocking` checks the interruption flag of the calling thread before it checks whether the coroutine is already
completed. So with an interrupted composition thread any access to a Compose resource threw an `InterruptedException` - even a cache hit, whose value was already computed.

Replace `runBlocking` in the blocking `rememberResourceState` with a minimal `runResourceBlocking` bridge:
- a block which doesn't suspend (a cache hit) is executed on the calling thread and returns its result directly, without any parking and without touching the interruption flag at all;
- if the block really suspends, the thread waits in `LockSupport.park`, which never throws an `InterruptedException`. The flag is taken away for the time of waiting, otherwise `park` returns immediately and the wait turns into a busy spin, and it is given back to its real addressee afterwards.

Native targets keep `runBlocking` - there is no thread interruption there. `ResourceCaches.clearBlocking` on desktop uses the new bridge too.

Fixes https://youtrack.jetbrains.com/issue/CMP-6615

## Testing
New unit tests

## Release Notes
### Fixes - Android
- Fixed rare `InterruptedException` crashes when reading resources during composition on an interrupted thread.
