### PR TITLE
Configure independent versioning for browser common subset

### DIFF
--- a/.github/workflows/kotlinx-browser-common-subset.yml
+++ b/.github/workflows/kotlinx-browser-common-subset.yml
@@ -1,0 +1,38 @@
+name: Kotlinx Browser Common Subset
+
+on:
+  pull_request:
+    paths:
+      - 'html/kotlinx-browser-common-subset/**'
+      - 'html/buildSrc/gradle.properties'
+      - '.github/workflows/kotlinx-browser-common-subset.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'html/kotlinx-browser-common-subset/**'
+      - 'html/buildSrc/gradle.properties'
+      - '.github/workflows/kotlinx-browser-common-subset.yml'
+
+jobs:
+  check-and-publish-to-maven-local:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'jetbrains'
+          java-version: '21'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Check and publish to Maven Local
+        working-directory: html/kotlinx-browser-common-subset
+        run: |
+          ./gradlew --no-daemon --stacktrace --rerun-tasks --max-workers=1 check publishToMavenLocal

--- a/html/kotlinx-browser-common-subset/build.gradle.kts
+++ b/html/kotlinx-browser-common-subset/build.gradle.kts
@@ -11,9 +11,6 @@ plugins {
 
 val browserIdentityTestSources = layout.projectDirectory.dir("src/browserIdentityTest/kotlin")
 val karmaConfigDirectory = layout.projectDirectory.dir("karma.config.d")
-val htmlProperties = Properties().apply {
-    layout.projectDirectory.file("../gradle.properties").asFile.inputStream().use(::load)
-}
 val generatorProperties = Properties().apply {
     layout.projectDirectory.file("generator/gradle.properties").asFile.inputStream().use(::load)
 }
@@ -22,11 +19,7 @@ val kotlinxBrowserVersion = requireNotNull(generatorProperties.getProperty("kotl
 }
 
 group = "org.jetbrains.compose.html"
-version = providers.gradleProperty("compose.version").orNull ?: requireNotNull(
-    htmlProperties.getProperty("compose.version"),
-) {
-    "compose.version is missing from html/gradle.properties"
-}
+version = providers.gradleProperty("deploy.version").get()
 
 kotlin {
     compilerOptions {

--- a/html/kotlinx-browser-common-subset/gradle.properties
+++ b/html/kotlinx-browser-common-subset/gradle.properties
@@ -1,0 +1,1 @@
+deploy.version=0.0.1-SNAPSHOT

--- a/html/kotlinx-browser-common-subset/gradle.properties
+++ b/html/kotlinx-browser-common-subset/gradle.properties
@@ -1,1 +1,2 @@
+org.gradle.jvmargs=-Xmx8g
 deploy.version=0.0.1-SNAPSHOT


### PR DESCRIPTION
Configure `kotlinx-browser-common-subset` to use a publication version independent of the Compose Multiplatform version.

The module now reads its version from the `deploy.version` Gradle property and uses `0.0.1-SNAPSHOT` as the local default.

Involes [CMP-10676](https://youtrack.jetbrains.com/issue/CMP-10676/Setup-the-publication-of-compose-html-ssr-parts-to-maven)

## Testing

- Published to Maven Local with `0.0.1-ssr-local`
- Ran the module checks, including generator consistency checks and JVM, JS, and Wasm tests

## Release Notes
N/A