### PR TITLE
Benchmarks: remove deprecated macosX64 and iosX64 targets

### DIFF
--- a/benchmarks/multiplatform/README.md
+++ b/benchmarks/multiplatform/README.md
@@ -136,7 +136,6 @@ benchmarks may affect others within one process):
 
 ## Run native on MacOS
  - `./gradlew :benchmarks:runReleaseExecutableMacosArm64` (Works on Arm64 processors)
- - `./gradlew :benchmarks:runReleaseExecutableMacosX64` (Works on Intel processors)
 
 ## Run K/Wasm target in D8:
 `./gradlew :benchmarks:wasmJsD8ProductionRun`

--- a/benchmarks/multiplatform/benchmarks/build.gradle.kts
+++ b/benchmarks/multiplatform/benchmarks/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
     androidTarget()
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
@@ -40,11 +39,8 @@ kotlin {
         }
     }
 
-    listOf(
-        macosX64(),
-        macosArm64()
-    ).forEach { macosTarget ->
-        macosTarget.binaries {
+    macosArm64 {
+        binaries {
             executable {
                 entryPoint = "main"
             }


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-78660 for context.

macosX64 will become error-deprecated in 2.5.0 (and is already so in master).
iosX64 is still warning-deprecated but will be promoted anyway.

This commit removes these two targets from benchmarks/multiplatform, therefore.

## Release Notes
N/A