### PR TITLE
Allow excluding libraries from the dependency compatibility check

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -35,6 +35,9 @@ abstract class ComposePlugin : Plugin<Project> {
         val composeExtension = project.extensions.create("compose", ComposeExtension::class.java, project)
         val desktopExtension = composeExtension.extensions.create("desktop", DesktopExtension::class.java)
         val resourcesExtension = composeExtension.extensions.create("resources", ResourcesExtension::class.java)
+        val dependencyCompatibilityExtension = composeExtension.extensions.create(
+            "dependencyCompatibility", DependencyCompatibilityExtension::class.java
+        )
 
         project.dependencies.extensions.add("compose", Dependencies(project))
 
@@ -51,7 +54,7 @@ abstract class ComposePlugin : Plugin<Project> {
 
         project.configureWeb()
 
-        project.configureRuntimeLibrariesCompatibilityCheck()
+        project.configureRuntimeLibrariesCompatibilityCheck(dependencyCompatibilityExtension)
 
         project.afterEvaluate {
             configureDesktop(project, desktopExtension)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/DependencyCompatibilityExtension.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/DependencyCompatibilityExtension.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.compose
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.SetProperty
+import org.jetbrains.compose.desktop.application.internal.ComposeProperties
+import org.jetbrains.compose.internal.utils.property
+import javax.inject.Inject
+
+/**
+ * Configuration of the compatibility check for Compose Multiplatform runtime dependencies.
+ *
+ * The check warns when resolved versions of Compose Multiplatform libraries don't match the Gradle plugin version,
+ * or when Skiko is resolved to a version that is incompatible with the requested one.
+ */
+abstract class DependencyCompatibilityExtension @Inject constructor(
+    objects: ObjectFactory,
+    providers: ProviderFactory,
+) {
+    /**
+     * Whether the compatibility check runs.
+     *
+     * Default is `true`, or `false` when `org.jetbrains.compose.library.compatibility.check.disable=true`
+     * is set in `gradle.properties`.
+     */
+    val enabled: Property<Boolean> = objects.property<Boolean>().convention(
+        ComposeProperties.disableLibraryCompatibilityCheck(providers).map { disabled -> !disabled }
+    )
+
+    internal val excludedModules: SetProperty<String> = objects.setProperty(String::class.java)
+
+    /**
+     * Excludes a library from the compatibility check.
+     *
+     * The notation is a whole group (`"com.example"`) or a single module (`"com.example:library"`),
+     * without a version.
+     *
+     * A version mismatch is not reported when the exclusion matches the library with the mismatched version
+     * or the library that depends on it:
+     * ```
+     * compose {
+     *     dependencyCompatibility {
+     *         // keep the check for other dependencies, but ignore mismatches introduced by com.example libraries
+     *         exclude("com.example")
+     *         // ignore every Skiko version mismatch
+     *         exclude("org.jetbrains.skiko:skiko")
+     *     }
+     * }
+     * ```
+     */
+    fun exclude(notation: String) {
+        val parts = notation.split(":")
+        require(parts.size <= 2 && parts.none { it.isBlank() }) {
+            "Invalid library notation '$notation'. Expected 'group' or 'group:name' without a version, " +
+                    "for example 'com.example' or 'com.example:library'."
+        }
+        excludedModules.add(notation)
+    }
+}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/RuntimeLibrariesCompatibilityCheck.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/RuntimeLibrariesCompatibilityCheck.kt
@@ -12,12 +12,11 @@ import org.gradle.api.artifacts.component.ProjectComponentSelector
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
-import org.jetbrains.compose.desktop.application.internal.ComposeProperties
 import org.jetbrains.compose.internal.KOTLIN_JVM_PLUGIN_ID
 import org.jetbrains.compose.internal.KOTLIN_MPP_PLUGIN_ID
 import org.jetbrains.compose.internal.kotlinJvmExt
@@ -29,18 +28,17 @@ import org.jetbrains.compose.internal.utils.registerOrConfigure
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
-import javax.inject.Inject
 
-internal fun Project.configureRuntimeLibrariesCompatibilityCheck() {
+internal fun Project.configureRuntimeLibrariesCompatibilityCheck(extension: DependencyCompatibilityExtension) {
     plugins.withId(KOTLIN_MPP_PLUGIN_ID) {
-        mppExt.targets.configureEach { target -> target.configureRuntimeLibrariesCompatibilityCheck() }
+        mppExt.targets.configureEach { target -> target.configureRuntimeLibrariesCompatibilityCheck(extension) }
     }
     plugins.withId(KOTLIN_JVM_PLUGIN_ID) {
-        kotlinJvmExt.target.configureRuntimeLibrariesCompatibilityCheck()
+        kotlinJvmExt.target.configureRuntimeLibrariesCompatibilityCheck(extension)
     }
 }
 
-private fun KotlinTarget.configureRuntimeLibrariesCompatibilityCheck() {
+private fun KotlinTarget.configureRuntimeLibrariesCompatibilityCheck(extension: DependencyCompatibilityExtension) {
     val target = this
     if (
         target.platformType == KotlinPlatformType.common ||
@@ -61,6 +59,8 @@ private fun KotlinTarget.configureRuntimeLibrariesCompatibilityCheck() {
             joinLowerCamelCase("check", target.name, compilation.name, "composeLibrariesCompatibility"),
         ) {
             expectedVersion.set(composeVersion)
+            checkEnabled.set(extension.enabled)
+            excludedModules.set(extension.excludedModules)
             projectPath.set(project.path)
             configurationName.set(runtimeDependencyConfigurationName)
             allDependencies.set(
@@ -92,9 +92,6 @@ internal abstract class RuntimeLibrariesCompatibilityCheck : DefaultTask() {
         }
     }
 
-    @get:Inject
-    protected abstract val providers: ProviderFactory
-
     @get:Input
     abstract val expectedVersion: Property<String>
 
@@ -107,16 +104,24 @@ internal abstract class RuntimeLibrariesCompatibilityCheck : DefaultTask() {
     @get:Input
     abstract val allDependencies: SetProperty<ResolvedDependencyResult>
 
+    @get:Input
+    abstract val excludedModules: SetProperty<String>
+
+    @get:Internal
+    abstract val checkEnabled: Property<Boolean>
+
     init {
         onlyIf {
-            !ComposeProperties.disableLibraryCompatibilityCheck(providers).get()
+            checkEnabled.get()
         }
     }
 
     @TaskAction
     fun run() {
         val expectedRuntimeVersion = expectedVersion.get()
-        val composeLibraries = allDependencies.get()
+        val excludes = excludedModules.get()
+        val dependencies = allDependencies.get().filterNot { it.isExcludedBy(excludes) }
+        val composeLibraries = dependencies
             .mapNotNull { it.selected.moduleVersion }
             .filter { lib -> "${lib.group}:${lib.name}" in composeLibrariesForCheck }
             .distinctBy { lib -> "${lib.group}:${lib.name}:${lib.version}" }
@@ -134,7 +139,7 @@ internal abstract class RuntimeLibrariesCompatibilityCheck : DefaultTask() {
             )
         }
 
-        val skikoIncompatibleDependencyUsages = allDependencies.get().filter { dependency ->
+        val skikoIncompatibleDependencyUsages = dependencies.filter { dependency ->
             val requested = dependency.requested as? ModuleComponentSelector ?: return@filter false
             val selected = dependency.selected.moduleVersion ?: return@filter false
             if ("${requested.group}:${requested.module}" != skikoLibraryForCheck) return@filter false
@@ -150,6 +155,20 @@ internal abstract class RuntimeLibrariesCompatibilityCheck : DefaultTask() {
                 )
             )
         }
+    }
+
+    /**
+     * Whether any module of this dependency edge - the dependent, the requested or the resolved one - is excluded
+     * from the check. Project dependencies are never excluded: exclusions match only external modules.
+     */
+    private fun ResolvedDependencyResult.isExcludedBy(excludes: Set<String>): Boolean {
+        if (excludes.isEmpty()) return false
+        val modules = listOfNotNull(
+            (from.id as? ModuleComponentIdentifier)?.let { it.group to it.module },
+            (requested as? ModuleComponentSelector)?.let { it.group to it.module },
+            (selected.id as? ModuleComponentIdentifier)?.let { it.group to it.module },
+        )
+        return modules.any { (group, name) -> group in excludes || "$group:$name" in excludes }
     }
 
     private fun getComposeMessage(
@@ -198,6 +217,8 @@ internal abstract class RuntimeLibrariesCompatibilityCheck : DefaultTask() {
         val taskName = if (projectName.isNotEmpty() && !projectName.endsWith(":")) "$projectName:dependencies" else "${projectName}dependencies"
         appendLine("You can inspect resulted dependencies tree via `./gradlew $taskName  --configuration ${configurationName}`.")
         appendLine("See more details in Gradle documentation: https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#sec:listing-dependencies")
+        appendLine("If the mismatch is expected, you can exclude a library from this check:")
+        appendLine("    compose { dependencyCompatibility { exclude(\"<group>\") } }")
     }
 
     private fun ModuleVersionIdentifier?.toModuleString() = when (this) {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/RuntimeLibrariesCompatibilityCheckTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/RuntimeLibrariesCompatibilityCheckTest.kt
@@ -91,6 +91,75 @@ class RuntimeLibrariesCompatibilityCheckTest : GradlePluginTestBase() {
         checkMainTargetsCompatibility(logMsg, warningExpected = false, disabled = true)
     }
 
+    @Test
+    fun excludedLibrariesAreNotChecked(): Unit = with(
+        testProject("misc/compatibilityLibCheck")
+    ) {
+        val logMsg = "w: Skiko dependencies' versions are incompatible."
+        file("build.gradle.kts").modify {
+            it.replace(
+                "api(\"org.jetbrains.compose.foundation:foundation:${defaultTestEnvironment.composeVersion}\")",
+                "api(\"org.jetbrains.compose.foundation:foundation:${defaultTestEnvironment.composeVersion}\")\n" +
+                        "            implementation(\"$OLD_SKIKO_DEPENDENCY\")",
+            )
+        }
+        checkJvmMainCompatibility(logMsg, warningExpected = true)
+
+        configureCompatibilityCheck(excludes = arrayOf("org.example.unrelated", "org.jetbrains.skiko:other"))
+        checkJvmMainCompatibility(logMsg, warningExpected = true)
+
+        configureCompatibilityCheck(excludes = arrayOf("org.jetbrains.skiko:skiko"))
+        checkJvmMainCompatibility(logMsg, warningExpected = false)
+
+        configureCompatibilityCheck(excludes = arrayOf("org.jetbrains.skiko"))
+        checkJvmMainCompatibility(logMsg, warningExpected = false)
+
+        configureCompatibilityCheck(enabled = false)
+        checkJvmMainCompatibility(logMsg, warningExpected = false, skipped = true)
+    }
+
+    @Test
+    fun invalidExclusionNotationFailsTheBuild(): Unit = with(
+        testProject("misc/compatibilityLibCheck")
+    ) {
+        configureCompatibilityCheck(excludes = arrayOf("org.jetbrains.skiko:skiko:0.8.4"))
+        gradleFailure("jvmMainClasses").checks {
+            check.logContains("Invalid library notation 'org.jetbrains.skiko:skiko:0.8.4'")
+        }
+    }
+
+    private fun TestProject.configureCompatibilityCheck(
+        enabled: Boolean? = null,
+        excludes: Array<String> = emptyArray(),
+    ) {
+        val marker = "// compatibility check configuration"
+        val configuration = buildString {
+            appendLine(marker)
+            appendLine("compose {")
+            appendLine("    dependencyCompatibility {")
+            if (enabled != null) appendLine("        enabled.set($enabled)")
+            excludes.forEach { appendLine("        exclude(\"$it\")") }
+            appendLine("    }")
+            appendLine("}")
+        }
+        file("build.gradle.kts").modify { it.substringBefore(marker) + configuration }
+    }
+
+    private fun TestProject.checkJvmMainCompatibility(
+        warningMessage: String,
+        warningExpected: Boolean,
+        skipped: Boolean = false,
+    ) {
+        gradle("jvmMainClasses").checks {
+            if (skipped) {
+                check.taskSkipped(":checkJvmMainComposeLibrariesCompatibility")
+            } else {
+                check.taskSuccessful(":checkJvmMainComposeLibrariesCompatibility")
+            }
+            if (warningExpected) check.logContains(warningMessage) else check.logDoesntContain(warningMessage)
+        }
+    }
+
     private fun TestProject.checkMainTargetsCompatibility(
         warningMessage: String,
         warningExpected: Boolean,


### PR DESCRIPTION
[CMP-10512](https://youtrack.jetbrains.com/issue/CMP-10512) Provide a way to disable skiko compatibility warning for specific libraries

Currently, the check could only be turned off as a whole, via `org.jetbrains.compose.library.compatibility.check.disable`. A project that knowingly tolerates one mismatched dependency had to give up the check for every other dependency too.

This PR adds a `compose` extension:
```kt
compose {
    dependencyCompatibility {
        enabled = false // default: !org.jetbrains.compose.library.compatibility.check.disable
        exclude("com.example") // whole group
        exclude("org.jetbrains.skiko:skiko") // single module
    }
}
```

## Release Notes
### Features - Gradle Plugin
- Allow excluding libraries from the dependency compatibility check via `compose { dependencyCompatibility { } }` extension