### PR TITLE
Update chat sample for the liquid glass era

### DIFF
--- a/examples/chat/iosApp/iosApp/ComposeInsideSwiftUIScreen.swift
+++ b/examples/chat/iosApp/iosApp/ComposeInsideSwiftUIScreen.swift
@@ -1,25 +1,197 @@
 import SwiftUI
+import UIKit
 
 struct ComposeInsideSwiftUIScreen: View {
     var body: some View {
         ZStack {
             ComposeLayer()
+            ChatFooterScrimLayer()
+            ChatHeaderLayer()
             TextInputLayer()
         }.onTapGesture {
-            // Hide keyboard on tap outside of TextField
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+        .onAppear {
+            UIApplication.shared.statusBarStyle = .lightContent
+        }
+        .onDisappear {
+            UIApplication.shared.statusBarStyle = .default
         }
     }
 }
 
 struct ComposeLayer: View {
     var body: some View {
-        NavigationView {
-            ComposeViewControllerToSwiftUI()
-                .ignoresSafeArea() // Extend Compose background behind nav title and tab bar; Compose handles its own keyboard
-                .navigationTitle("The Composers Chat")
-                .navigationBarTitleDisplayMode(.inline)
+        ComposeViewControllerToSwiftUI()
+            .ignoresSafeArea()
+    }
+}
+
+struct ChatHeaderLayer: View {
+    static let extraTopInset: CGFloat = 100
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack(alignment: .top) {
+                LinearGradient(
+                    colors: [
+                        Color.black.opacity(0.75),
+                        Color.black.opacity(0.45),
+                        Color.black.opacity(0)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: 200)
+                .ignoresSafeArea(edges: .top)
+                .allowsHitTesting(false)
+
+                VStack(spacing: 10) {
+                    HStack {
+                        ChatBackButton()
+                        Spacer()
+                        OverlappingAvatarGroup()
+                        Spacer()
+                        VideoCallButton()
+                    }
+                    ChatTitlePill(title: "The Composers Chat")
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 8)
+            }
+
+            Spacer()
         }
+    }
+}
+
+private struct ChatBackButton: View {
+    var body: some View {
+        Button(action: {}) {
+            HStack(spacing: 6) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 15, weight: .semibold))
+                Text("2")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.black)
+                    .frame(width: 18, height: 18)
+                    .background(Circle().fill(Color.white))
+            }
+            .foregroundColor(.white)
+            .padding(.leading, 12)
+            .padding(.trailing, 8)
+            .padding(.vertical, 8)
+            .modifier(LiquidGlassCapsule())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct VideoCallButton: View {
+    var body: some View {
+        Button(action: {}) {
+            Image(systemName: "video.fill")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundColor(.white)
+                .frame(width: 44, height: 44)
+                .modifier(LiquidGlassCircle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct ChatTitlePill: View {
+    let title: String
+
+    var body: some View {
+        Button(action: {}) {
+            HStack(spacing: 4) {
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.white)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 6)
+            .modifier(LiquidGlassCapsule())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct OverlappingAvatarGroup: View {
+    private let size: CGFloat = 26
+    private let overlap: CGFloat = 9
+
+    var body: some View {
+        ZStack {
+            avatar("stock2")
+                .offset(x: -overlap, y: overlap * 0.6)
+            avatar("stock3")
+                .offset(x: overlap, y: overlap * 0.6)
+            avatar("stock1")
+                .offset(y: -overlap * 0.6)
+        }
+        .frame(width: size + overlap * 2, height: size + overlap * 2)
+    }
+
+    // Path mirrors where the Compose Multiplatform Gradle plugin copies shared module resources into the app bundle; it'll need updating if the shared module's name ever changes.
+    private static let composeResourcesDir = "compose-resources/composeResources/chat_mpp.shared.generated.resources/drawable"
+
+    private func avatar(_ imageName: String) -> some View {
+        Group {
+            if let path = Bundle.main.path(forResource: imageName, ofType: "jpg", inDirectory: Self.composeResourcesDir),
+               let uiImage = UIImage(contentsOfFile: path) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Color.gray
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .overlay(Circle().stroke(Color.white.opacity(0.85), lineWidth: 1.5))
+    }
+}
+
+private struct LiquidGlassCapsule: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.glassEffect(.regular.tint(.black.opacity(0.35)).interactive(), in: Capsule())
+        } else {
+            content.background(Capsule().fill(.ultraThinMaterial))
+        }
+    }
+}
+
+private struct LiquidGlassCircle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.glassEffect(.regular.tint(.black.opacity(0.35)).interactive(), in: Circle())
+        } else {
+            content.background(Circle().fill(.ultraThinMaterial))
+        }
+    }
+}
+
+private struct ChatFooterScrimLayer: View {
+    var body: some View {
+        LinearGradient(
+            colors: [
+                Color.black.opacity(0),
+                Color.black.opacity(0.2),
+                Color.black.opacity(0.4)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .frame(height: 80)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .ignoresSafeArea(edges: .bottom)
+        .allowsHitTesting(false)
     }
 }
 

--- a/examples/chat/iosApp/iosApp/ComposeViewControllerToSwiftUI.swift
+++ b/examples/chat/iosApp/iosApp/ComposeViewControllerToSwiftUI.swift
@@ -4,7 +4,10 @@ import shared
 
 struct ComposeViewControllerToSwiftUI: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        return Main_iosKt.ChatViewController()
+        return Main_iosKt.ChatViewController(
+            extraTopInset: Double(ChatHeaderLayer.extraTopInset),
+            extraBottomInset: 0
+        )
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {

--- a/examples/chat/iosApp/iosApp/ContentView.swift
+++ b/examples/chat/iosApp/iosApp/ContentView.swift
@@ -2,6 +2,20 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
+        Group {
+            if #available(iOS 18.0, *) {
+                tabView
+                    .toolbarBackground(.ultraThinMaterial, for: .tabBar)
+                    .toolbarBackgroundVisibility(.visible, for: .tabBar)
+            } else {
+                tabView
+                    .toolbarBackground(.ultraThinMaterial, for: .tabBar)
+            }
+        }
+            .accentColor(Color(red: 0.671, green: 0.365, blue: 0.792)).preferredColorScheme(.light)
+    }
+
+    private var tabView: some View {
         TabView {
             ComposeInsideSwiftUIScreen()
                 .tabItem {
@@ -14,7 +28,6 @@ struct ContentView: View {
                 }
 
         }
-            .accentColor(Color(red: 0.671, green: 0.365, blue: 0.792)).preferredColorScheme(.light)
     }
 }
 

--- a/examples/chat/iosApp/iosApp/Info.plist
+++ b/examples/chat/iosApp/iosApp/Info.plist
@@ -22,6 +22,8 @@
 	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/examples/chat/shared/src/commonMain/kotlin/Messages.kt
+++ b/examples/chat/shared/src/commonMain/kotlin/Messages.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Size
@@ -29,24 +29,18 @@ internal fun Messages(
     contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     val listState = rememberLazyListState()
-    if (messages.isNotEmpty()) {
-        LaunchedEffect(messages.last()) {
-            listState.animateScrollToItem(messages.lastIndex, scrollOffset = 2)
-        }
-    }
     LazyColumn(
         modifier = Modifier.fillMaxSize().padding(start = 4.dp, end = 4.dp),
         contentPadding = contentPadding,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.Bottom),
         state = listState,
+        reverseLayout = true,
     ) {
-        item { Spacer(Modifier.size(20.dp)) }
-        items(messages, key = { it.id }) {
+        item { Box(Modifier.height(70.dp)) }
+        items(messages.asReversed(), key = { it.id }) {
             ChatMessage(isMyMessage = it.user == myUser, it)
         }
-        item {
-            Box(Modifier.height(70.dp))
-        }
+        item { Spacer(Modifier.size(20.dp)) }
     }
 }
 

--- a/examples/chat/shared/src/iosMain/kotlin/main.ios.kt
+++ b/examples/chat/shared/src/iosMain/kotlin/main.ios.kt
@@ -1,13 +1,28 @@
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
 import platform.UIKit.UIViewController
 
-fun ChatViewController(): UIViewController = ComposeUIViewController {
+// Extra inset (in points) to clear a native SwiftUI header/footer drawn on top of this
+// Compose content, on top of what WindowInsets.systemBars already accounts for.
+fun ChatViewController(extraTopInset: Double, extraBottomInset: Double): UIViewController = ComposeUIViewController {
+    val systemBars = WindowInsets.systemBars.asPaddingValues()
+    val layoutDirection = LocalLayoutDirection.current
+    val combinedPadding = PaddingValues(
+        start = systemBars.calculateStartPadding(layoutDirection),
+        top = systemBars.calculateTopPadding() + extraTopInset.dp,
+        end = systemBars.calculateEndPadding(layoutDirection),
+        bottom = systemBars.calculateBottomPadding() + extraBottomInset.dp,
+    )
     ChatApp(
         displayTextField = false,
-        contentPadding = WindowInsets.systemBars.asPaddingValues(),
+        contentPadding = combinedPadding,
     )
 }
 


### PR DESCRIPTION
Updates the chat example with a fresh look and liquid glass controls.

<img width="568" height="1084" alt="Screenshot 2026-08-28 at 06 43 14" src="https://github.com/user-attachments/assets/29720ff5-6fe5-4003-bcd6-5c0e3e0a4369" />


The previous version looked like this on modern iOS:

<img width="524" height="1040" alt="image" src="https://github.com/user-attachments/assets/c7820bcb-2251-4065-8823-4ba26e9f5d8c" />

(and for real comparison, back in the olden days, it looked like the following)

<img width="278" height="518" alt="Screenshot 2026-08-28 at 06 44 44" src="https://github.com/user-attachments/assets/bb2553ff-8a3b-462a-a617-4a83d2e58460" />

## Release Notes
N/A
