### PR TITLE
Revert dependency compose.desktop.currentOs

### DIFF
--- a/components/AnimatedImage/demo/build.gradle.kts
+++ b/components/AnimatedImage/demo/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
             }
         }
         jvmMain.dependencies {
-            implementation(libs.compose.desktop.jvm)
+            implementation(compose.desktop.currentOs)
             implementation(project(":AnimatedImage:library"))
         }
     }

--- a/components/SplitPane/demo/build.gradle.kts
+++ b/components/SplitPane/demo/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
         }
 
         jvmMain.dependencies {
-            implementation(libs.compose.desktop.jvm)
+            implementation(compose.desktop.currentOs)
             implementation(project(":SplitPane:library"))
         }
     }

--- a/components/gradle/libs.versions.toml
+++ b/components/gradle/libs.versions.toml
@@ -26,7 +26,6 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-desktop = { module = "org.jetbrains.compose.desktop:desktop", version.ref = "compose" }
-compose-desktop-jvm = { module = "org.jetbrains.compose.desktop:desktop-jvm-all", version.ref = "compose" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
 compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose" }
 compose-material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version = "1.7.3" }

--- a/components/resources/demo/desktopApp/build.gradle.kts
+++ b/components/resources/demo/desktopApp/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
     jvm()
     sourceSets {
         jvmMain.dependencies {
-            implementation(libs.compose.desktop.jvm)
+            implementation(compose.desktop.currentOs)
             implementation(project(":resources:demo:shared"))
         }
     }

--- a/components/resources/library/build.gradle.kts
+++ b/components/resources/library/build.gradle.kts
@@ -125,7 +125,7 @@ kotlin {
             dependsOn(skikoTest)
             dependsOn(jvmAndAndroidTest)
             dependencies {
-                implementation(libs.compose.desktop.jvm)
+                implementation(compose.desktop.currentOs)
             }
         }
         val androidMain by getting {

--- a/components/ui-tooling-preview/demo/desktopApp/build.gradle.kts
+++ b/components/ui-tooling-preview/demo/desktopApp/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
     jvm()
     sourceSets {
         jvmMain.dependencies {
-            implementation(libs.compose.desktop.jvm)
+            implementation(compose.desktop.currentOs)
             implementation(project(":ui-tooling-preview:demo:shared"))
         }
     }


### PR DESCRIPTION
The https://github.com/JetBrains/compose-multiplatform/pull/5679 is blocked by:
```
ld: warning: ignoring duplicate libraries: '-lc++', '-ldl', '-lobjc'
ld: warning: search path '/Applications/Xcode_26.2_Universal.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator' not found
ld: library 'swiftCompatibility51' not found
```

For a quick fix, this PR just reverts to using `compose.desktop.currentOs` until the issue is fixed.

## Release Notes
N/A