### PR TITLE
Disable using local JDK installations when resolving Java toolchain in application/jvm test project

### DIFF
--- a/gradle-plugins/compose/src/test/test-projects/application/jvm/gradle.properties
+++ b/gradle-plugins/compose/src/test/test-projects/application/jvm/gradle.properties
@@ -1,0 +1,4 @@
+# Ignore JVMs installed on the machine when resolving toolchains.
+# This is needed to ensure that we get JBRSDK and not JBR (which lacks
+# jpackage, jlink) when requesting KnownJvmVendor.JETBRAINS
+org.gradle.java.installations.auto-detect=false


### PR DESCRIPTION
Disable using local JDK installations when resolving Java toolchain in application/jvm test project

This hopefully fixes `testFontStripping` test [failing](https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Dev/6565203) on CI.

## Testing
N/A

## Release Notes
N/A