### PR TITLE
Made the replaceVersions scripts cwd independent

### DIFF
--- a/tools/replace_version_common.sh
+++ b/tools/replace_version_common.sh
@@ -29,5 +29,5 @@ replaceVersionInFile() {
 }
 
 replaceVersionInFolder() {
-    find $1 -wholename $2 -not -path "**/build/*" -not -path "**/.gradle**" | while read file; do replaceVersionInFile "$file"; done
+    find "$1" -wholename "$2" -not -path "**/build/*" -not -path "**/.gradle**" | while read file; do replaceVersionInFile "$file"; done
 }


### PR DESCRIPTION
Quoted find's arguments in replaceVersionInFolder — find "$1" -wholename "$2" instead of find $1 -wholename $2

Before: when run from the repo root, bash replaced `**gradle.properties` and `**README.md `with the same-named files sitting there, so find received -wholename gradle.properties and matched nothing — silently, with exit 0;

After: the pattern reaches find untouched and matches every file.

As a result, the script doesn't depend on the working directory

Fix should be platform-independent as well.

## Release Notes
N/A
