### PR TITLE
Update Compose version and remove desktop-jvm-all dependencies

### DIFF
--- a/components/AnimatedImage/demo/build.gradle.kts
+++ b/components/AnimatedImage/demo/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
             }
         }
         jvmMain.dependencies {
-            implementation(libs.compose.desktop.jvm)
+            implementation(libs.compose.material3)
             implementation(project(":AnimatedImage:library"))
         }
     }

--- a/components/AnimatedImage/demo/src/jvmMain/kotlin/org/jetbrains/compose/animatedimage/demo/Main.kt
+++ b/components/AnimatedImage/demo/src/jvmMain/kotlin/org/jetbrains/compose/animatedimage/demo/Main.kt
@@ -3,8 +3,8 @@ package org.jetbrains.compose.animatedimage.demo
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Text
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue

--- a/components/SplitPane/demo/build.gradle.kts
+++ b/components/SplitPane/demo/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
         }
 
         jvmMain.dependencies {
-            implementation(libs.compose.desktop.jvm)
+            implementation(libs.compose.material3)
             implementation(project(":SplitPane:library"))
         }
     }

--- a/components/SplitPane/demo/src/jvmMain/kotlin/org/jetbrains/compose/splitpane/demo/Main.kt
+++ b/components/SplitPane/demo/src/jvmMain/kotlin/org/jetbrains/compose/splitpane/demo/Main.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.Button
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedTextField
-import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -91,7 +91,7 @@ fun main() = singleWindowApplication(
                             Modifier
                                 .width(1.dp)
                                 .fillMaxHeight()
-                                .background(MaterialTheme.colors.background)
+                                .background(MaterialTheme.colorScheme.background)
                         )
                     }
                     handle {

--- a/components/gradle.properties
+++ b/components/gradle.properties
@@ -9,7 +9,7 @@ android.useAndroidX=true
 #Versions
 kotlin.version=2.3.20
 agp.version=9.1.1
-compose.version=1.12.10-alpha01+dev4472
+compose.version=1.12.10-alpha01+dev4564
 deploy.version=9999.0.0-SNAPSHOT
 
 #Compose

--- a/components/gradle/libs.versions.toml
+++ b/components/gradle/libs.versions.toml
@@ -26,7 +26,6 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-desktop = { module = "org.jetbrains.compose.desktop:desktop", version.ref = "compose" }
-compose-desktop-jvm = { module = "org.jetbrains.compose.desktop:desktop-jvm-all", version.ref = "compose" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
 compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose" }
 compose-material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version = "1.7.3" }

--- a/components/resources/demo/desktopApp/build.gradle.kts
+++ b/components/resources/demo/desktopApp/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
     jvm()
     sourceSets {
         jvmMain.dependencies {
-            implementation(libs.compose.desktop.jvm)
+            implementation(libs.compose.material3)
             implementation(project(":resources:demo:shared"))
         }
     }

--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -124,9 +124,6 @@ kotlin {
         val desktopTest by getting {
             dependsOn(skikoTest)
             dependsOn(jvmAndAndroidTest)
-            dependencies {
-                implementation(libs.compose.desktop.jvm)
-            }
         }
         val androidMain by getting {
             dependsOn(jvmAndAndroidMain)

--- a/components/ui-tooling-preview/demo/desktopApp/build.gradle.kts
+++ b/components/ui-tooling-preview/demo/desktopApp/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
     jvm()
     sourceSets {
         jvmMain.dependencies {
-            implementation(libs.compose.desktop.jvm)
+            implementation(libs.compose.material3)
             implementation(project(":ui-tooling-preview:demo:shared"))
         }
     }

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -8,7 +8,7 @@ kotlin.code.style=official
 dev.junit.parallel=false
 
 # Default version of Compose Libraries used by Gradle plugin
-compose.version=1.12.10-alpha01+dev4472
+compose.version=1.12.10-alpha01+dev4564
 compose.material3.version=1.9.0
 # The latest version of Kotlin compatible with compose.tests.compiler.version. Used only in tests/CI.
 compose.tests.kotlin.version=2.3.20


### PR DESCRIPTION
`desktop-jvm-all `no longer exists as the Skiko runtime is now pulled transitively through `ui-skiko`

## Release Notes
N/A