### PR TITLE
Fix `skikoWebRuntime` resolve in a configuration phase when `whenTaskAdded` is used.

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/web/internal/configureWebApplication.kt
@@ -58,14 +58,15 @@ private fun configureSkikoWebRuntime(
             cont.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, "skiko-runtime"))
         }
     }.files
+    val skikoWebRuntimeFiles = skikoWebRuntimeJarFiles.elements.map {
+        it.map { artifact -> project.zipTree(artifact) }
+    }
     val unpackedRuntimeDir = project.layout.buildDirectory.dir("compose/skiko-${target.name}-runtime")
 
     val unpackRuntime = project.registerTask<Copy>("unpackSkikoRuntimeFor$titledTargetName") {
         destinationDir = project.file(unpackedRuntimeDir)
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-        from(
-            skikoWebRuntimeJarFiles.map { artifact -> project.zipTree(artifact) }
-        )
+        from(skikoWebRuntimeFiles)
     }
 
     target.compilations.all { compilation ->

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/GradlePluginTest.kt
@@ -192,6 +192,17 @@ class GradlePluginTest : GradlePluginTestBase() {
         }
     }
 
+    //https://youtrack.jetbrains.com/issue/CMP-10608
+    @Test
+    fun testEarlyTaskMaterialization(): Unit = with(testProject("misc/skikoWasm")) {
+        //whenTaskAdded materialize tasks in the configuration phase
+        file("build.gradle").appendText("\ntasks.whenTaskAdded { }")
+
+        gradle("tasks").checks {
+            check.taskSuccessful(":tasks")
+        }
+    }
+
     private fun testConfigureDesktopPreviewImpl(port: Int) {
         check(port > 0) { "Invalid port: $port" }
         with(testProject("misc/jvmPreview")) {


### PR DESCRIPTION
Fix `skikoWebRuntime` resolve in a configuration phase.

Fixes https://youtrack.jetbrains.com/issue/CMP-10608

## Testing
Added a new test for the case.

## Release Notes
N/A
