### PR TITLE
Fix packaging on Linux

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -430,7 +430,7 @@ abstract class AbstractJPackageTask @Inject constructor(
         }
 
         if (targetFormat != TargetFormat.AppImage) {
-            // Args that can only be used when creating an installer
+            // Args that can only be used when creating an installer from an existing app image
             val appImageDir = when {
                 currentOS == OS.MacOS -> appImage.dir("${packageName.get()}.app")
                 else -> appImage.dir(packageName.get())
@@ -438,7 +438,6 @@ abstract class AbstractJPackageTask @Inject constructor(
             cliArg("--app-image", appImageDir)
             cliArg("--install-dir", installationPath)
             cliArg("--license-file", licenseFile)
-            cliArg("--resource-dir", jpackageResources)
 
             val propertyFilesDirJava = propertyFilesDir.ioFile
             fileOperations.clearDirs(propertyFilesDir)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -396,7 +396,7 @@ abstract class AbstractJPackageTask @Inject constructor(
         }
 
         if (targetFormat == TargetFormat.AppImage || appImage.orNull == null) {
-            // Args, that can only be used, when creating an app image or an installer w/o --app-image parameter
+            // Args that can only be used when creating an app image or an installer w/o --app-image parameter
             cliArg("--input", libsDir)
             cliArg("--runtime-image", runtimeImage)
             cliArg("--resource-dir", jpackageResources)
@@ -412,7 +412,6 @@ abstract class AbstractJPackageTask @Inject constructor(
             if (currentOS == OS.Windows) {
                 cliArg("--win-console", winConsole)
             }
-            cliArg("--icon", iconFile)
             launcherArgs.orNull?.forEach {
                 cliArg("--arguments", "'$it'")
             }
@@ -431,9 +430,8 @@ abstract class AbstractJPackageTask @Inject constructor(
         }
 
         if (targetFormat != TargetFormat.AppImage) {
-            // Args, that can only be used, when creating an installer
+            // Args that can only be used when creating an installer
             val appImageDir = when {
-                jvmRuntimeInfo.majorVersion < 18 -> appImage
                 currentOS == OS.MacOS -> appImage.dir("${packageName.get()}.app")
                 else -> appImage.dir(packageName.get())
             }
@@ -497,6 +495,7 @@ abstract class AbstractJPackageTask @Inject constructor(
         cliArg("--verbose", verbose)
 
         cliArg("--name", packageName)
+        cliArg("--icon", iconFile)
         cliArg("--description", packageDescription)
         cliArg("--copyright", packageCopyright)
         cliArg("--app-version", packageVersion)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/osUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/utils/osUtils.kt
@@ -128,6 +128,9 @@ internal object UnixUtils {
     val git: File by lazy {
         File("/usr/bin/git").checkExistingFile()
     }
+    val dpkgDeb: File by lazy {
+        File("/usr/bin/dpkg-deb").checkExistingFile()
+    }
 }
 
 internal fun jvmToolFile(toolName: String, javaHome: Provider<String>): File =

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -672,14 +672,7 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     @Test
     fun testAppCdsNoneOnJdk17() {
         with(aotProject(AotMode.None, javaVendor = JvmVendor.KnownJvmVendor.AMAZON, javaVersion = 17)) {
-//        fun testRunTask(runTask: String) {
-//            gradleFailure(runTask).checks {
-//                check.logContains("AotMode 'AppCdsAuto' is not supported on JDK earlier than 19; current is 17")
-//            }
-//        }
             gradle(":packageReleaseDmg")
-
-//        testRunTask(":runReleaseDistributable")
         }
     }
 
@@ -687,7 +680,7 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     fun testAppCdsAutoFailsOnJdk17() = with(aotProject(AotMode.AppCdsAuto, javaVersion = 17)) {
         fun testRunTask(runTask: String) {
             gradleFailure(runTask).checks {
-                check.logContains("AotMode 'AppCdsAuto' is not supported on JDK earlier than 19; current is 17")
+                check.logContains("AotMode '${AotMode.AppCdsAuto.name}' is not supported on JDK earlier than 19; current is 17")
             }
         }
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -9,6 +9,7 @@ import org.gradle.internal.jvm.inspection.JvmVendor
 import org.jetbrains.compose.desktop.application.dsl.AotMode
 import org.jetbrains.compose.internal.utils.MacUtils
 import org.jetbrains.compose.internal.utils.OS
+import org.jetbrains.compose.internal.utils.UnixUtils
 import org.jetbrains.compose.internal.utils.currentArch
 import org.jetbrains.compose.internal.utils.currentOS
 import org.jetbrains.compose.internal.utils.currentTarget
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.Test
 import java.io.File
 import java.util.*
 import java.util.jar.JarFile
+import kotlin.test.assertTrue
 
 class DesktopApplicationTest : GradlePluginTestBase() {
     @Test
@@ -282,6 +284,15 @@ class DesktopApplicationTest : GradlePluginTestBase() {
             check(possibleNames.any { packageFile.name.equals(it, ignoreCase = true) }) {
                 "Unexpected package name '${packageFile.name}' in $packageDir\n" +
                         "Possible names: ${possibleNames.joinToString(", ") { "'$it'" }}"
+            }
+
+            // Verify the presence of a .desktop file in the .deb
+            val packagedFiles = runProcess(UnixUtils.dpkgDeb, listOf("-c", packageFile.absolutePath))
+                .out
+                .lines()
+            assertTrue("Packaged .deb did not contain .desktop file") {
+                val desktopFile = "$name.desktop"
+                packagedFiles.any { it.contains(desktopFile) }
             }
         } else {
             assertEquals("TestPackage-1.0.0.$ext", packageFile.name, "Unexpected package name")
@@ -655,6 +666,20 @@ class DesktopApplicationTest : GradlePluginTestBase() {
                     .replace("%JAVA_VERSION%", "$javaVersion")
                     .replace("%JVM_VENDOR%", javaVendor.name)
             }
+        }
+    }
+
+    @Test
+    fun testAppCdsNoneOnJdk17() {
+        with(aotProject(AotMode.None, javaVendor = JvmVendor.KnownJvmVendor.AMAZON, javaVersion = 17)) {
+//        fun testRunTask(runTask: String) {
+//            gradleFailure(runTask).checks {
+//                check.logContains("AotMode 'AppCdsAuto' is not supported on JDK earlier than 19; current is 17")
+//            }
+//        }
+            gradle(":packageReleaseDmg")
+
+//        testRunTask(":runReleaseDistributable")
         }
     }
 

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -290,9 +290,8 @@ class DesktopApplicationTest : GradlePluginTestBase() {
             val packagedFiles = runProcess(UnixUtils.dpkgDeb, listOf("-c", packageFile.absolutePath))
                 .out
                 .lines()
-            assertTrue("Packaged .deb did not contain .desktop file") {
-                val desktopFile = "$name.desktop"
-                packagedFiles.any { it.contains(desktopFile) }
+            assertTrue("Packaged .deb did not contain `.desktop` file") {
+                packagedFiles.any { it.endsWith(".desktop") }
             }
         } else {
             assertEquals("TestPackage-1.0.0.$ext", packageFile.name, "Unexpected package name")

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
@@ -53,7 +53,7 @@ private val testJdks = TestProperties
     .testJdksRoot?.let { listTestJdks(it) }.orEmpty()
 
 class TestProject(
-    private val name: String,
+    val name: String,
     private val testEnvironment: TestEnvironment
 ) {
     private val testProjectsRootDir = File("src/test/test-projects")

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/TestProject.kt
@@ -53,7 +53,7 @@ private val testJdks = TestProperties
     .testJdksRoot?.let { listTestJdks(it) }.orEmpty()
 
 class TestProject(
-    val name: String,
+    private val name: String,
     private val testEnvironment: TestEnvironment
 ) {
     private val testProjectsRootDir = File("src/test/test-projects")


### PR DESCRIPTION
Pass `--app-image` and `--icon` correctly.

Before https://github.com/JetBrains/compose-multiplatform/pull/5644 the packaging for Linux was done in one step. Now the packaging is always done in [two steps](https://docs.oracle.com/en/java/javase/17/jpackage/image-and-runtime-modifications.html): first create an "app image" and then from that an installer.

The packaging task was not set up correctly for this (on Linux).

Fixes https://youtrack.jetbrains.com/issue/CMP-10546

## Testing
Tested manually and added a check in a unit test

## Release Notes
N/A
