### PR TITLE
[wasm] preloadFont, preloadImageBitmap, preloadImageVector are not experimental

### DIFF
--- a/components/resources/demo/shared/src/webMain/kotlin/main.wasm.kt
+++ b/components/resources/demo/shared/src/webMain/kotlin/main.wasm.kt
@@ -15,12 +15,11 @@ import components.resources.demo.shared.generated.resources.NotoColorEmoji
 import components.resources.demo.shared.generated.resources.Res
 import components.resources.demo.shared.generated.resources.Workbench_Regular
 import components.resources.demo.shared.generated.resources.font_awesome
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.configureWebResources
 import org.jetbrains.compose.resources.demo.shared.UseResources
 import org.jetbrains.compose.resources.preloadFont
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalResourceApi::class, InternalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, InternalComposeUiApi::class)
 fun main() {
     configureWebResources {
         // Not necessary - It's the same as the default. We add it here just to present this feature.

--- a/components/resources/library/src/webMain/kotlin/org/jetbrains/compose/resources/Resource.web.kt
+++ b/components/resources/library/src/webMain/kotlin/org/jetbrains/compose/resources/Resource.web.kt
@@ -95,7 +95,6 @@ internal fun getResourceUrl(windowOrigin: String, windowPathname: String, resour
  * @return A [State]<[Font]?> object that holds the loaded [Font] when available,
  * or `null` if the font is not yet ready.
  */
-@ExperimentalResourceApi
 @Composable
 fun preloadFont(
     resource: FontResource,
@@ -141,7 +140,6 @@ fun preloadFont(
  * @return A [State]<[ImageBitmap]?> object that holds the loaded [ImageBitmap] when available,
  * or `null` if the resource is not yet ready.
  */
-@ExperimentalResourceApi
 @Composable
 fun preloadImageBitmap(
     resource: DrawableResource,
@@ -185,7 +183,6 @@ fun preloadImageBitmap(
  * @return A [State]<[ImageVector]?> object that holds the loaded [ImageVector] when available,
  * or `null` if the resource is not yet ready.
  */
-@ExperimentalResourceApi
 @Composable
 fun preloadImageVector(
     resource: DrawableResource,


### PR DESCRIPTION
This is the part of the effort of stabilisation of Web API where we see it make sense to do
in framework of following task:
[OSIP-1196](https://youtrack.jetbrains.com/issue/OSIP-1196) Fix and promote experimental APIs to stabilize Compose for Web.

## Testing
not needed

## Release Notes
### Highlights - Web
- preloadFont, preloadImageBitmap, preloadImageVector are no longer experimental
