### PR TITLE
Strip JRE fonts by default

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/JvmApplicationDistributions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/JvmApplicationDistributions.kt
@@ -18,6 +18,7 @@ abstract class JvmApplicationDistributions : AbstractDistributions() {
         this.modules.addAll(modules.toList())
     }
     var includeAllModules: Boolean = false
+    var stripJreFonts: Boolean = true
 
     val linux: LinuxPlatformSettings = objects.newInstance(LinuxPlatformSettings::class.java)
     open fun linux(fn: Action<LinuxPlatformSettings>) {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureJvmApplication.kt
@@ -115,6 +115,7 @@ private fun JvmApplicationContext.configurePackagingTasks(
         modules.set(provider { app.nativeDistributions.modules })
         includeAllModules.set(provider { app.nativeDistributions.includeAllModules })
         javaRuntimePropertiesFile.set(commonTasks.checkRuntime.flatMap { it.javaRuntimePropertiesFile })
+        stripJreFonts.set(app.nativeDistributions.stripJreFonts)
         destinationDir.set(appTmpDir.dir("runtime"))
         stripNativeCommands.set(!buildType.aot.mode.generateJreClassesArchive)  // `java` is needed to generate the JRE CDS archive
         generateJreCdsArchive.set(buildType.aot.mode.generateJreClassesArchive)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
@@ -36,6 +36,9 @@ abstract class AbstractJLinkTask : AbstractJvmToolOperationTask("jlink") {
     val javaRuntimePropertiesFile: RegularFileProperty = objects.fileProperty()
 
     @get:Input
+    val stripJreFonts: Property<Boolean> = objects.property<Boolean>().value(true)
+
+    @get:Input
     internal val stripDebug: Property<Boolean> = objects.property<Boolean>().value(true)
 
     @get:Input
@@ -67,6 +70,7 @@ abstract class AbstractJLinkTask : AbstractJvmToolOperationTask("jlink") {
         cliArg("--no-header-files", noHeaderFiles)
         cliArg("--no-man-pages", noManPages)
         cliArg("--strip-native-commands", stripNativeCommands)
+        cliArg("--exclude-files=glob:/java.desktop/lib/fonts/**", stripJreFonts)
         cliArg("--compress", compressionLevel.orNull?.id)
         if (generateJreCdsArchive.get()) {
             if (stripNativeCommands.get()) {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -303,20 +303,76 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     }
 
     @Test
-    fun testJdk19() = with(customJdkProject(19)) {
+    fun testJdk19() = with(customJdkProject(javaVersion = 19)) {
         testPackageJvmDistributions()
     }
 
-    private fun customJdkProject(javaVersion: Int): TestProject =
+    @Test
+    fun testFontStripping() =
+        // JBR25 comes with bundled fonts, so we can check stripping them on it
+        with(
+            customJdkProject(
+                javaVendor = "JETBRAINS",
+                javaVersion = 25,
+                extraConfig = """
+                    nativeDistributions {
+                        stripJreFonts = true
+                    }
+                """.replaceIndent("    ") + "\n"
+            )
+        ) {
+            gradle(":createRuntimeImage")
+            val runtimeDir = file("build/compose/tmp/main/runtime")
+            assertTrue(runtimeDir.isDirectory)
+            assertFalse(runtimeDir.list()!!.contains("fonts"))
+        }
+
+    private fun customJdkProject(
+        javaVendor: String? = null,
+        javaVersion: Int? = null,
+        extraConfig: String? = null,
+    ): TestProject =
         testProject("application/jvm").apply {
             appendText("build.gradle") {
-                """
-                    compose.desktop.application {
-                        javaHome = javaToolchains.launcherFor {
-                            languageVersion.set(JavaLanguageVersion.of($javaVersion))
-                        }.get().metadata.installationPath.asFile.absolutePath
+                buildString {
+                    append(
+                        """
+                        compose.desktop.application {
+                            javaHome = javaToolchains.launcherFor {
+                        """.trimIndent()
+                    )
+                    appendLine()
+                    if (javaVendor != null) {
+                        append(
+                            """
+                            vendor.set(
+                                org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec.of(
+                                    org.gradle.internal.jvm.inspection.JvmVendor.KnownJvmVendor.$javaVendor
+                                )
+                            )
+                            """.replaceIndent("        ")
+                        )
+                        appendLine()
                     }
-                """.trimIndent()
+                    if (javaVersion != null) {
+                        append(
+                            """
+                            languageVersion.set(JavaLanguageVersion.of($javaVersion))
+                            """.replaceIndent("        ")
+                        )
+                        appendLine()
+                    }
+                    append(
+                        """
+                            }.get().metadata.installationPath.asFile.absolutePath
+                        """.replaceIndent("    ")
+                    )
+                    if (extraConfig != null) {
+                        appendLine()
+                        append(extraConfig)
+                    }
+                    append("}")
+                }
             }
         }
 


### PR DESCRIPTION
Added a property to control JRE runtime font stripping and made it `true` by default.

To include the fonts, use 
```
compose.desktop {
    application {
        nativeDistributions {
            stripJreFonts = false
        }
    }
}
```

Note that not all JREs have bundled fonts, so in those JREs this change won't affect the distributable size.
In JBR 25, this should save about 5MB.

Fixes https://youtrack.jetbrains.com/issue/CMP-10772/Strip-JRE-fonts-from-desktop-distributable

## Testing
Added tests and tested manually

## Release Notes
### Migration Notes - Desktop
- JRE fonts are now stripped from the distributable by default. If you need them, use `stripJreFonts = false` in the `nativeDistributions` section of your Gradle build file.
