### PR TITLE
Benchmarks: reorder repository declarations for consistency

### DIFF
--- a/benchmarks/multiplatform/benchmarks/build.gradle.kts
+++ b/benchmarks/multiplatform/benchmarks/build.gradle.kts
@@ -18,10 +18,10 @@ repositories {
     google {
         url = uri("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2")
     }
+    maven("https://packages.jetbrains.team/maven/p/cmp/dev")
     mavenCentral {
         url = uri("https://cache-redirector.jetbrains.com/maven-central")
     }
-    maven("https://packages.jetbrains.team/maven/p/cmp/dev")
 }
 
 kotlin {

--- a/benchmarks/multiplatform/build.gradle.kts
+++ b/benchmarks/multiplatform/build.gradle.kts
@@ -11,13 +11,13 @@ plugins {
 
 allprojects {
     repositories {
+        mavenLocal()
         google {
             url = uri("https://cache-redirector.jetbrains.com/dl.google.com/dl/android/maven2")
         }
+        maven("https://packages.jetbrains.team/maven/p/cmp/dev")
         mavenCentral {
             url = uri("https://cache-redirector.jetbrains.com/maven-central")
         }
-        maven("https://packages.jetbrains.team/maven/p/cmp/dev")
-        mavenLocal()
     }
 }

--- a/benchmarks/multiplatform/settings.gradle.kts
+++ b/benchmarks/multiplatform/settings.gradle.kts
@@ -10,11 +10,11 @@ pluginManagement {
                 includeGroupAndSubgroups("androidx")
             }
         }
+        maven("https://packages.jetbrains.team/maven/p/cmp/dev")
         mavenCentral {
             url = uri("https://cache-redirector.jetbrains.com/maven-central")
         }
         gradlePluginPortal()
-        maven("https://packages.jetbrains.team/maven/p/cmp/dev")
     }
 }
 


### PR DESCRIPTION
Make CMP repository go before Maven Central and Gradle Plugins Portal for the consistency with Google and across subprojects.

## Testing
Performance CI execution

## Release Notes
N/A
